### PR TITLE
Updated db.py to comply to sqlalchemy 1.4

### DIFF
--- a/src/gourmand/backends/db.py
+++ b/src/gourmand/backends/db.py
@@ -9,7 +9,8 @@ import sqlalchemy
 import sqlalchemy.orm
 from gi.repository import Gtk
 from sqlalchemy import (Boolean, Column, Float, ForeignKey, Integer,
-                        LargeBinary, Numeric, String, Table, Text, event, func)
+                        LargeBinary, Numeric, String, Table, Text,
+                        event, func, select)
 from sqlalchemy.sql import and_, case, or_
 
 import gourmand.__version__
@@ -741,9 +742,16 @@ class RecData (Pluggable):
         """Return the number of rows in table that match criteria
         """
         if criteria:
-            return table.count(*make_simple_select_arg(criteria,table)).execute().fetchone()[0]
-        else:
-            return table.count().execute().fetchone()[0]
+            return select(
+                [func.count(list(table.primary_key.columns)[0])])\
+                    .where(*make_simple_select_arg(criteria,table))\
+                    .execute()\
+                    .fetchone()[0]
+
+        return select(
+            [func.count(list(table.primary_key.columns)[0])])\
+                .execute()\
+                .fetchone()[0]
 
     def fetch_join (self, table1, table2, col1, col2,
                     column_names=None, sort_by=None, **criteria):


### PR DESCRIPTION
Fixed Issue #79 by switching table.count() to equivalent calls to func.count(). 

## Description
Ran into Issue #79 trying to install and run gourmand from AUR on Arch Linux.
I switched to func.count() following the sqlalchemy 1.4 API doc. As func.count() needs an attribute to run on, I chose to use the primary key of the table for that (usually just an int and present). Another candidate would have been table.c[0].

## How Has This Been Tested?
Looked at the generated Query structure in fetch_len():

```
...
        criteria={'id':1628}
        print("With criteria: ", select(
                [func.count(list(table.primary_key.columns)[0])])\
                    .where(*make_simple_select_arg(criteria,table)).compile())

        print("Without criteria: ", select(
            [func.count(list(table.primary_key.columns)[0])]).compile())
...
```
yields:

```
With criteria:  SELECT count(keylookup.id) AS count_1 
FROM keylookup 
WHERE keylookup.id = ?
Without criteria:  SELECT count(keylookup.id) AS count_1 
FROM keylookup
```
... which I guess is what was the purpose of that. The code returns plausible values for the count() queries ("1" with the criterium above, "1638" without).

Also the fixed code works fine so far with sqlalchemy 1.4, however I could not find out how to get the application to actually call fetch_len() with a set of criteria. Also I didn't dig deeper into esp. make_simple_select_arg(), and this is just a quick fix.
Please verify.

Style (of the changed bits) checks out with pylint / PEP8.

## Types of changes
[x] Updated use of library, removed deprecated function

## Checklist:
[x] My code follows the code style of this project.
[ ] My change requires a change to the documentation.
[ ] I have updated the documentation accordingly.
