### PR TITLE
Fix AppImage builds

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -13,10 +13,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install Ubuntu dependencies
+      run: >
+        sudo apt-get update -q && sudo apt-get install
+        --no-install-recommends -y xvfb python3-dev python3-gi
+        python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev
+        intltool enchant python3-enchant gir1.2-poppler-0.18 python3-gst-1.0
+        python3-testresources imagemagick
+
     - name: Setup AppImage Environment
       run: |
-        sudo apt-get update -q
-        sudo apt-get -y install python3-testresources intltool imagemagick libgirepository1.0-dev python3-dev
         wget -c https://github.com/$(wget -q https://github.com/niess/python-appimage/releases/expanded_assets/python3.8 -O - | grep "python3.8.*-cp38-cp38-manylinux1_x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
         chmod +x ./python3*.AppImage
         ./python3*.AppImage --appimage-extract

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -21,9 +21,6 @@ jobs:
         intltool enchant python3-enchant gir1.2-poppler-0.18 python3-gst-1.0
         python3-testresources imagemagick
 
-    - name: Fix Python.h location
-      run: sudo ln -s /usr/include/python3.8/Python.h /usr/include
-
     - name: Setup AppImage Environment
       run: |
         wget -c https://github.com/$(wget -q https://github.com/niess/python-appimage/releases/expanded_assets/python3.8 -O - | grep "python3.8.*x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
@@ -55,6 +52,7 @@ jobs:
 
     - name: Pack AppImage
       run: |
+          chmod 0775 squashfs-root
           VERSION=${GITHUB_SHA::8} ./appimagetool-*.AppImage squashfs-root/
 
     - name: Upload AppImage

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -22,7 +22,9 @@ jobs:
         python3-testresources imagemagick
 
     - name: Fix Python.h location
