### PR TITLE
Skip `None` values when converting nutritional values

### DIFF
--- a/src/gourmand/backends/db.py
+++ b/src/gourmand/backends/db.py
@@ -765,7 +765,7 @@ class RecData (Pluggable):
             where_statement,
             distinct=True).execute().fetchall()]
 
-    def search_nutrition (self, words, group=None):
+    def search_nutrition(self, words: List[str], group=None):
         """Search nutritional information for ingredient keys."""
         where_statement = and_(
             *[self.nutrition_table.c.desc.like('%%%s%%'%w)

--- a/src/gourmand/exporters/xml_exporter.py
+++ b/src/gourmand/exporters/xml_exporter.py
@@ -1,5 +1,5 @@
-import types
 import xml.dom
+from typing import Optional, List
 
 from .exporter import exporter_mult
 
@@ -12,9 +12,10 @@ class XmlExporter (exporter_mult):
     #dtd_path = ''
 
     def __init__ (self, rd, r, out,
-                  order=['attr','image','ings','text'],
+                  order: Optional[List[str]] = None,
                   xmlDoc=None,
                   **kwargs):
+        order = order or ['attr', 'image', 'ings', 'text']
         if xmlDoc:
             self.xmlDoc = xmlDoc
             self.i_created_this_document = False
@@ -45,20 +46,20 @@ class XmlExporter (exporter_mult):
         element.setAttributeNode(a)
         element.setAttribute(attribute,value)
 
-    def append_text (self, element, text):
+    def append_text(self, element, text):
         try:
             assert isinstance(text, str)
-        except:
+        except AssertionError:
             print('Text is not text')
             print('append_text received',element,text)
             raise TypeError('%r is not a StringType' % text)
         try:
             t = self.xmlDoc.createTextNode(text)
             element.appendChild(t)
-        except:
+        except Exception as e:
             print('FAILED WHILE WORKING ON ',element)
             print('TRYING TO APPEND',text[:100])
-            raise
+            raise e
 
     def create_text_element (self, element_name, text, attrs={}):
         element = self.create_element_with_attrs(element_name,attrs)

--- a/src/gourmand/plugins/nutritional_information/nutrition.py
+++ b/src/gourmand/plugins/nutritional_information/nutrition.py
@@ -17,7 +17,6 @@ class NutritionData:
     def __init__ (self, db, conv):
         self.db = db
         self.conv = conv
-        self.conv.density_table
         self.gramwght_regexp = re.compile("([0-9.]+)?( ?([^,]+))?(, (.*))?")
         self.wght_breaker = re.compile(r'([^ ,]+)([, ]+\(?(.*)\)?)?$')
 

--- a/tests/test_nutritional_information.py
+++ b/tests/test_nutritional_information.py
@@ -1,0 +1,25 @@
+from unittest.mock import Mock
+import pytest
+
+from gourmand.plugins.nutritional_information.nutrition import NutritionData
+
+@pytest.mark.parametrize(
+    'description, mock_content, expected',
+    [
+        ('', ['', ''], []),
+        ('with', ['', ''], []),
+        ('what a str', ['str', 5], [('str', 5)])
+    ],
+)
+def test_get_matches(description, mock_content, expected):
+    content_mock = Mock()
+    content_mock.desc = mock_content[0]
+    content_mock.ndbno = mock_content[1]
+
+    mock_db = Mock()
+    mock_db.search_nutrition = Mock(return_value=(content_mock,))
+
+    nd = NutritionData(db=mock_db, conv=None)
+
+    ret = nd.get_matches(description)
+    assert ret == expected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This closes #75, where it was reported that some unsupported values are handed over to `NutritionData.get_matches`, which expects strings, but might be given `None`s.

There was a bit of clean-up done as well in the xml exporter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by passing `None` values as descriptions to `get_nutinfo_from_desc` .
Moreover, an unittest was added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
