### PR TITLE
Correctly get recipe link from reccard widget

### DIFF
--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -3070,6 +3070,6 @@ def create_spinner(val: int = 1,
 
 
 def open_uri(button: Gtk.Button):
-    uri = button.get_child().get_label()
+    uri = button.get_child().get_text()
     if uri:
         webbrowser.open_new_tab(uri)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes an issue where label content was used, rather than label text to open recipe links.  
This would result in malformatted urls, with Pango escape characters.  
Closes #105. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by checking various links, such as `https://www.allrecipes.com/recipe/54788/` and checking that the page is correctly opened and loaded.
When erroneous, the url was `https://www.allrecipes.com/recipe/_54788/` (note the extra `_` before the recipe id).  


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
