### PR TITLE
Escape special characters when saving recipe to database

### DIFF
--- a/src/gourmand/gtk_extras/pango_html.py
+++ b/src/gourmand/gtk_extras/pango_html.py
@@ -1,3 +1,4 @@
+from html import escape
 from html.parser import HTMLParser
 from typing import Dict, List, Optional, Tuple
 
@@ -184,7 +185,7 @@ class PangoToHtml(HTMLParser):
             self.current_closing_tags.pop()  # FILO
             self.current_opening_tags.pop()
         else:
-            data = ''.join(self.current_opening_tags) + data
+            data = ''.join(self.current_opening_tags) + escape(data)
             self.current_opening_tags.clear()
 
         self.markup_text += data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes #37, escaping special characters when saving recipes.  
The content of a recipe is saved a html to preserve links and formatting. Special characters such as ampersand were not escaped and caused problems when deserializing (loading) the recipes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by creating a recipe with ampersands everywhere and formatting where applicable and seeing that the recipe is correctly displayed and exported (to PDF.)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2159577/132952712-0f8981f5-4f8c-42d3-a9d7-e3f3a0d21ed8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
