### PR TITLE
Refactor clipboard exporter as a function

### DIFF
--- a/src/gourmand/main.py
+++ b/src/gourmand/main.py
@@ -11,7 +11,7 @@ from gourmand import (__version__, batchEditor, convert, plugin, plugin_gui,
                       shopgui)
 from gourmand.defaults.defaults import get_pluralized_form
 from gourmand.defaults.defaults import lang as defaults
-from gourmand.exporters.clipboard_exporter import ClipboardExporter
+from gourmand.exporters.clipboard_exporter import copy_to_clipboard
 from gourmand.exporters.exportManager import ExportManager
 from gourmand.exporters.printer import PrintManager
 from gourmand.gdebug import debug
@@ -711,8 +711,7 @@ class StuffThatShouldBePlugins:
         recipes = self.get_selected_recs_from_rec_tree()
         ingredients = [self.rd.rd.get_ings(recipe.id)
                        for recipe in recipes]
-        ce = ClipboardExporter(list(zip(recipes, ingredients)))
-        ce.export()
+        copy_to_clipboard(list(zip(recipes, ingredients)))
 
     def batch_edit_recs (self, *args):
         recs = self.get_selected_recs_from_rec_tree()

--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -10,7 +10,7 @@ from PIL import Image
 from gourmand import Undo, convert, defaults
 from gourmand import image_utils as iu
 from gourmand import plugin_loader, prefs, timeScanner
-from gourmand.exporters.clipboard_exporter import ClipboardExporter
+from gourmand.exporters.clipboard_exporter import copy_to_clipboard
 from gourmand.exporters.exportManager import ExportManager
 from gourmand.exporters.printer import PrintManager
 from gourmand.gdebug import debug
@@ -594,8 +594,7 @@ class RecCardDisplay (plugin_loader.Pluggable):
 
         ingredients = self.rg.rd.get_ings(self.current_rec.id)
         # The exporter can do several recipes at once, hence the list of tuples.
-        ce = ClipboardExporter([(self.current_rec, ingredients)])
-        ce.export()
+        copy_to_clipboard([(self.current_rec, ingredients)])
 
     def print_cb(self, action: Gtk.Action):
         if self.reccard.edited:

--- a/tests/test_clipboard_exporter.py
+++ b/tests/test_clipboard_exporter.py
@@ -4,13 +4,14 @@ import pytest
 gi.require_version("Gtk", "3.0")
 from collections import namedtuple  # noqa: import not at top of file
 from gi.repository import Gtk, Gdk  # noqa: import not at top of file
-from gourmand.exporters.clipboard_exporter import ClipboardExporter  # noqa
+from gourmand.exporters.clipboard_exporter import copy_to_clipboard  # noqa
 
 Recipe = namedtuple('Recipe', ['title', 'source', 'yields', 'yield_unit',
-                               'description', 'instructions'])
+                               'description', 'instructions', 'link'])
 
-recipe1 = Recipe('Title1', 'Source1', 700.0, 'g.', None, 'Make the Dough.')
-recipe2 = Recipe('Title2', 'Source2', 2, 'litres', 'test', 'Directions.')
+recipe1 = Recipe('Title1', 'Source1', 700.0, 'g.', None, 'Make the Dough.', '')
+recipe2 = Recipe('Title2', 'Source2', 2, 'litres', 'test', 'Directions.',
+                 'https://example.com')
 
 Ingredient = namedtuple('Ingredient', ['amount', 'unit', 'item'])
 
@@ -19,10 +20,10 @@ ingredients2 = (Ingredient(600, 'g.', 'flour'),
                 Ingredient(2, 'l.', 'water'))
 
 recipe_input = [(recipe1, ingredients1)]
-recipe_expected_output = """
-# Title1
+recipe_expected_output = """# Title1
 
 Source1
+
 700.0 g.
 
 600 g. flour
@@ -32,10 +33,10 @@ Make the Dough.
 
 two_recipes_input = [(recipe1, ingredients1), (recipe2, ingredients2)]
 
-two_recipes_expected_output = """
-# Title1
+two_recipes_expected_output = """# Title1
 
 Source1
+
 700.0 g.
 
 600 g. flour
@@ -46,6 +47,8 @@ Make the Dough.
 # Title2
 
 Source2
+https://example.com
+
 2 litres
 
 test
@@ -66,8 +69,7 @@ Directions.
      ],
 )
 def test_clipboard_exporter(recipes, expected):
-    ce = ClipboardExporter(recipes)
-    ce.export()
+    copy_to_clipboard(recipes)
 
     clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
     assert clipboard.wait_for_text() == expected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This simplifies the clipboard exporter to a single function, rather than an object.  

Ingredients that do not have quantities are now better formatted, as mentionned in #26 , as well as links if any.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by updating the test, and by copying a recipe to a text file and checking the expected output.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2159577/132093493-29bdb552-861f-4f5e-99ff-e58c958b1821.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
