### PR TITLE
Remove deprecated arguments to Pango.AttrIterator.get_font

### DIFF
--- a/src/gourmand/exporters/exporter.py
+++ b/src/gourmand/exporters/exporter.py
@@ -310,7 +310,7 @@ class exporter (SuspendableThread, Pluggable):
         more = True
         while more:
             fd = Pango.FontDescription()
-            ai.get_font(fd, None, None)
+            ai.get_font(fd)
             start, end = ai.range()
             # The range should never split up a code point in the UTF-8
             chunk = xml.sax.saxutils.escape(b[start:end].decode('utf-8'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes issue #13 where it's described how PDF cannot be exported when the application in ran from a flatpak.  
In older versions of pygobject, the deprecated arguments `language: Pango.Language, extra_attrs: list` default to `None` anyway.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by running the changes in a flatpak, and in a source installation.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
