### PR TITLE
Display ingredient quantities as strings

### DIFF
--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -1771,25 +1771,20 @@ class IngredientController (plugin_loader.Pluggable):
             widget=self.imodel,
             ).perform()
 
-    def update_ingredient_row (self,iter,
-                               amount=None,
-                               unit=None,
-                               item=None,
-                               optional=None,
-                               ingkey=None,
-                               shop_cat=None,
-                               refid=None,
-                               undoable=False
-                               ):
-        if amount is not None: self.imodel.set_value(iter,1,amount)
-        if unit is not None: self.imodel.set_value(iter,2,unit)
-        if item is not None: self.imodel.set_value(iter,3,item)
-        if optional is not None: self.imodel.set_value(iter,4,optional)
-        #if ingkey is not None: self.imodel.set_value(iter,5,ingkey)
-        #if shop_cat:
-        #    self.imodel.set_value(iter,6,shop_cat)
-        #elif ingkey and self.re.rg.sl.orgdic.has_key(ingkey):
-        #    self.imodel.set_value(iter,6,self.re.rg.sl.orgdic[ingkey])
+    def update_ingredient_row(self,
+                              iter: Gtk.TreeIter,
+                              amount: Optional[float] = None,
+                              unit: Optional[str] = None,
+                              item: Optional[str] = None,
+                              optional: Optional[bool] = None):
+        if amount is not None:
+            self.imodel.set_value(iter, 1, str(amount))
+        if unit is not None:
+            self.imodel.set_value(iter, 2, unit)
+        if item is not None:
+            self.imodel.set_value(iter, 3, item)
+        if optional is not None:
+            self.imodel.set_value(iter, 4, optional)
 
     def add_ingredient (self, ing, prev_iter=None, group_iter=None,
                         fallback_on_append=True, shop_cat=None,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes #89: ingredient quantities values are handled as floats throughout the application, but the treeview expects string.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested with the steps described in the issue:  
1) Edit ingredients of existing recipe
2) Change an ingredient unit e.g. from ounces to g
3) Select the converted radio button in the "Changed unit" dialog and click OK

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
