### PR TITLE
Import Distutils after Setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,15 @@
 import os
 import re
-from distutils.core import Command
-from distutils.log import INFO
 from pathlib import Path
 from typing import Union
 
 from setuptools import find_packages, setup
 from setuptools.command.develop import develop
 from setuptools.command.sdist import sdist
+
+from distutils.core import Command
+from distutils.log import INFO
+
 from wheel.bdist_wheel import bdist_wheel
 
 


### PR DESCRIPTION
From python

```UserWarning: Distutils was imported before Setuptools, but importing Setuptools also replaces the `distutils` module in `sys.modules`. This may lead to undesirable behaviors or errors. To avoid these issues, avoid using distutils directly, ensure that setuptools is installed in the traditional way (e.g. not an editable install), and/or make sure that setuptools is always imported before distutils.
```
