### PR TITLE
Focus input on displayed widget when using shortcut to edit recipe

### DIFF
--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -823,7 +823,9 @@ class RecEditor(WidgetSaver.WidgetPrefs, plugin_loader.Pluggable):
             InstructionsEditorModule,
             NotesEditorModule,
             ]
-        self.reccard= reccard; self.rg = rg; self.recipe_display = recipe_display
+        self.reccard = reccard
+        self.rg = rg
+        self.recipe_display = recipe_display
         if self.recipe_display and not recipe:
             recipe = self.recipe_display.current_rec
         self.current_rec = recipe
@@ -856,9 +858,8 @@ class RecEditor(WidgetSaver.WidgetPrefs, plugin_loader.Pluggable):
         self.show()
         self.modules[0].grab_focus()
 
-    def present (self):
+    def present(self):
         self.window.present()
-        self.modules[0].grab_focus()
 
     def setup_defaults (self):
         self.edit_title = _('Edit Recipe:')
@@ -941,14 +942,15 @@ class RecEditor(WidgetSaver.WidgetPrefs, plugin_loader.Pluggable):
                     return
             self.set_edited(False)
 
-    def show_module(self, module_name: str) -> None:
-        """Show the part of our interface corresponding with module
-        named module_name."""
-        if module_name not in self.module_tab_by_name:
+    def show_module(self, module_name: str):
+        """Show and focus on the requested notebook."""
+        try:
+            module_index = self.module_tab_by_name[module_name]
+        except KeyError:
             raise ValueError('RecEditor has no module named %s'%module_name)
-        self.notebook.set_current_page(
-            self.module_tab_by_name[module_name]
-            )
+
+        self.notebook.set_current_page(module_index)
+        self.modules[module_index].grab_focus()
 
     def setup_main_interface (self):
         self.window = Gtk.Window()
@@ -967,7 +969,8 @@ class RecEditor(WidgetSaver.WidgetPrefs, plugin_loader.Pluggable):
         main_vb.pack_start(self.ui_manager.get_widget('/RecipeEditorMenuBar'),expand=False,fill=False, padding=0)
         main_vb.pack_start(self.ui_manager.get_widget('/RecipeEditorToolBar'),expand=False,fill=False, padding=0)
         main_vb.pack_start(self.ui_manager.get_widget('/RecipeEditorEditToolBar'),expand=False,fill=False, padding=0)
-        self.notebook = Gtk.Notebook(); self.notebook.show()
+        self.notebook = Gtk.Notebook()
+        self.notebook.show()
         main_vb.pack_start(self.notebook, True, True, 0)
         self.window.add(main_vb)
         self.window.add_accel_group(self.ui_manager.get_accel_group())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes an issue where directly editing a recipe's field (eg. description) would show that field, but the input focus would still be on the hidden title widget.  
The changes here now keep track of what the is the opened notebook and sets focus on it.

Closes #56 .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by opening a recipe, clicking `Edit Description`, and starting to type without further interaction.  
The input was appended to the existing content, as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
