### PR TITLE
Set spellcheck to locale.LANG by default

### DIFF
--- a/src/gourmand/plugins/spellcheck/reccard_spellcheck_plugin.py
+++ b/src/gourmand/plugins/spellcheck/reccard_spellcheck_plugin.py
@@ -1,31 +1,34 @@
+import locale
+
 from gi.repository import Gtk
 from gtkspellcheck import SpellChecker
 
 from gourmand.plugin import RecEditorPlugin, UIPlugin
 
 
-class SpellPlugin (RecEditorPlugin, UIPlugin):
-
-    main = None
-
-    ui_string = '''
-    '''
-
-    def activate (self, recEditor):
-        UIPlugin.activate(self,recEditor)
-        for module in self.pluggable.modules:
-            tvs = harvest_textviews(module.main)
-            for tv in tvs:
-                SpellChecker(tv)
-
-def harvest_textviews (widget):
-    if isinstance(widget,Gtk.TextView):
+def harvest_textviews(widget):
+    if isinstance(widget, Gtk.TextView):
         return [widget]
     else:
         tvs = []
-        if hasattr(widget,'get_children'):
+        if hasattr(widget, 'get_children'):
             for child in widget.get_children():
                 tvs.extend(harvest_textviews(child))
-        elif hasattr(widget,'get_child'):
+        elif hasattr(widget, 'get_child'):
             tvs.extend(harvest_textviews(widget.get_child()))
         return tvs
+
+
+class SpellPlugin(RecEditorPlugin, UIPlugin):
+
+    main = None
+
+    ui_string = ''
+
+    def activate(self, editor):
+        UIPlugin.activate(self, editor)
+        language, _ = locale.getlocale()
+        for module in self.pluggable.modules:
+            tvs = harvest_textviews(module.main)
+            for tv in tvs:
+                SpellChecker(tv, language=language)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR closes #29 by setting the default spellchecker language to the one of locale.LANG

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested as follows"

1)  launch Gourmand so: `LANGUAGE=fr_FR.utf-8 LANG=fr_FR.utf-8 gourmand`; 
2) Click `Nouveau`;  
3) Switch to the `Instruction` tab;
4) Right-click in the editor, `Languages` sub-menu;  
5) Confirm that the spellchecker is set to `French (France)`.

This was also tested with `de_DE.utf-8` with the correct result of the `German (Germany)` language selected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
