### PR TITLE
Fix invalid reccard size

### DIFF
--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -372,7 +372,7 @@ class RecCardDisplay (plugin_loader.Pluggable):
                                                                 {'window_size':(700,600)})
                                                  )
                          )
-        self.window.set_default_size(*self.prefs.get('reccard_window_%s'%self.current_rec.id)['window_size'])
+        self.window.set_default_size(*self.prefs.get('reccard_window')['window_size'])
         main_vb = Gtk.VBox()
         menu = self.ui_manager.get_widget('/RecipeDisplayMenuBar')
         main_vb.pack_start(menu, fill=False, expand=False, padding=0)


### PR DESCRIPTION
Use common reccard_window size instead of obsolete(?)
reccard_window_(id) from prefs

Signed-off-by: Eliot Blennerhassett <eliot@blennerhassett.gen.nz>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #63

## How Has This Been Tested?
Tested by running and observing correct behaviour.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
