### PR TITLE
Web import: adjust category method invocation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ setup(
         'pygobject==3.40.1',
         'sqlalchemy==1.4.36',
         'toml==0.10.2',
-        'recipe-scrapers',
+        'recipe-scrapers>=14.27.0',
     ],
     extras_require={
         'epub-export': ['ebooklib==0.17.1'],

--- a/src/gourmand/importers/web_importer.py
+++ b/src/gourmand/importers/web_importer.py
@@ -112,7 +112,7 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
                 link=recipe.canonical_url(),
                 last_modified=None,
                 nutrients=recipe.nutrients(),
-                category=recipe.schema.category()
+                category=recipe.category(),
                 )
 
         rec = rec._asdict()


### PR DESCRIPTION
## Description
Since `recipe-scrapers` v14.27.0, there is a default-field-fallback behaviour (see hhursev/recipe-scrapers#705) for the `scraper.category` method, making that field easier to rely on.

Gourmand's code has previously referenced the `scraper.schema.category` method during web import -- this refers to the generic schema.org page parser -- and that implementation is fine, but may make it difficult for scraper developers who want to use customized `category` code in Gourmand to achieve their expected results.

To address this, this changeset sets `recipe-scrapers` v14.27.0 as the minimum dependency version, and call the `scraper.category` method instead of `scraper.schema.category`.

## How Has This Been Tested?
This was tricky to test - I did manage to run the `test_web_importer.py` tests, but only with a few small change locally (that I'll open separate issues/pull requests for).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.