### PR TITLE
Add access to shopping list from Go menu

### DIFF
--- a/src/gourmand/main.py
+++ b/src/gourmand/main.py
@@ -809,6 +809,7 @@ ui_string = '''<ui>
     <placeholder name="DataTool"/>
     <separator/>
     <menuitem action="ViewTrash"/>
+    <menuitem action="OpenShoppingList"/>
   </menu>
   <menu name="Settings" action="Settings">
     <menuitem action="search_regex_toggle"/>
@@ -1045,6 +1046,9 @@ class RecGui(RecIndex, GourmandApplication, ImporterExporter, StuffThatShouldBeP
 
             ('ViewTrash', None, _('Open _Trash'), None, None,
              self.show_deleted_recs),
+
+            ('OpenShoppingList', None, _('Open _Shopping List'), None, None,
+             lambda action: self.sl.show()),
 
             ('Preferences', Gtk.STOCK_PREFERENCES, _('_Preferences'),
              None, None, self.show_preferences),

--- a/src/gourmand/main.py
+++ b/src/gourmand/main.py
@@ -800,6 +800,9 @@ ui_string = '''<ui>
     <menuitem action="BatchEdit"/>
   </menu>
   <menu name="Go" action="Go">
+    <menuitem action="OpenShoppingList"/>
+    <menuitem action="OpenTrash"/>
+    <separator/>
   </menu>
   <menu name="Tools" action="Tools">
     <placeholder name="StandaloneTool">
@@ -807,9 +810,6 @@ ui_string = '''<ui>
     </placeholder>
     <separator/>
     <placeholder name="DataTool"/>
-    <separator/>
-    <menuitem action="ViewTrash"/>
-    <menuitem action="OpenShoppingList"/>
   </menu>
   <menu name="Settings" action="Settings">
     <menuitem action="search_regex_toggle"/>
@@ -1044,11 +1044,10 @@ class RecGui(RecIndex, GourmandApplication, ImporterExporter, StuffThatShouldBeP
             ('Actions',None,_('_Actions')),
             ('Edit',None,_('_Edit')),
 
-            ('ViewTrash', None, _('Open _Trash'), None, None,
-             self.show_deleted_recs),
-
-            ('OpenShoppingList', None, _('Open _Shopping List'), None, None,
+            ('OpenShoppingList', None, _('_Shopping List'), None, None,
              lambda action: self.sl.show()),
+            ('OpenTrash', None, _('_Trash'), None, None,
+             self.show_deleted_recs),
 
             ('Preferences', Gtk.STOCK_PREFERENCES, _('_Preferences'),
              None, None, self.show_preferences),
@@ -1154,12 +1153,10 @@ class RecGui(RecIndex, GourmandApplication, ImporterExporter, StuffThatShouldBeP
                 GObject.idle_add(show)
 
     # Deletion
-    def show_deleted_recs (self, *args):
-        if not hasattr(self,'recTrash'):
+    def show_deleted_recs(self, *action: Gtk.Action):
+        if not hasattr(self, 'recTrash'):
             self.recTrash = RecTrash(self.rg)
-            self.recTrash.show()
-        else:
-            self.recTrash.show()
+        self.recTrash.show()
 
     def rec_tree_keypress_cb (self, widget, event):
         keyname = Gdk.keyval_name(event.keyval)
@@ -1209,7 +1206,7 @@ class RecGui(RecIndex, GourmandApplication, ImporterExporter, StuffThatShouldBeP
         self.setup_delete_messagebox(
             _((f'You just moved {len(recs)} recipe to the trash.\nYou can '
                'recover this recipe or permanently delete it at any time by '
-               'clicking Tools->Open Trash.'))
+               'clicking Go->Trash.'))
         )
         self.set_reccount()
         if hasattr(self,'recTrash'):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR address the feature request in #90 to have a way to display the shopping list without having to add a recipe to it.  
The shopping list can now be displayed from the *Go* menu.  
Access to the trash has also been moved there.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2159577/171670690-e93df00e-f990-476c-af4d-ad1943725688.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
