### PR TITLE
Fix pasting of ingredients in IngredientEditorModule

### DIFF
--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -1106,7 +1106,6 @@ class IngredientEditorModule (RecEditorModule):
         <toolitem  action="AddIngredientGroup"/>
         <toolitem action="AddRecipeAsIngredient"/>
         <separator/>
-        <toolitem action="ImportIngredients"/>
         <toolitem action="PasteIngredient"/>
         <separator/>
       </toolbar>
@@ -1147,8 +1146,6 @@ class IngredientEditorModule (RecEditorModule):
              None,None),
             ('AddIngredientGroup',None,_('Add group'),
              '<Control>G',None,self.ingtree_ui.ingNewGroupCB),
-            ('ImportIngredients',None,_('Import from file'),
-             '<Control>O',None,self.import_ingredients_cb),
             ('AddRecipeAsIngredient',None,_('Add _recipe'),
              '<Control>R',_('Add another recipe as an ingredient in this recipe'),
              lambda *args: RecSelector(self.rg, self)),
@@ -1200,16 +1197,6 @@ class IngredientEditorModule (RecEditorModule):
             )
         return itr
 
-    def import_ingredients(self, filename: str) -> None:
-        with open(filename, 'r') as ifi:
-            for line in ifi:
-                self.add_ingredient_from_line(line)
-
-    def import_ingredients_cb (self, *args):
-        f = de.select_file(_("Choose a file containing your ingredient list."),
-                           action=Gtk.FileChooserAction.OPEN)
-        if f:  # knowingly work with only a single file
-            add_with_undo(self, lambda *args: self.import_ingredients(f[0]))
 
     def paste_ingredients_cb(self, action: Gtk.Action):
         self.cb = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)

--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -828,7 +828,7 @@ class RecEditor(WidgetSaver.WidgetPrefs, plugin_loader.Pluggable):
             recipe = self.recipe_display.current_rec
         self.current_rec = recipe
         self.setup_defaults()
-        self.conf: List[Gtk.Widget] = []
+        self.conf: List[Union[Gtk.Widget, WidgetSaver.WindowSaver]] = []
         self.setup_ui_manager()
         #self.setup_undo()
         self.setup_main_interface()
@@ -982,7 +982,7 @@ class RecEditor(WidgetSaver.WidgetPrefs, plugin_loader.Pluggable):
         self.last_merged_action_groups = None
         self.notebook_change_cb()
 
-    def set_edited (self, edited):
+    def set_edited(self, edited: bool):
         self.edited = edited
         if edited:
             self.mainRecEditActionGroup.get_action('Save').set_sensitive(True)
@@ -1094,7 +1094,6 @@ class IngredientEditorModule (RecEditorModule):
           <menuitem action="MoveIngredientDown"/>
           <separator/>
           <menuitem action="AddRecipeAsIngredient"/>
-          <menuitem action="ImportIngredients"/>
           </placeholder>
         </menu>
       </menubar>
@@ -1122,25 +1121,25 @@ class IngredientEditorModule (RecEditorModule):
         self.ingtree_ui = IngredientTreeUI(self, self.ui.get_object('ingTree'))
         self.setup_action_groups()
         self.update_from_database()
-        self.quickEntry = self.ui.get_object('quickIngredientEntry')
-        self.ui.connect_signals({'addQuickIngredient':self.quick_add})
+        self.entry = self.ui.get_object('quickIngredientEntry')
+        self.ui.connect_signals({'addQuickIngredient': self.quick_add})
 
-    def quick_add (self, *args):
-        txt = str(self.quickEntry.get_text())
-        prev_iter,group_iter = self.ingtree_ui.get_previous_iter_and_group_iter()
+    def quick_add(self, *args):
+        txt = str(self.entry.get_text())
+        prev_iter, group_iter = self.ingtree_ui.get_previous_iter_and_group_iter()
         add_with_undo(self,
-                      lambda *args: self.add_ingredient_from_line(txt,
-                                                                  prev_iter=prev_iter,
-                                                                  group_iter=group_iter)
+                      lambda *args: self.add_ingredient_from_line(
+                          txt,
+                          prev_iter=prev_iter,
+                          group_iter=group_iter)
                       )
-        self.quickEntry.set_text('')
+        self.entry.set_text('')
 
     def update_from_database (self):
         self.ingtree_ui.set_tree_for_rec(self.current_rec)
 
-    def setup_action_groups (self):
+    def setup_action_groups(self):
         self.ingredientEditorActionGroup = Gtk.ActionGroup(name='IngredientEditorActionGroup')  # noqa
-        self.ingredientEditorOnRowActionGroup = Gtk.ActionGroup(name='IngredientEditorOnRowActionGroup')  # noqa
         self.ingredientEditorActionGroup.add_actions([
             ('AddIngredient', Gtk.STOCK_ADD, _('Add ingredient'), None, None),
 
@@ -1152,6 +1151,8 @@ class IngredientEditorModule (RecEditorModule):
             ('AddRecipeAsIngredient', None, _('Add _recipe'), '<Control>R',
              _('Add another recipe as an ingredient in this recipe'), lambda *args: RecSelector(self.rg, self)),
             ])
