### PR TITLE
Do not query ingredient key when parsing ingredients from line

### DIFF
--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -1174,7 +1174,7 @@ class IngredientEditorModule (RecEditorModule):
         selected item, so that the new ingredient can be added right below it in
         the tree.
         """
-        d = self.rg.rd.parse_ingredient(line, conv=self.rg.conv)
+        d = self.rg.rd.parse_ingredient(line, conv=self.rg.conv, get_key=False)
         if d:
             if 'rangeamount' in d:
                 d['amount'] = self.rg.rd.format_amount_string_from_amount(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. --> 
This PR closes #141 where it's shown that adding an ingredient from the recipe editor fails.  

This was due to a refactor of mine where I had removed the unused `ingkey` argument.  
The issue was not caught because the tests were skipped and I missed parent calls when checking for `ingkey` as arguments up the call tree are passed as `**kwargs`.  

The real fix is to remove `ingkey` altogether.  
It's used to define a unique ingredient for the pantry, but is not used effectively (mis-parsing and typos will create a new ingredient).  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->  
This was tested manually by editing a recipe and addind an ingredient from the recipe editor, as reported in the issue. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.  

This resolves the issue so that users can continue using the application.  
The real fix is a refactor of `ingkey`, for which I will create an issue.