-      run: sudo ln -s /usr/include/python3.10/* /usr/include
+      run: |
+        locate Python.h
+        sudo ln -s /usr/include/python3.10/* /usr/include
 
     - name: Setup AppImage Environment
       run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install Gourmand in AppImage
       run: |
           ./squashfs-root/AppRun -m pip install --upgrade pip
-          ./squashfs-root/AppRun -m pip install decorator six BeautifulSoup4 html5lib lxml pyenchant pygobject Sphinx
+          C_INCLUDE_PATH=/usr/include/python3.8 ./squashfs-root/AppRun -m pip install decorator six BeautifulSoup4 html5lib lxml pyenchant pygobject Sphinx
 
           ./squashfs-root/AppRun setup.py bdist_wheel
           ./squashfs-root/AppRun -m pip install .[epub-export,mycookbook,pdf-export,spellcheck,web-import]

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -19,12 +19,10 @@ jobs:
         --no-install-recommends -y xvfb python3-dev python3-gi
         python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev
         intltool enchant python3-enchant gir1.2-poppler-0.18 python3-gst-1.0
-        python3-testresources imagemagick
+        python3-testresources imagemagick plocate
 
     - name: Fix Python.h location
-      run: |
-        locate Python.h
-        sudo ln -s /usr/include/python3.10/* /usr/include
+      run: sudo ln -s $(plocate Python.h | tail -n1) /usr/include
 
     - name: Setup AppImage Environment
       run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -21,9 +21,12 @@ jobs:
         intltool enchant python3-enchant gir1.2-poppler-0.18 python3-gst-1.0
         python3-testresources imagemagick
 
+    - name: Fix Python.h location
+      run: sudo ln -s /usr/include/python3.10/* /usr/include
+
     - name: Setup AppImage Environment
       run: |
-        wget -c https://github.com/$(wget -q https://github.com/niess/python-appimage/releases/expanded_assets/python3.8 -O - | grep "python3.8.*-cp38-cp38-manylinux1_x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
+        wget -c https://github.com/$(wget -q https://github.com/niess/python-appimage/releases/expanded_assets/python3.10 -O - | grep "python3.10.*x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
         chmod +x ./python3*.AppImage
         ./python3*.AppImage --appimage-extract
         wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases/expanded_assets/655 -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
@@ -37,7 +40,7 @@ jobs:
           ./squashfs-root/AppRun setup.py bdist_wheel
           ./squashfs-root/AppRun -m pip install .[epub-export,mycookbook,pdf-export,spellcheck,web-import]
           ./squashfs-root/AppRun -m pip install dist/gourmand*.whl
-          sed -i -e 's|/opt/python3.8/bin/python3.8|/usr/bin/gourmand|g' ./squashfs-root/AppRun
+          sed -i -e 's|/opt/python3.10/bin/python3.10|/usr/bin/gourmand|g' ./squashfs-root/AppRun
           rm squashfs-root/*.desktop
           cp data/io.github.GourmandRecipeManager.Gourmand.desktop squashfs-root/usr/share/applications/io.github.GourmandRecipeManager.Gourmand.desktop
           cp data/io.github.GourmandRecipeManager.Gourmand.desktop squashfs-root/io.github.GourmandRecipeManager.Gourmand.desktop

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -22,13 +22,11 @@ jobs:
         python3-testresources imagemagick
 
     - name: Fix Python.h location
-      run: |
-        find /usr/include/ | grep python
-        sudo ln -s $(plocate Python.h | tail -n1) /usr/include
+      run: sudo ln -s /usr/include/python3.8/Python.h /usr/include
 
     - name: Setup AppImage Environment
       run: |
-        wget -c https://github.com/$(wget -q https://github.com/niess/python-appimage/releases/expanded_assets/python3.10 -O - | grep "python3.10.*x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
+        wget -c https://github.com/$(wget -q https://github.com/niess/python-appimage/releases/expanded_assets/python3.8 -O - | grep "python3.8.*x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
         chmod +x ./python3*.AppImage
         ./python3*.AppImage --appimage-extract
         wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases/expanded_assets/655 -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
@@ -42,7 +40,7 @@ jobs:
           ./squashfs-root/AppRun setup.py bdist_wheel
           ./squashfs-root/AppRun -m pip install .[epub-export,mycookbook,pdf-export,spellcheck,web-import]
           ./squashfs-root/AppRun -m pip install dist/gourmand*.whl
-          sed -i -e 's|/opt/python3.10/bin/python3.10|/usr/bin/gourmand|g' ./squashfs-root/AppRun
+          sed -i -e 's|/opt/python3.8/bin/python3.8|/usr/bin/gourmand|g' ./squashfs-root/AppRun
           rm squashfs-root/*.desktop
           cp data/io.github.GourmandRecipeManager.Gourmand.desktop squashfs-root/usr/share/applications/io.github.GourmandRecipeManager.Gourmand.desktop
           cp data/io.github.GourmandRecipeManager.Gourmand.desktop squashfs-root/io.github.GourmandRecipeManager.Gourmand.desktop

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -19,10 +19,12 @@ jobs:
         --no-install-recommends -y xvfb python3-dev python3-gi
         python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev
         intltool enchant python3-enchant gir1.2-poppler-0.18 python3-gst-1.0
-        python3-testresources imagemagick plocate
+        python3-testresources imagemagick
 
     - name: Fix Python.h location
-      run: sudo ln -s $(plocate Python.h | tail -n1) /usr/include
+      run: |
+        find /usr/include/ | grep python
+        sudo ln -s $(plocate Python.h | tail -n1) /usr/include
 
     - name: Setup AppImage Environment
       run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -34,9 +34,10 @@ jobs:
 
     - name: Install Gourmand in AppImage
       run: |
+          C_INCLUDE_PATH=/usr/include/python3.8
+          export C_INCLUDE_PATH
           ./squashfs-root/AppRun -m pip install --upgrade pip
-          C_INCLUDE_PATH=/usr/include/python3.8 ./squashfs-root/AppRun -m pip install decorator six BeautifulSoup4 html5lib lxml pyenchant pygobject Sphinx
-
+          ./squashfs-root/AppRun -m pip install decorator six BeautifulSoup4 html5lib lxml pyenchant pygobject Sphinx
           ./squashfs-root/AppRun setup.py bdist_wheel
           ./squashfs-root/AppRun -m pip install .[epub-export,mycookbook,pdf-export,spellcheck,web-import]
           ./squashfs-root/AppRun -m pip install dist/gourmand*.whl

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -20,7 +20,7 @@ jobs:
         wget -c https://github.com/$(wget -q https://github.com/niess/python-appimage/releases/expanded_assets/python3.8 -O - | grep "python3.8.*-cp38-cp38-manylinux1_x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
         chmod +x ./python3*.AppImage
         ./python3*.AppImage --appimage-extract
-        wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
+        wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases/expanded_assets/655 -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
         chmod +x appimagetool-*.AppImage
 
     - name: Install Gourmand in AppImage

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         sudo apt-get update -q
         sudo apt-get -y install python3-testresources intltool imagemagick libgirepository1.0-dev
-        wget -c https://github.com/$(wget -q https://github.com/niess/python-appimage/releases/tag/python3.8 -O - | grep "python3.8.*-cp38-cp38-manylinux1_x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
+        wget -c https://github.com/$(wget -q https://github.com/niess/python-appimage/releases/expanded_assets/python3.8 -O - | grep "python3.8.*-cp38-cp38-manylinux1_x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
         chmod +x ./python3*.AppImage
         ./python3*.AppImage --appimage-extract
         wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup AppImage Environment
       run: |
         sudo apt-get update -q
-        sudo apt-get -y install python3-testresources intltool imagemagick libgirepository1.0-dev
+        sudo apt-get -y install python3-testresources intltool imagemagick libgirepository1.0-dev python3-dev
         wget -c https://github.com/$(wget -q https://github.com/niess/python-appimage/releases/expanded_assets/python3.8 -O - | grep "python3.8.*-cp38-cp38-manylinux1_x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
         chmod +x ./python3*.AppImage
         ./python3*.AppImage --appimage-extract


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The path to the Python header files, used to build pycairo (as a dependency of pygobject), was no longer in the path of GCC, thus resulting in build errors.  
This is resolved by setting `C_INCLUDE_PATH` before calling pip (ie. before the compilation happens).


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The CI created an AppImage that could be downloaded and ran.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
