### PR TITLE
Better describe the URL field supporting only certain sites

### DIFF
--- a/src/gourmand/importers/importManager.py
+++ b/src/gourmand/importers/importManager.py
@@ -61,7 +61,7 @@ class ImportManager(plugin_loader.Pluggable):
         """Offer to import url or files."""
 
         uris = de.get_uri(label=_('Open recipe...'),
-                          sublabel=_('Enter a recipe file path or website address.'),
+                          sublabel=_('Enter a recipe file path or a supported website address.'),
                           entryLabel=_('Location:'),
                           entryTip=_('Enter the address of a website or recipe archive.'),
                           default_character_width=60,


### PR DESCRIPTION
The URL field doesn't currently inform the user that only certain sites are supported. I only understood this after digging through the source code.

## Description
Change the label by adding the word supported.

## How Has This Been Tested?
I wasn't able to test it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