+
+        self.ingredientEditorOnRowActionGroup = Gtk.ActionGroup(name='IngredientEditorOnRowActionGroup')  # noqa
         self.ingredientEditorOnRowActionGroup.add_actions([
             ('DeleteIngredient',Gtk.STOCK_DELETE,_('Delete'),
              #'Delete', # Binding to the delete key meant delete
@@ -1164,16 +1165,29 @@ class IngredientEditorModule (RecEditorModule):
             ('MoveIngredientDown',Gtk.STOCK_GO_DOWN,_('Down'),
              '<Control>Down',None,self.ingtree_ui.ingDownCB),
             ])
-        for group in [self.ingredientEditorActionGroup,
-                      self.ingredientEditorOnRowActionGroup,
-                      ]:
-            fix_action_group_importance(group)
+
+        fix_action_group_importance(self.ingredientEditorActionGroup)
+        fix_action_group_importance(self.ingredientEditorOnRowActionGroup)
+
         self.action_groups.append(self.ingredientEditorActionGroup)
         self.action_groups.append(self.ingredientEditorOnRowActionGroup)
 
-    def add_ingredient_from_line (self, line, group_iter=None, prev_iter=None):
-        """Add an ingredient to our list from a line of plain text"""
-        d=self.rg.rd.parse_ingredient(line, conv=self.rg.conv)
+    def add_ingredient_from_line(self,
+                                 line: str,
+                                 group_iter: Optional[Gtk.TreeIter] = None,
+                                 prev_iter: Optional[Gtk.TreeIter] = None):
+        """Add an ingredient to the list from a line of plain text.
+
+        The line will parsed if it matches the expected format of
+        "{amount} {unit} {item}".
+
+        `group_iter` is a tree iterator used to put the item under the group,
+        if the group is selected in the tree.
+        `prev_iter` is a tree iterator used to keep track of a previously
+        selected item, so that the new ingredient can be added right below it in
+        the tree.
+        """
+        d = self.rg.rd.parse_ingredient(line, conv=self.rg.conv)
         if d:
             if 'rangeamount' in d:
                 d['amount'] = self.rg.rd.format_amount_string_from_amount(
@@ -1182,21 +1196,25 @@ class IngredientEditorModule (RecEditorModule):
             elif 'amount' in d:
                 d['amount'] = convert.float_to_frac(d['amount'])
         else:
-            d = {}
-            d['item'] = line
-            d['amount'] = None
-            d['unit'] = None
-        itr = self.ingtree_ui.ingController.add_new_ingredient(prev_iter=prev_iter,group_iter=group_iter,**d)
+            d = {'item': line,
+                 'amount': None,
+                 'unit': None}
+        itr = self.ingtree_ui.ingController.add_new_ingredient(
+            prev_iter=prev_iter,
+            group_iter=group_iter,
+            **d
+        )
         # If there is just one row selected...
         sel = self.ingtree_ui.ingTree.get_selection()
-        if sel.count_selected_rows()==1:
+        if sel.count_selected_rows() == 1:
             # Then we move our selection down to our current ingredient...
             sel.unselect_all()
             sel.select_iter(itr)
         # Make sure our newly added ingredient is visible...
         self.ingtree_ui.ingTree.scroll_to_cell(
             self.ingtree_ui.ingController.imodel.get_path(itr)
-            )
+        )
+
         return itr
 
     def paste_ingredients_cb(self):

--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -1142,13 +1142,15 @@ class IngredientEditorModule (RecEditorModule):
         self.ingredientEditorActionGroup = Gtk.ActionGroup(name='IngredientEditorActionGroup')  # noqa
         self.ingredientEditorOnRowActionGroup = Gtk.ActionGroup(name='IngredientEditorOnRowActionGroup')  # noqa
         self.ingredientEditorActionGroup.add_actions([
-            ('AddIngredient',Gtk.STOCK_ADD,_('Add ingredient'),
-             None,None),
-            ('AddIngredientGroup',None,_('Add group'),
-             '<Control>G',None,self.ingtree_ui.ingNewGroupCB),
-            ('AddRecipeAsIngredient',None,_('Add _recipe'),
-             '<Control>R',_('Add another recipe as an ingredient in this recipe'),
-             lambda *args: RecSelector(self.rg, self)),
+            ('AddIngredient', Gtk.STOCK_ADD, _('Add ingredient'), None, None),
+
+            ('PasteIngredient', Gtk.STOCK_PASTE, None, '<Control>V', None,
+             lambda args: add_with_undo(self, self.paste_ingredients_cb)),
+
+            ('AddIngredientGroup', None, _('Add group'), '<Control>G', None, self.ingtree_ui.ingNewGroupCB),
+
+            ('AddRecipeAsIngredient', None, _('Add _recipe'), '<Control>R',
+             _('Add another recipe as an ingredient in this recipe'), lambda *args: RecSelector(self.rg, self)),
             ])
         self.ingredientEditorOnRowActionGroup.add_actions([
             ('DeleteIngredient',Gtk.STOCK_DELETE,_('Delete'),
@@ -1197,17 +1199,12 @@ class IngredientEditorModule (RecEditorModule):
             )
         return itr
 
+    def paste_ingredients_cb(self):
+        text = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD).wait_for_text()
 
-    def paste_ingredients_cb(self, action: Gtk.Action):
-        self.cb = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
-        def add_ings_from_clippy(cb, text):
-            if text:
-                def do_add():
-                    for l in text.split('\n'):
-                        if l.strip():
-                            self.add_ingredient_from_line(l)
-                add_with_undo(self, lambda *args: do_add())
-        self.cb.request_text(add_ings_from_clippy)
+        for line in text.split('\n'):
+            if line.strip():
+                self.add_ingredient_from_line(line)
 
     def delete_cb (self, *args):
         debug("delete_cb (self, *args):",5)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes #19 wherein it's described how pasting several lines of ingredients in a new recipe not behaving as expected.
A previous PR in Gourmet had fixed the conflicting handlers of the clipboard paste callbacks, but the lines were not automatically parsed and appended to the recipe.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by repeatedly adding text to the various tabs of a new recipe window. 

## Screenshots (if appropriate):
![output](https://user-images.githubusercontent.com/2159577/132488977-42eb64ac-de75-4854-8232-ab063ea24db3.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
