### PR TITLE
Cancel file import if encoding selection cancelled

### DIFF
--- a/src/gourmand/check_encodings.py
+++ b/src/gourmand/check_encodings.py
@@ -141,6 +141,11 @@ class EncodingDialog(de.OptionDialog):
         options = list(self.encodings.keys())
         masterlist = CheckEncoding.encodings + CheckEncoding.all_encodings
         options.sort(key=lambda x: masterlist.index(x))
+        # Make utf-8 the default value if available, as it is likely right
+        # format
+        if 'utf-8' in options:
+            options.remove('utf-8')
+            options.insert(0, 'utf-8')
         return options
 
     def create_expander(self):

--- a/src/gourmand/importers/plaintext_importer.py
+++ b/src/gourmand/importers/plaintext_importer.py
@@ -20,16 +20,22 @@ class TextImporter (importer.Importer):
         self.rec = {}
         self.ing = {}
         self.compile_regexps()
+        self.lines = None
         importer.Importer.__init__(self,conv=conv)
 
-    def pre_run (self):
+    def pre_run(self):
         self.lines = check_encodings.get_file(self.fn)
+
+        if self.lines is None:
+            return  # The operation has been cancelled
+
         self.total_lines = len(self.lines)
         print('we have ',self.total_lines,'lines in file',self.fn)
 
-    def do_run (self):
-        if not hasattr(self,'lines'):
-            raise Exception("pre_run has not been run!")
+    def do_run(self):
+        if self.lines is None:
+            return
+
         for n in range(self.total_lines):
             l=self.lines[n]
             if n % 15 == 0:

--- a/src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py
+++ b/src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py
@@ -5,14 +5,13 @@ from gi.repository import Gtk
 
 from gourmand import check_encodings
 from gourmand.i18n import _
-from gourmand.importers.importer import Tester
 from gourmand.importers.interactive_importer import InteractiveImporter
 from gourmand.plugin import ImporterPlugin
-from gourmand.threadManager import get_thread_manager
 
 MAX_PLAINTEXT_LENGTH = 100000
 
-class PlainTextImporter (InteractiveImporter):
+
+class PlainTextImporter(InteractiveImporter):
 
     name = 'Plain Text Importer'
 
@@ -29,10 +28,15 @@ class PlainTextImporter (InteractiveImporter):
                             sublabel=_('Your file exceeds the maximum length of %s characters. You probably didn\'t mean to import it anyway. If you really do want to import this file, use a text editor to split it into smaller files and try importing again.')%MAX_PLAINTEXT_LENGTH,
                             message_type=Gtk.MessageType.ERROR)
             return
-        with open(self.filename, 'rb') as ifi:
-            data = '\n'.join(check_encodings.get_file(ifi))
+
+        content = check_encodings.get_file(self.filename)
+        if content is None:
+            return
+
+        data = '\n'.join(check_encodings.get_file(content))
         self.set_text(data)
         return InteractiveImporter.do_run(self)
+
 
 class PlainTextImporterPlugin (ImporterPlugin):
 

--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -1389,8 +1389,8 @@ class DescriptionEditorModule (TextEditor, RecEditorModule):
         except (TypeError, ValueError):
             self.yields = None
             if hasattr(self.current_rec, 'yields'):
-                msg = (f'Could not make sense of {self.current_rec.yields}'
-                        'as a number of yields')
+                msg = (f'Could not make sense of {self.current_rec.yields} '
+                       'as a number of yields')
                 debug(msg, 0)
 
         for c in self.reccom:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves #24 where it's described how cancelling encoding selection still imports recipes when a user would expect the import to be cancelled.  

This also makes `utf-8` the default file format if found, as it's likely to be the correct format nowadays.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by starting importing a file and cancelling the encoding selection, checking that no recipes were imported and that the application behaves as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
