### PR TITLE
Use Pillow 8.3.2 minimum

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ setup(
     install_requires=[
         'beautifulsoup4==4.9.3',
         'lxml==4.6.3',
-        'pillow==8.2.0',
+        'pillow>=8.3.2',
         'pygobject==3.40.1',
         'requests==2.25.1',
         'sqlalchemy==1.3.22',


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves issue where Pillow would crash when imported after Gtk.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested manually, as I had described on the pillow project:

Thanks, I also encountered a similar issue with `pillow==8.3.1` and `PyGObject==3.40.1`.

I could reduce it down to the code below:

```python
import gi
from gi.repository import Gtk, Gdk, GdkPixbuf
from PIL import ImageDraw
```

which would segfault.

Modifying this excerpt by importing `pillow` first resolved the issue:
```python
import gi
from PIL import ImageDraw
from gi.repository import Gtk, Gdk, GdkPixbuf
```

With `pillow==8.3.0`, the order does not matter and the code runs fine.
The wheel linked above also resolves the issue in my case!

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
