### PR TITLE
Update GNOME 42 for Flatpak build

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Flatpak
       run: |
         flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install flathub org.gnome.Platform//40 org.gnome.Sdk//40 -y
+        flatpak install flathub org.gnome.Platform//42 org.gnome.Sdk//42 -y
 
     - name: Build Flatpak
       run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is an action to try to correct Issue #110.  GNOME 40 is no longer available via Flatpak.

## Description
<!--- Describe your changes in detail -->
Currently, Flatpak has GNOME version 3.38, 41, and 42.  (I don't particularly care which one this gets moved to.)
<!--- Why is this change required? What problem does it solve? -->
The Flatpak version cannot be installed.
<!--- If it fixes an open issue, please link to the issue here. -->
Related to Issue #110 

## How Has This Been Tested?
It has not be tested.  I don't really know how to test this.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
