### PR TITLE
Update beautifulsoup4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ setup(
     packages=find_packages('src'),
     include_package_data=True,
     install_requires=[
-        'beautifulsoup4==4.9.3',
+        'beautifulsoup4>=4.10.0',
         'lxml==4.6.3',
         'pillow>=8.3.2',
         'pygobject==3.40.1',

--- a/src/gourmand/importers/web_importer.py
+++ b/src/gourmand/importers/web_importer.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 from gi.repository import Gtk
 from recipe_scrapers import SCRAPERS, scrape_me
+from recipe_scrapers._exceptions import SchemaOrgException
 
 from gourmand.image_utils import ImageBrowser, image_to_bytes, make_thumbnail
 from gourmand.recipeManager import get_recipe_manager
@@ -80,6 +81,13 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
 
         # Convert the recipe into the expected namedtuple `recipe_tuple`
         # expected by the rest of the application.
+        try:
+            preptime = recipe.schema.prep_time()
+            cooktime = recipe.schema.cook_time()
+        except SchemaOrgException:
+            preptime = ""
+            cooktime = ""
+
         rec = Recipe(
                 id=None,
                 title=recipe.title(),
@@ -90,8 +98,8 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
                 description='',
                 source=recipe.author(),
                 totaltime=recipe.total_time(),
-                preptime=recipe.schema.prep_time(),
-                cooktime=recipe.schema.cook_time(),
+                preptime=preptime,
+                cooktime=cooktime,
                 servings=yields,
                 yields=yields,
                 yield_unit=yield_unit,


### PR DESCRIPTION
Fixes for #115 

## Description
Updated the version of beautifulsoup4 to 4.10.0 or later to be in sync with recipe-scrapers.
Small fix to allow importing recipes without prep and cook time

## How Has This Been Tested?
* Tested fresh install
* Imported recipes from ica.se (that requires latest version of recipe-scrapers)
* The only usage of beautifulsoup4 (that i can find) in the codebase is in src/gourmand/gtk_extras/pango_html.py and since i don't fully understand it I clicked around in the GUI where I think this code is used and it seems to work :-)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
