### PR TITLE
Use beautiful soup to import unstructured recipes

### DIFF
--- a/src/gourmand/gtk_extras/dialog_extras.py
+++ b/src/gourmand/gtk_extras/dialog_extras.py
@@ -1193,16 +1193,15 @@ class URIDialog(EntryDialog):
         self.ok_button.set_sensitive(False)
 
         def validate(uri: str) -> Optional[str]:
-            uri_ = urlparse(uri).netloc.strip('www.')
             supported = False
 
             if not uri:  # Do nothing, but disable ok button
                 self.ok_button.set_sensitive(False)
-                return 
+                return
             try:
                 if ';' in uri:  # Match files from FileSelectorDialog
                     supported = True
-                elif uri_ in supported_urls:
+                elif urlparse(uri).netloc:
                     supported = True
                 elif Path(uri).is_file():
                     supported = True

--- a/src/gourmand/importers/importManager.py
+++ b/src/gourmand/importers/importManager.py
@@ -8,6 +8,7 @@ import gourmand.gtk_extras.dialog_extras as de
 import gourmand.plugin_loader as plugin_loader
 from gourmand.i18n import _
 from gourmand.importers.web_importer import import_urls, supported_sites
+from gourmand.importers.interactive_importer import import_interactivally
 from gourmand.plugin import ImporterPlugin, ImportManagerPlugin
 from gourmand.threadManager import (NotThreadSafe, get_thread_manager,
                                     get_thread_manager_gui)
@@ -74,7 +75,9 @@ class ImportManager(plugin_loader.Pluggable):
 
         # There should be only a single url
         if urlparse(uris[-1]).netloc:
-            import_urls(uris)
+            supported, unsupported = import_urls(uris)
+            if unsupported:
+                import_interactivally(unsupported)
         else:
             self.import_filenames(uris)
 

--- a/src/gourmand/importers/interactive_importer.py
+++ b/src/gourmand/importers/interactive_importer.py
@@ -1,9 +1,15 @@
 import re
 
-from gi.repository import Gtk
+import requests
 
 import gourmand.gglobals as gglobals
 import gourmand.gtk_extras.cb_extras as cb
+
+from typing import List
+
+from bs4 import BeautifulSoup
+from gi.repository import Gtk
+
 from gourmand.i18n import _
 from gourmand.image_utils import ImageBrowser, image_to_bytes
 from gourmand.importers import importer
@@ -502,6 +508,18 @@ class InteractiveImporter (ConvenientImporter, NotThreadSafe):
         else:
             self.w.connect('delete-event',lambda *args: self.w.hide())
 
+
+def import_interactivally(uris: List[str]):
+    """Import pages not supported by recipe-scrapers."""
+    for uri in uris:
+        resp = requests.get(uri)
+        if not resp.ok:
+            continue
+        text = BeautifulSoup(resp.text, 'html.parser').get_text()
+        text = text.replace('  ', '\n')  # Make the text more readable
+        importer = InteractiveImporter()
+        importer.set_text(text)
+        importer.do_run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This closes #88 by implementing the import of unstructured recipes using  requests and beautifulsoup to get the page's content and Gourmand's plaintext importer to let the user mark the recipe.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by importing a url and seeing it being parsed, as shown below.


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2159577/184135049-14e0cc9f-a5cd-49eb-a55c-2ec778d054d5.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
