### PR TITLE
Fix saving and loading of sort preferences

### DIFF
--- a/src/gourmand/main.py
+++ b/src/gourmand/main.py
@@ -888,7 +888,7 @@ class RecGui(RecIndex, GourmandApplication, ImporterExporter, StuffThatShouldBeP
                                       'ascending': True})
         column, ascending = preferences.values()
         ascending = 1 if ascending else -1
-        return ([column, ascending],)
+        return [(column, ascending)]
 
     @sort_by.setter
     def sort_by(self, value):

--- a/src/gourmand/main.py
+++ b/src/gourmand/main.py
@@ -2,7 +2,7 @@ import re
 import threading
 from gettext import ngettext
 from pkgutil import get_data
-from typing import Set
+from typing import List, Set, Tuple
 
 from gi.repository import Gdk, GLib, GObject, Gtk
 
@@ -26,7 +26,8 @@ from gourmand.i18n import _
 from gourmand.image_utils import load_pixbuf_from_resource
 from gourmand.importers.clipboard_importer import import_from_clipboard
 from gourmand.importers.importManager import ImportManager
-from gourmand.prefs import copy_old_installation_or_initialize
+from gourmand.prefs import (copy_old_installation_or_initialize,
+                            update_preferences_file_format)
 from gourmand.recindex import RecIndex
 from gourmand.threadManager import (SuspendableThread, get_thread_manager,
                                     get_thread_manager_gui)
@@ -621,6 +622,7 @@ def launch_webbrowser(dialog, link, user_data):
 
 def launch_app():
     copy_old_installation_or_initialize(gourmanddir)
+    update_preferences_file_format(gourmanddir)
     RecGui.instance()
     Gtk.main()
 
@@ -892,8 +894,7 @@ class RecGui(RecIndex, GourmandApplication, ImporterExporter, StuffThatShouldBeP
         return ret
 
     @sort_by.setter
-    def sort_by(self, value):
-        print(value)
+    def sort_by(self, value: List[Tuple[str, int]]):
         if not value:
             self.prefs.pop('sort_by')
         else:

--- a/src/gourmand/main.py
+++ b/src/gourmand/main.py
@@ -884,17 +884,24 @@ class RecGui(RecIndex, GourmandApplication, ImporterExporter, StuffThatShouldBeP
     @property
     def sort_by(self):
         preferences = self.prefs.get('sort_by',
-                                     {'column': 'title',
-                                      'ascending': True})
-        column, ascending = preferences.values()
-        ascending = 1 if ascending else -1
-        return [(column, ascending)]
+                                     {'title': True})
+        ret = []
+        for column, ascending in preferences.items():
+            ascending = 1 if ascending else -1
+            ret.append((column, ascending))
+        return ret
 
     @sort_by.setter
     def sort_by(self, value):
-        column, ascending = value[-1]
-        ascending = True if ascending == 1 else False  # -1
-        self.prefs['sort_by'] = {'column': column, 'ascending': ascending}
+        print(value)
+        if not value:
+            self.prefs.pop('sort_by')
+        else:
+            d = {}
+            for (column, ascending) in value:
+                ascending = True if ascending == 1 else False  # -1
+                d[column] = ascending
+            self.prefs['sort_by'] = d
 
 
     def setup_hacks (self):

--- a/src/gourmand/prefs.py
+++ b/src/gourmand/prefs.py
@@ -43,6 +43,30 @@ class Prefs(dict):
         return False
 
 
+def update_preferences_file_format(target_dir: Path = gourmanddir):
+    """Update saved preferences upon updates.
+
+    This function is called upon launch to handle changes in the structure of the preference.
+    Each change applied is documented inline.
+    """
+    filename = target_dir / 'preferences.toml'
+    if not filename.is_file():
+        return
+
+    with open(filename) as fin:
+        prefs = toml.load(fin)
+
+    # Gourmand 1.2.0: several sorting parameters can be saved.
+    # The old format had `column=name` and `ascending=bool`, which are now `name=bool`
+    sort_by = prefs.get('sort_by')
+    if sort_by is not None:
+        if 'column' in sort_by.keys():  # old format
+            prefs['sort_by'] = {sort_by['column']: sort_by['ascending']}
+
+    with open(filename, 'w') as fout:
+        toml.dump(prefs, fout)
+
+
 def copy_old_installation_or_initialize(target_dir: Path):
     """Initialize or migrate earlier installations.
 

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -1,6 +1,12 @@
 import pytest
+import toml
 
-from gourmand.prefs import Prefs
+from pathlib import Path
+
+from gourmand.prefs import (
+    Prefs,
+    update_preferences_file_format
+)
 
 
 def test_singleton():
@@ -23,3 +29,30 @@ def test_get_sets_default():
 
     with pytest.raises(KeyError):
         prefs['anotherkey']
+
+
+def test_update_preferences_file_format(tmpdir):
+    """Test the update of preferences file format."""
+
+    filename = tmpdir.join('preferences.toml')
+
+    with open(filename, 'w') as fout:
+        toml.dump({'sort_by': {'column': 'title', 'ascending': True}}, fout)
+
+    update_preferences_file_format(Path(tmpdir))
+
+    with open(filename) as fin:
+        d = toml.load(fin)
+
+    assert 'category' not in d['sort_by'].keys()
+    assert d['sort_by']['title'] == True
+
+    with open(filename, 'w') as fout:
+        toml.dump({}, fout)
+
+    update_preferences_file_format(Path(tmpdir))
+
+    with open(filename) as fin:
+        d = toml.load(fin)
+
+    assert d == {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This MR fixes the loading and saving of recipe sorting preferences.  

In #134, it is shown that there's a bug where the expected format of sort preferences is a list of tuples, but I had implemented a tuple of lists, which this MR resolves.  

In addition, only a single sorting parameter was saved, rather than all applied parameters.  
Here, all parameters are now saved.  

However, this introduces a change in the `preferences.toml` format.  
To mitigate this, a function has been implemented to update the preferences file upon start up to update the preferences format.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->  
This has been tested by launching the application with:
- [x] no sort_by saved
- [x] new sort_by saved
- [x] old sort_by saved
and seeing the application starting correctly.

Different sort_by parameters were applied (none, a single, many), and were verified to be correctly saved in the preferences file, and correctly reloaded.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly: This should also be added to the release notes.
