### PR TITLE
Reactivate some of the unit tests

### DIFF
--- a/src/gourmand/backends/db.py
+++ b/src/gourmand/backends/db.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from gi.repository import Gtk
 import sqlalchemy
 import sqlalchemy.orm
 from sqlalchemy import (Boolean, Column, Float, ForeignKey, Integer,
@@ -17,6 +18,7 @@ import gourmand.recipeIdentifier as recipeIdentifier
 from gourmand import Undo, convert, image_utils
 from gourmand.defaults import lang as defaults
 from gourmand.gdebug import TimeAction, debug
+from gourmand.gtk_extras.dialog_extras import show_message
 from gourmand.i18n import _
 from gourmand.keymanager import KeyManager
 from gourmand.plugin import DatabasePlugin
@@ -2133,6 +2135,16 @@ def backup_database(filename: Union[None, Path, str]) -> Union[None, Path]:
 
     while backup_name.is_file():
         backup_name = backup_name.with_name(backup_name.name + 'I')
+
+    show_message(
+        title=_("Database Backup"),
+        label=_("Database Backup"),
+        sublabel=_("Depending on the size of your database, this may take some time."),
+        expander=(_("Details"),
+                  _("A backup will be made as %s in case something goes wrong."
+                    " If this upgrade fails, you can manually rename the "
+                    "backup file to recipes.db to recover it.") % backup_name),
+        message_type=Gtk.MessageType.INFO)
 
     shutil.copy(filename, backup_name)
 

--- a/src/gourmand/backends/db.py
+++ b/src/gourmand/backends/db.py
@@ -2,11 +2,10 @@ import re
 import shutil
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import sqlalchemy
 import sqlalchemy.orm
-from gi.repository import Gtk
 from sqlalchemy import (Boolean, Column, Float, ForeignKey, Integer,
                         LargeBinary, Numeric, String, Table, Text,
                         event, func, select)
@@ -18,7 +17,6 @@ import gourmand.recipeIdentifier as recipeIdentifier
 from gourmand import Undo, convert, image_utils
 from gourmand.defaults import lang as defaults
 from gourmand.gdebug import TimeAction, debug
-from gourmand.gtk_extras.dialog_extras import show_message
 from gourmand.i18n import _
 from gourmand.keymanager import KeyManager
 from gourmand.plugin import DatabasePlugin
@@ -2110,21 +2108,19 @@ def get_database (*args, **kwargs):
     return RecData.instance_for(*args, **kwargs)
 
 
-def backup_database(filename: Path) -> Path:
-    backup_name = filename.with_name(filename.name + '.backup-' + time.strftime('%d-%m-%y'))
+def backup_database(filename: Union[None, Path, str]) -> Union[None, Path]:
+    if filename is None:
+        return None
+
+    if type(filename) == str:
+        filename = Path(filename)
+
+    backup_name = filename.with_name(
+        filename.name + '.backup-' + time.strftime('%d-%m-%y')
+    )
 
     while backup_name.is_file():
         backup_name = backup_name.with_name(backup_name.name + 'I')
-
-    show_message(
-        title=_("Database Backup"),
-        label=_("Database Backup"),
-        sublabel=_("Depending on the size of your database, this may take some time."),
-        expander=(_("Details"),
-                  _("A backup will be made as %s in case something goes wrong."
-                    " If this upgrade fails, you can manually rename the "
-                    "backup file to recipes.db to recover it.") % backup_name),
-        message_type=Gtk.MessageType.INFO)
 
     shutil.copy(filename, backup_name)
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -12,12 +12,10 @@ class ConvertTest (unittest.TestCase):
     def testEqual (self):
         self.assertEqual(self.c.convert_simple('c','c'),1)
 
-    @pytest.mark.skip("Broken as of 20220813")
     def testDensity (self):
          self.assertEqual(self.c.convert_w_density('ml','g',item='water'),1)
          self.assertEqual(self.c.convert_w_density('ml','g',density=0.5),0.5)
 
-    @pytest.mark.skip("Broken as of 20220813")
     def testReadability (self):
         self.assertTrue(self.c.readability_score(1,'cup') > self.c.readability_score(0.8,'cups') )
         self.assertTrue(self.c.readability_score(1/3.0,'tsp.') > self.c.readability_score(0.123,'tsp.'))
@@ -37,7 +35,6 @@ class ConvertTest (unittest.TestCase):
                 ('1/%s'%d)
                 )
 
-    @pytest.mark.skip("Broken as of 20220813")
     def testFractToFloat (self):
         for s,n in [
             ('1',1),
@@ -51,7 +48,6 @@ class ConvertTest (unittest.TestCase):
             ]:
             self.assertEqual(convert.frac_to_float(s),n)
 
-    @pytest.mark.skip("Broken as of 20220813")
     def test_ingmatcher (self):
         for s,a,u,i in [
             ('1 cup sugar', '1','cup','sugar'),

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,236 +1,400 @@
 import tempfile
-import unittest
+import pytest
 
 from gourmand.backends import db
 from gourmand.plugin_loader import MasterLoader
 
 
-class DBTest (unittest.TestCase):
-    def setUp (self):
-        print('Calling setUp')
-        # Remove all plugins for testing purposes
-        ml = MasterLoader.instance()
-        ml.save_active_plugins = lambda *args: True; # Don't save anything we do to plugins
-        ml.active_plugins = []
-        ml.active_plugin_sets = []
-        # Done knocking out plugins...
-        tmpfile = tempfile.mktemp()
-        self.db = db.get_database(file=tmpfile)
-
-class testRecBasics (DBTest):
-    def runTest (self):
-        initial_recipe_count = self.db.fetch_len(self.db.recipe_table)
-        rec = self.db.add_rec({'title':'Fooboo'})
-        self.assertEqual(rec.title,'Fooboo')
-        rec2 = self.db.new_rec()
-        rec2 = self.db.modify_rec(rec2,{'title':'Foo','cuisine':'Bar'})
-        self.assertEqual(rec2.title,'Foo')
-        self.assertEqual(rec2.cuisine,'Bar')
-        self.db.delete_rec(rec)
-        self.db.delete_rec(rec2)
-        self.assertEqual(self.db.fetch_len(self.db.recipe_table), initial_recipe_count)
-
-class testIngBasics (DBTest):
-    def testAddIngs (self):
-        initial_ingredient_count = self.db.fetch_len(self.db.ingredients_table)
-        rid = self.db.new_rec().id
-        ing = self.db.add_ing({'amount':1,
-                          'unit':'c.',
-                          'item':'Carrot juice',
-                          'ingkey':'juice, carrot',
-                          'recipe_id':rid
-                          })
-        ing2 = self.db.add_ing({'amount':2,
-                       'unit':'c.',
-                      'item':'Tomato juice',
-                      'ingkey':'juice, tomato',
-                      'recipe_id':rid
-                       })
-        self.assertEqual(len(self.db.get_ings(rid)),2)
-        ing = self.db.modify_ing(ing,{'amount':2})
-        self.assertEqual(ing.amount,2)
-        ing = self.db.modify_ing(ing,{'unit':'cup'})
-        self.assertEqual(ing.unit,'cup')
-        self.db.delete_ing(ing)
-        self.db.delete_ing(ing2)
-        self.assertEqual(self.db.fetch_len(self.db.ingredients_table), initial_ingredient_count)
-        self.db.add_ings([
-                {'rangeamount': None, 'item': 'water', 'recipe_id': rid, 'position': 1, 'ingkey': 'water'},
-                {'rangeamount': None, 'item': 'linguine', 'amount': 0.5, 'recipe_id': rid, 'position': 1, 'ingkey': 'linguine', 'unit': 'pound'}
-             ]
-                         )
-        ings = self.db.get_ings(rid)
-        self.assertEqual(ings[1].unit,'pound')
-        self.assertEqual(ings[1].amount,0.5)
-
-    def testUnique (self):
-        self.db.delete_by_criteria(self.db.ingredients_table,{}) # Clear out ingredients
-        for i in ['juice, tomato',
-                  'broccoli',
-                  'spinach',
-                  'spinach',
-                  'spinach',]:
-            self.db.add_ing({'amount':1,'unit':'c.','item':i,'ingkey':i})
-        vv=self.db.get_unique_values('ingkey',self.db.ingredients_table)
-        assert(len(vv)==3)
-        cvw = self.db.fetch_count(self.db.ingredients_table,'ingkey',ingkey='spinach',sort_by=[('count',-1)])
-        assert(cvw[0].count==3)
-        assert(cvw[0].ingkey=='spinach')
-
-class testSearch (DBTest):
-    def runTest (self):
-        self.db.delete_by_criteria(self.db.ingredients_table,{}) # Clear out ingredients
-        self.db.delete_by_criteria(self.db.recipe_table,{}) # Clear out recipes
-        self.db.delete_by_criteria(self.db.categories_table,{}) # Clear out categories
-        self.db.add_rec({'title':'Foo','cuisine':'Bar','source':'Z'})
-        self.db.add_rec({'title':'Fooey','cuisine':'Bar','source':'Y'})
-        self.db.add_rec({'title':'Fooey','cuisine':'Foo','source':'X'})
-        self.db.add_rec({'title':'Foo','cuisine':'Foo','source':'A'})
-        self.db.add_rec({'title':'Boe','cuisine':'Fa'})
-        result = self.db.search_recipes([{'column':'deleted','search':False,'operator':'='},
-                                    {'column':'cuisine','search':'Foo','operator':'='}])
-        assert(len(result)==2)
-        result = self.db.search_recipes([{'column':'deleted','search':False,'operator':'='},
-                                    {'column':'cuisine','search':'F.*','operator':'REGEXP'}])
-
-        assert(len(result)==3)
-        result = self.db.search_recipes([{'column':'deleted','search':False,'operator':'='},
-                                    {'column':'cuisine','search':'Foo'},
-                                    {'column':'title','search':'Foo','operator':'='},])
-        assert(len(result)==1)
-        result = self.db.search_recipes([{'column':'title','search':'Fo.*','operator':'REGEXP'}],
-                                   [('source',1)])
-        assert(result[0].title=='Foo' and result[0].source=='A')
-        # Advanced searching
-        self.db.add_rec({'title':'Spaghetti','category':'Entree'})
-        self.db.add_rec({'title':'Quiche','category':'Entree, Low-Fat, High-Carb'})
-        assert(len(self.db.search_recipes([
-            {'column':'deleted','search':False,'operator':'='},
-            {'column':'category','search':'Entree','operator':'='}]))==2)
-        # Test fancy multi-category searches...
-        assert(len(self.db.search_recipes([{'column':'category','search':'Entree','operator':'='},
-                                      {'column':'category','search':'Low-Fat','operator':'='}])
-                   )==1)
-        # Test ingredient search
-        recs = self.db.fetch_all(self.db.recipe_table)
-        r = recs[0]
-        self.db.add_ing({'recipe_id':r.id,'ingkey':'apple'})
-        self.db.add_ing({'recipe_id':r.id,'ingkey':'cinnamon'})
-        self.db.add_ing({'recipe_id':r.id,'ingkey':'sugar, brown'})
-        r2 = recs[1]
-        self.db.add_ing({'recipe_id':r2.id,'ingkey':'sugar, brown'})
-        self.db.add_ing({'recipe_id':r2.id,'ingkey':'flour, all-purpose'})
-        self.db.add_ing({'recipe_id':r2.id,'ingkey':'sugar, white'})
-        self.db.add_ing({'recipe_id':r2.id,'ingkey':'vanilla extract'})
-        r3 = recs[2]
-        self.db.add_ing({'recipe_id':r3.id,'ingkey':'sugar, brown'})
-        self.db.add_ing({'recipe_id':r3.id,'ingkey':'sugar, brown','unit':3,'unit':'c.'} )
-        assert(len(self.db.search_recipes([{'column':'ingredient',
-                                       'search':'sugar%',
-                                       'operator':'LIKE',
-                                      }])
-                   )==3)
-        assert(len(self.db.search_recipes([{'column':'ingredient',
-                                      'search':'sugar, brown'},
-                                     {'column':'ingredient',
-                                      'search':'apple'}])
-                   )==1)
-
-class testUnicode (DBTest):
-    def runTest (self):
-        rec = self.db.add_rec({'title':'Comida de \xc1guila',
-                          'source':'C\xc6SAR',
-                          'category':'C\xc6sar',
-                          })
-        assert(rec.title == 'Comida de \xc1guila')
-        assert(rec.source == 'C\xc6SAR')
-        rec = self.db.modify_rec(rec,{'title':'\xc1 Comida de \xc1guila'})
-        assert(rec.title=='\xc1 Comida de \xc1guila')
-        ing = self.db.add_ing_and_update_keydic({
-                'recipe_id':rec.id,
-                'amount':1.0,
-                'unit':'\xc1guila',
-                'item':'\xc1guila',
-                'ingkey':'\xc1guila'
-                })
-        for attr in 'unit','item','ingkey':
-            assert(getattr(ing,attr)=='\xc1guila')
+@pytest.fixture
+def database():
+    # Remove all plugins for testing purposes
+    ml = MasterLoader.instance()
+    ml.save_active_plugins = lambda *args: True
+    # Don't save anything we do to plugins
+    ml.active_plugins = []
+    ml.active_plugin_sets = []
+    # Done knocking out plugins...
+    tmpfile = tempfile.mktemp()
+    return db.get_database(file=tmpfile)
 
 
-class testIDReservation (DBTest):
-    def runTest (self):
-        rid = self.db.new_id()
-        rid2 = self.db.new_id()
-        r1 = self.db.add_rec({'title':'intermittent'})
-        r1i = self.db.add_rec({'title':'intermittent2'})
-        r12 = self.db.add_rec({'title':'intermittent3'})
-        r2 = self.db.add_rec({'title':'reserved','id':rid})
-        r3 = self.db.add_rec({'title':'reserved2','id':rid2})
-        try: assert(r2.id==rid)
-        except:
-            print('reserved ID',rid)
-            print('fetched ID',r2.id)
-            print('intermittent ID',r1.id)
-            raise
-        for r in [r1,r1i,r12,r2,r3]: self.db.delete_rec(r)
+def test_recipe_basics(database):
+    initial_recipe_count = database.fetch_len(database.recipe_table)
 
-img = b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07\x07\t\t\x08\n\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f\x14\x1d\x1a\x1f\x1e\x1d\x1a\x1c\x1c $.\' ",#\x1c\x1c(7),01444\x1f\'9=82<.342\xff\xdb\x00C\x01\t\t\t\x0c\x0b\x0c\x18\r\r\x182!\x1c!22222222222222222222222222222222222222222222222222\xff\xc0\x00\x11\x08\x00(\x00#\x03\x01"\x00\x02\x11\x01\x03\x11\x01\xff\xc4\x00\x1f\x00\x00\x01\x05\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\xff\xc4\x00\xb5\x10\x00\x02\x01\x03\x03\x02\x04\x03\x05\x05\x04\x04\x00\x00\x01}\x01\x02\x03\x00\x04\x11\x05\x12!1A\x06\x13Qa\x07"q\x142\x81\x91\xa1\x08#B\xb1\xc1\x15R\xd1\xf0$3br\x82\t\n\x16\x17\x18\x19\x1a%&\'()*456789:CDEFGHIJSTUVWXYZcdefghijstuvwxyz\x83\x84\x85\x86\x87\x88\x89\x8a\x92\x93\x94\x95\x96\x97\x98\x99\x9a\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xff\xc4\x00\x1f\x01\x00\x03\x01\x01\x01\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\xff\xc4\x00\xb5\x11\x00\x02\x01\x02\x04\x04\x03\x04\x07\x05\x04\x04\x00\x01\x02w\x00\x01\x02\x03\x11\x04\x05!1\x06\x12AQ\x07aq\x13"2\x81\x08\x14B\x91\xa1\xb1\xc1\t#3R\xf0\x15br\xd1\n\x16$4\xe1%\xf1\x17\x18\x19\x1a&\'()*56789:CDEFGHIJSTUVWXYZcdefghijstuvwxyz\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x92\x93\x94\x95\x96\x97\x98\x99\x9a\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xff\xda\x00\x0c\x03\x01\x00\x02\x11\x03\x11\x00?\x00\xf5\x01#r\xc0\x1c\x01\x92q\xd0S\x9a\xea+x\x1a{\xa9\x92(\x82\x16R\xc7n\xefl\x9e+\x07\xc6z\xf0\xd3$\x16p\xa4A\xf2\xb2d\xb1S\x8eq\xfc\'=\xff\x00:\xcf\x9a\xf7Q\xf1O\x85\x9eDB\xa9\x14\xdbJ\xc7\xceO\xe4\x0f\x7f\xd6\xaeUU\xb4*4\x9bj\xfb\x1d5\x9e\xadk}m\xba\x19\xe3\x92U8a\x1b\x02\x05`k\xfe\'m1\x84\x0bl\x1d\x87F.F>\xb8\xebShKi\xa0\xe9-4\xf8I\xe7E\r\xba,\x98\xd8\x03\x81\x8c\xe4\xf5\xcf^A\x14\x96\x97:>\xb5rl\xae\x00\xbd\x91\x8b"\xbbB\xcaz\xfd\xe1\xe9\xeb\xc1\x1c}1I\xc9\xc9+n5\x15\x17\xaa\xba,\xe9\xda\xb5\xd6\xa3a\r\xdb\xa2\xabH2F\x07c\x8f\xe9Etp\xd9\xc1o\x04p\xc5\x10\x11\xc6\xa1T{\n+U-52v\xbe\x86\x0f\x8c\xbc2\xfa\xcc\x90\xdc@3 \xc4dd\x0f\xa7\xf3\xadm\x13H\x87C\xd2\xa2\xb2\x1f31\xdc\xe4\x0e\x0b\x1cg\xf9\x01Z\x8e\xe7#\x18\x1e\xe6\xa2\xbb\xbb\x8a\xd9Y\x9d\x86\xc03\x9a\xc9E\'r\xdc\xdb\x8f)\xc6\xfcF\xd3e\xb9\xb3\x82\xea0\xc7h*v\xfey\xff\x00>\x95\x93\xf0\xfbIxo\x1e\xfex\xdbj\x02\xa8I\xfe#\xd7\xf4\xcf\xe7]\xcc\x97\xd1\xdd\xda\xc8\x8a\x98S\xf2\xe5\xfe\\\xfd;\xf1\x8c\xfe\x1d\xba\xd3\x86AX\xc4,\x15F7\xed\x00\x13\xdf\x8c\xf1\xcei{?{\x98~\xd3\xdc\xe5,1%\x89\x07\x03\xd0QF(\xadL\xc9\xd9\xc6*\xa5\xec"x\n\xed\xdcr\x1b\x1e\xb84QR\x80\xa0\xc8\xb3C\xf6i"|0\xc6\x0eG\x1f^\xb9\xabS\\}\x968`p\xca\xa3\x01X\xe4\x8f\xc4\xff\x00\x8d\x14U\x89\n\xf7r+m\x8ebT\x01\x8c-\x14QH\x0f\xff\xd9'
+    recipe1 = database.add_rec({'title': 'Fooboo'})
+    assert recipe1.title == 'Fooboo'
 
-class TestMoreDataStuff (DBTest):
-    def test_image_data (self):
-        r = self.db.add_rec({'image': img})
-        self.assertEqual(r.image, img)
+    recipe2 = database.new_rec()
+    recipe2 = database.modify_rec(recipe2, {'title': 'Foo', 'cuisine': 'Bar'})
+    assert recipe2.title == 'Foo'
+    assert recipe2.cuisine == 'Bar'
 
-    def test_update (self):
-        r = self.db.add_rec({'title':'Foo','cuisine':'Bar','source':'Z'})
-        self.db.update_by_criteria(self.db.recipe_table,{'title':'Foo'},{'title':'Boo'})
-        self.assertEqual(self.db.get_rec(r.id).title, 'Boo')
+    database.delete_rec(recipe1)
+    database.delete_rec(recipe2)
+    assert database.fetch_len(database.recipe_table) == initial_recipe_count
 
-    def test_modify_rec (self):
-        orig_attrs = {'title':'Foo','cuisine':'Bar','yields':7,'yield_unit':'cups'}
-        new_attrs =  {'title':'Foob','cuisine':'Baz','yields':4,'yield_unit':'servings'}
-        r = self.db.add_rec(orig_attrs.copy())
-        for attr,val in list(new_attrs.items()):
-            r = self.db.modify_rec(r,{attr:val})
-            # Make sure our value changed...
-            self.assertEqual(getattr(r,attr),val,'Incorrect modified value for %s'%attr)
-            # Make sure no other values changed
-            for a,v in list(orig_attrs.items()):
-                if a != attr:
-                    self.assertEqual(getattr(r,a),v,'Incorrect original value for %s'%a)
-            # Change back our recipe
-            r = self.db.modify_rec(r,{attr:orig_attrs[attr]})
 
-    def test_modify_ing (self):
-        r = self.db.add_rec({'title':'itest'})
-        orig_attrs = {'item':'Foo','ingkey':'Bar','amount':7,'unit':'cups','optional':True,'rangeamount':None,'recipe_id':r.id}
-        new_attrs ={'item':'Fooz','ingkey':'Baz','amount':3,'unit':'ounces','optional':False,'rangeamount':2,}
-        i = self.db.add_ing(orig_attrs.copy())
-        for attr,val in list(new_attrs.items()):
-            r = self.db.modify_ing(i,{attr:val})
-            # Make sure our value changed...
-            self.assertEqual(getattr(r,attr),val,'Incorrect modified value for %s'%attr)
-            # Make sure no other values changed
-            for a,v in list(orig_attrs.items()):
-                if a != attr:
-                    self.assertEqual(getattr(r,a),v,'Incorrect original vlaue for %s'%a)
-            # Change back our ingredient...
-            r = self.db.modify_ing(i,{attr:orig_attrs[attr]})
+def test_ingredient_basics(database):
+    initial_ingredient_count = database.fetch_len(database.ingredients_table)
+    recipe_id = database.new_rec().id
+    ingredient1 = database.add_ing(
+        {
+            'amount': 1,
+            'unit': 'c.',
+            'item': 'Carrot juice',
+            'ingkey': 'juice, carrot',
+            'recipe_id': recipe_id,
+        }
+    )
+    ingredient2 = database.add_ing(
+        {
+            'amount': 2,
+            'unit': 'c.',
+            'item': 'Tomato juice',
+            'ingkey': 'juice, tomato',
+            'recipe_id': recipe_id,
+        }
+    )
 
-suite = unittest.TestSuite()
-suite.addTests([
-        testRecBasics(),
-        testSearch(),
-        testUnicode(),
-        testIDReservation(),
-        TestMoreDataStuff('test_image_data'),
-        TestMoreDataStuff('test_update'),
-        TestMoreDataStuff('test_modify_rec'),
-        TestMoreDataStuff('test_modify_ing'),
-        ] + [
-        testIngBasics(m) for m in ['testUnique','testAddIngs',]
+    assert len(database.get_ings(recipe_id)) == 2
+
+    ingredient1 = database.modify_ing(ingredient1, {'amount': 2})
+    assert ingredient1.amount == 2
+
+    ingredient1 = database.modify_ing(ingredient1, {'unit': 'cup'})
+    assert ingredient1.unit == 'cup'
+
+    database.delete_ing(ingredient1)
+    database.delete_ing(ingredient2)
+    assert database.fetch_len(database.ingredients_table) == initial_ingredient_count
+
+
+def test_add_multiple_ingredients(database):
+    recipe_id = database.new_rec().id
+    database.add_ings(
+        [
+            {
+                'rangeamount': None,
+                'item': 'water',
+                'recipe_id': recipe_id,
+                'position': 1,
+                'ingkey': 'water',
+            },
+            {
+                'rangeamount': None,
+                'item': 'linguine',
+                'amount': 0.5,
+                'recipe_id': recipe_id,
+                'position': 1,
+                'ingkey': 'linguine',
+                'unit': 'pound',
+            },
         ]
-               )
+    )
+    ingredients = database.get_ings(recipe_id)
+    assert ingredients[0].item == 'water'
+    assert ingredients[1].item == 'linguine'
+    assert ingredients[1].unit == 'pound'
+    assert ingredients[1].amount == 0.5
+
+
+def test_ingredients_unique(database):
+    # Clear out ingredients
+    database.delete_by_criteria(database.ingredients_table, {})
+
+    for ingredient in ['juice, tomato', 'broccoli', 'spinach', 'spinach', 'spinach']:
+        database.add_ing(
+            {'amount': 1, 'unit': 'c.', 'item': ingredient, 'ingkey': ingredient}
+        )
+
+    ingredient_keys = database.get_unique_values('ingkey', database.ingredients_table)
+    assert len(ingredient_keys) == 3
+
+    spinach_keys = database.fetch_count(
+        database.ingredients_table,
+        'ingkey',
+        ingkey='spinach',
+        sort_by=[('count', -1)],
+    )
+    assert spinach_keys[0].count == 3
+    assert spinach_keys[0].ingkey == 'spinach'
+
+
+def test_recipe_search(database):
+    # Clear out ingredients, recipes and categories
+    database.delete_by_criteria(database.ingredients_table, {})
+    database.delete_by_criteria(database.recipe_table, {})
+    database.delete_by_criteria(database.categories_table, {})
+    database.add_rec({'title': 'Foo', 'cuisine': 'Bar', 'source': 'Z'})
+    database.add_rec({'title': 'Fooey', 'cuisine': 'Bar', 'source': 'Y'})
+    database.add_rec({'title': 'Fooey', 'cuisine': 'Foo', 'source': 'X'})
+    database.add_rec({'title': 'Foo', 'cuisine': 'Foo', 'source': 'A'})
+    database.add_rec({'title': 'Boe', 'cuisine': 'Fa'})
+
+    result = database.search_recipes(
+        [
+            {'column': 'deleted', 'search': False, 'operator': '='},
+            {'column': 'cuisine', 'search': 'Foo', 'operator': '='},
+        ]
+    )
+    assert len(result) == 2
+
+    result = database.search_recipes(
+        [
+            {'column': 'deleted', 'search': False, 'operator': '='},
+            {'column': 'cuisine', 'search': 'F.*', 'operator': 'REGEXP'},
+        ]
+    )
+    assert len(result) == 3
+
+    result = database.search_recipes(
+        [
+            {'column': 'deleted', 'search': False, 'operator': '='},
+            {'column': 'cuisine', 'search': 'Foo'},
+            {'column': 'title', 'search': 'Foo', 'operator': '='},
+        ]
+    )
+    assert len(result) == 1
+
+    result = database.search_recipes(
+        [{'column': 'title', 'search': 'Fo.*', 'operator': 'REGEXP'}],
+        [('source', 1)],
+    )
+    assert result[0].title == 'Foo' and result[0].source == 'A'
+
+    # Advanced searching
+    database.add_rec({'title': 'Spaghetti', 'category': 'Entree'})
+    database.add_rec({'title': 'Quiche', 'category': 'Entree, Low-Fat, High-Carb'})
+    assert (
+        len(
+            database.search_recipes(
+                [
+                    {'column': 'deleted', 'search': False, 'operator': '='},
+                    {'column': 'category', 'search': 'Entree', 'operator': '='},
+                ]
+            )
+        )
+        == 2
+    )
+
+    # Test fancy multi-category searches...
+    assert (
+        len(
+            database.search_recipes(
+                [
+                    {'column': 'category', 'search': 'Entree', 'operator': '='},
+                    {'column': 'category', 'search': 'Low-Fat', 'operator': '='},
+                ]
+            )
+        )
+        == 1
+    )
+
+    # Test ingredient search
+    recs = database.fetch_all(database.recipe_table)
+    r = recs[0]
+    database.add_ing({'recipe_id': r.id, 'ingkey': 'apple'})
+    database.add_ing({'recipe_id': r.id, 'ingkey': 'cinnamon'})
+    database.add_ing({'recipe_id': r.id, 'ingkey': 'sugar, brown'})
+    r2 = recs[1]
+    database.add_ing({'recipe_id': r2.id, 'ingkey': 'sugar, brown'})
+    database.add_ing({'recipe_id': r2.id, 'ingkey': 'flour, all-purpose'})
+    database.add_ing({'recipe_id': r2.id, 'ingkey': 'sugar, white'})
+    database.add_ing({'recipe_id': r2.id, 'ingkey': 'vanilla extract'})
+    r3 = recs[2]
+    database.add_ing({'recipe_id': r3.id, 'ingkey': 'sugar, brown'})
+    database.add_ing({'recipe_id': r3.id, 'ingkey': 'sugar, brown', 'unit': 'c.'})
+
+    assert (
+        len(
+            database.search_recipes(
+                [
+                    {
+                        'column': 'ingredient',
+                        'search': 'sugar%',
+                        'operator': 'LIKE',
+                    }
+                ]
+            )
+        )
+        == 3
+    )
+
+    assert (
+        len(
+            database.search_recipes(
+                [
+                    {'column': 'ingredient', 'search': 'sugar, brown'},
+                    {'column': 'ingredient', 'search': 'apple'},
+                ]
+            )
+        )
+        == 1
+    )
+
+
+def test_unicode_records(database):
+    recipe = database.add_rec(
+        {
+            'title': '🥞',
+            'source': '🍰',
+            'category': 'C\xc6sar',
+        }
+    )
+    assert recipe.title == '🥞'
+    assert recipe.source == '🍰'
+
+    recipe = database.modify_rec(recipe, {'title': '\xc1 Comida de \xc1guila'})
+    assert recipe.title == '\xc1 Comida de \xc1guila'
+
+    ingredient = database.add_ing_and_update_keydic(
+        {
+            'recipe_id': recipe.id,
+            'amount': 1.0,
+            'unit': '🥚🥓',
+            'item': '🥚🥓',
+            'ingkey': '🥚🥓',
+        }
+    )
+    for attr in 'unit', 'item', 'ingkey':
+        assert getattr(ingredient, attr) == '🥚🥓'
+
+
+def test_ID_reservation(database):
+    recipe_id1 = database.new_id()
+    recipe_id2 = database.new_id()
+    recipe1 = database.add_rec({'title': 'intermittent'})
+    recipe2 = database.add_rec({'title': 'intermittent2'})
+    recipe3 = database.add_rec({'title': 'intermittent3'})
+    recipe4 = database.add_rec({'title': 'reserved', 'id': recipe_id1})
+    recipe5 = database.add_rec({'title': 'reserved2', 'id': recipe_id2})
+
+    assert recipe4.id == recipe_id1
+
+    for r in [recipe1, recipe2, recipe3, recipe4, recipe5]:
+        database.delete_rec(r)
+
+
+img = (
+    b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff'
+    b'\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07\x07\t\t\x08\n\x0c\x14'
+    b'\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f\x14\x1d\x1a\x1f\x1e\x1d\x1a\x1c\x1c $'
+    b'.\' ",#\x1c\x1c(7),01444\x1f\'9=82<.342\xff\xdb\x00C\x01\t\t\t\x0c\x0b'
+    b'\x0c\x18\r\r\x182!\x1c!2222222222222222222222222222222222222222222222222'
+    b'2\xff\xc0\x00\x11\x08\x00(\x00#\x03\x01"\x00\x02\x11\x01\x03\x11\x01\xff'
+    b'\xc4\x00\x1f\x00\x00\x01\x05\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00'
+    b'\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\xff\xc4\x00\xb5\x10'
+    b'\x00\x02\x01\x03\x03\x02\x04\x03\x05\x05\x04\x04\x00\x00\x01}\x01\x02'
+    b'\x03\x00\x04\x11\x05\x12!1A\x06\x13Qa\x07"q\x142\x81\x91\xa1\x08#B\xb1'
+    b'\xc1\x15R\xd1\xf0$3br\x82\t\n\x16\x17\x18\x19\x1a%&\'()*456789:CDEFGHIJS'
+    b'TUVWXYZcdefghijstuvwxyz\x83\x84\x85\x86\x87\x88\x89\x8a\x92\x93\x94\x95'
+    b'\x96\x97\x98\x99\x9a\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xb2\xb3\xb4\xb5'
+    b'\xb6\xb7\xb8\xb9\xba\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xd2\xd3\xd4\xd5'
+    b'\xd6\xd7\xd8\xd9\xda\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xf1\xf2\xf3'
+    b'\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xff\xc4\x00\x1f\x01\x00\x03\x01\x01\x01\x01'
+    b'\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07'
+    b'\x08\t\n\x0b\xff\xc4\x00\xb5\x11\x00\x02\x01\x02\x04\x04\x03\x04\x07\x05'
+    b'\x04\x04\x00\x01\x02w\x00\x01\x02\x03\x11\x04\x05!1\x06\x12AQ\x07aq\x13"'
+    b'2\x81\x08\x14B\x91\xa1\xb1\xc1\t#3R\xf0\x15br\xd1\n\x16$4\xe1%\xf1\x17'
+    b'\x18\x19\x1a&\'()*56789:CDEFGHIJSTUVWXYZcdefghijstuvwxyz\x82\x83\x84\x85'
+    b'\x86\x87\x88\x89\x8a\x92\x93\x94\x95\x96\x97\x98\x99\x9a\xa2\xa3\xa4\xa5'
+    b'\xa6\xa7\xa8\xa9\xaa\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xc2\xc3\xc4\xc5'
+    b'\xc6\xc7\xc8\xc9\xca\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xe2\xe3\xe4\xe5'
+    b'\xe6\xe7\xe8\xe9\xea\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xff\xda\x00\x0c'
+    b'\x03\x01\x00\x02\x11\x03\x11\x00?\x00\xf5\x01#r\xc0\x1c\x01\x92q\xd0S'
+    b'\x9a\xea+x\x1a{\xa9\x92(\x82\x16R\xc7n\xefl\x9e+\x07\xc6z\xf0\xd3$\x16p'
+    b'\xa4A\xf2\xb2d\xb1S\x8eq\xfc\'=\xff\x00:\xcf\x9a\xf7Q\xf1O\x85\x9eDB\xa9'
+    b'\x14\xdbJ\xc7\xceO\xe4\x0f\x7f\xd6\xaeUU\xb4*4\x9bj\xfb\x1d5\x9e\xadk}m'
+    b'\xba\x19\xe3\x92U8a\x1b\x02\x05`k\xfe\'m1\x84\x0bl\x1d\x87F.F>\xb8\xebSh'
+    b'Ki\xa0\xe9-4\xf8I\xe7E\r\xba,\x98\xd8\x03\x81\x8c\xe4\xf5\xcf^A\x14\x96'
+    b'\x97:>\xb5rl\xae\x00\xbd\x91\x8b"\xbbB\xcaz\xfd\xe1\xe9\xeb\xc1\x1c}1I'
+    b'\xc9\xc9+n5\x15\x17\xaa\xba,\xe9\xda\xb5\xd6\xa3a\r\xdb\xa2\xabH2F\x07c'
+    b'\x8f\xe9Etp\xd9\xc1o\x04p\xc5\x10\x11\xc6\xa1T{\n+U-52v\xbe\x86\x0f\x8c'
+    b'\xbc2\xfa\xcc\x90\xdc@3 \xc4dd\x0f\xa7\xf3\xadm\x13H\x87C\xd2\xa2\xb2'
+    b'\x1f31\xdc\xe4\x0e\x0b\x1cg\xf9\x01Z\x8e\xe7#\x18\x1e\xe6\xa2\xbb\xbb'
+    b'\x8a\xd9Y\x9d\x86\xc03\x9a\xc9E\'r\xdc\xdb\x8f)\xc6\xfcF\xd3e\xb9\xb3'
+    b'\x82\xea0\xc7h*v\xfey\xff\x00>\x95\x93\xf0\xfbIxo\x1e\xfex\xdbj\x02\xa8I'
+    b'\xfe#\xd7\xf4\xcf\xe7]\xcc\x97\xd1\xdd\xda\xc8\x8a\x98S\xf2\xe5\xfe\\'
+    b'\xfd;\xf1\x8c\xfe\x1d\xba\xd3\x86AX\xc4,\x15F7\xed\x00\x13\xdf\x8c\xf1'
+    b'\xcei{?{\x98~\xd3\xdc\xe5,1%\x89\x07\x03\xd0QF(\xadL\xc9\xd9\xc6*\xa5'
+    b'\xec"x\n\xed\xdcr\x1b\x1e\xb84QR\x80\xa0\xc8\xb3C\xf6i"|0\xc6\x0eG\x1f^'
+    b'\xb9\xabS\\}\x968`p\xca\xa3\x01X\xe4\x8f\xc4\xff\x00\x8d\x14U\x89\n\xf7'
+    b'r+m\x8ebT\x01\x8c-\x14QH\x0f\xff\xd9'
+)
+
+
+def test_recipe_image(database):
+    r = database.add_rec({'image': img})
+    assert r.image == img
+
+
+def test_update_by_criteria(database):
+    r = database.add_rec({'title': 'Foo', 'cuisine': 'Bar', 'source': 'Z'})
+
+    database.update_by_criteria(
+        database.recipe_table, {'title': 'Foo'}, {'title': 'Boo'}
+    )
+
+    assert database.get_rec(r.id).title == 'Boo'
+
+
+def test_modify_recipe(database):
+    orig_attrs = {
+        'title': 'Foo',
+        'cuisine': 'Bar',
+        'yields': 7,
+        'yield_unit': 'cups',
+    }
+    new_attrs = {
+        'title': 'Foob',
+        'cuisine': 'Baz',
+        'yields': 4,
+        'yield_unit': 'servings',
+    }
+    recipe = database.add_rec(orig_attrs.copy())
+
+    for new_attr, new_val in new_attrs.items():
+        recipe = database.modify_rec(recipe, {new_attr: new_val})
+        # Make sure our value changed...
+        assert getattr(recipe, new_attr) == new_val
+        # Make sure no other values changed
+        for old_attr, old_val in orig_attrs.items():
+            if old_attr != new_attr:
+                assert getattr(recipe, old_attr), old_val
+        # Change back our recipe
+        recipe = database.modify_rec(recipe, {new_attr: orig_attrs[new_attr]})
+
+
+def test_modify_ingredient(database):
+    r = database.add_rec({'title': 'itest'})
+    orig_attrs = {
+        'item': 'Foo',
+        'ingkey': 'Bar',
+        'amount': 7,
+        'unit': 'cups',
+        'optional': True,
+        'rangeamount': None,
+        'recipe_id': r.id,
+    }
+    new_attrs = {
+        'item': 'Fooz',
+        'ingkey': 'Baz',
+        'amount': 3,
+        'unit': 'ounces',
+        'optional': False,
+        'rangeamount': 2,
+    }
+    ingredient = database.add_ing(orig_attrs.copy())
+    for new_attr, new_val in list(new_attrs.items()):
+        ingredient = database.modify_ing(ingredient, {new_attr: new_val})
+        # Make sure our value changed...
+        assert getattr(ingredient, new_attr) == new_val
+        # Make sure no other values changed
+        for old_attr, old_val in list(orig_attrs.items()):
+            if old_attr != new_attr:
+                assert getattr(ingredient, old_attr) == old_val
+        # Change back our ingredient...
+        ingredient = database.modify_ing(ingredient, {new_attr: orig_attrs[new_attr]})
 
 
 def test_format_amount_string_from_amount():
@@ -248,6 +412,3 @@ def test_format_amount_string_from_amount():
 
     ret = db.RecData.format_amount_string_from_amount((1.5, 2.5))
     assert ret == '1 ½-2 ½'
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,5 @@
 import tempfile
 import unittest
-import pytest
 
 from gourmand.backends import db
 from gourmand.plugin_loader import MasterLoader
@@ -19,9 +18,8 @@ class DBTest (unittest.TestCase):
         self.db = db.get_database(file=tmpfile)
 
 class testRecBasics (DBTest):
-    @pytest.mark.skip("Broken as of 20220813")
     def runTest (self):
-        self.assertEqual(self.db.fetch_len(self.db.recipe_table), 2)
+        initial_recipe_count = self.db.fetch_len(self.db.recipe_table)
         rec = self.db.add_rec({'title':'Fooboo'})
         self.assertEqual(rec.title,'Fooboo')
         rec2 = self.db.new_rec()
@@ -30,12 +28,11 @@ class testRecBasics (DBTest):
         self.assertEqual(rec2.cuisine,'Bar')
         self.db.delete_rec(rec)
         self.db.delete_rec(rec2)
-        self.assertEqual(self.db.fetch_len(self.db.recipe_table), 2)
+        self.assertEqual(self.db.fetch_len(self.db.recipe_table), initial_recipe_count)
 
 class testIngBasics (DBTest):
-
-    @pytest.mark.skip("Broken as of 20220813")
     def testAddIngs (self):
+        initial_ingredient_count = self.db.fetch_len(self.db.ingredients_table)
         rid = self.db.new_rec().id
         ing = self.db.add_ing({'amount':1,
                           'unit':'c.',
@@ -56,7 +53,7 @@ class testIngBasics (DBTest):
         self.assertEqual(ing.unit,'cup')
         self.db.delete_ing(ing)
         self.db.delete_ing(ing2)
-        self.assertEqual(self.db.fetch_len(self.db.ingredients_table), 8)
+        self.assertEqual(self.db.fetch_len(self.db.ingredients_table), initial_ingredient_count)
         self.db.add_ings([
                 {'rangeamount': None, 'item': 'water', 'recipe_id': rid, 'position': 1, 'ingkey': 'water'},
                 {'rangeamount': None, 'item': 'linguine', 'amount': 0.5, 'recipe_id': rid, 'position': 1, 'ingkey': 'linguine', 'unit': 'pound'}
@@ -66,7 +63,6 @@ class testIngBasics (DBTest):
         self.assertEqual(ings[1].unit,'pound')
         self.assertEqual(ings[1].amount,0.5)
 
-    @pytest.mark.skip("Broken as of 20220813")
     def testUnique (self):
         self.db.delete_by_criteria(self.db.ingredients_table,{}) # Clear out ingredients
         for i in ['juice, tomato',
@@ -82,7 +78,6 @@ class testIngBasics (DBTest):
         assert(cvw[0].ingkey=='spinach')
 
 class testSearch (DBTest):
-    @pytest.mark.skip("Broken as of 20220813")
     def runTest (self):
         self.db.delete_by_criteria(self.db.ingredients_table,{}) # Clear out ingredients
         self.db.delete_by_criteria(self.db.recipe_table,{}) # Clear out recipes
@@ -142,8 +137,6 @@ class testSearch (DBTest):
                    )==1)
 
 class testUnicode (DBTest):
-
-    @pytest.mark.skip("Broken as of 20220813")
     def runTest (self):
         rec = self.db.add_rec({'title':'Comida de \xc1guila',
                           'source':'C\xc6SAR',
@@ -165,8 +158,6 @@ class testUnicode (DBTest):
 
 
 class testIDReservation (DBTest):
-
-    @pytest.mark.skip("Broken as of 20220813")
     def runTest (self):
         rid = self.db.new_id()
         rid2 = self.db.new_id()
@@ -186,19 +177,15 @@ class testIDReservation (DBTest):
 img = b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07\x07\t\t\x08\n\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f\x14\x1d\x1a\x1f\x1e\x1d\x1a\x1c\x1c $.\' ",#\x1c\x1c(7),01444\x1f\'9=82<.342\xff\xdb\x00C\x01\t\t\t\x0c\x0b\x0c\x18\r\r\x182!\x1c!22222222222222222222222222222222222222222222222222\xff\xc0\x00\x11\x08\x00(\x00#\x03\x01"\x00\x02\x11\x01\x03\x11\x01\xff\xc4\x00\x1f\x00\x00\x01\x05\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\xff\xc4\x00\xb5\x10\x00\x02\x01\x03\x03\x02\x04\x03\x05\x05\x04\x04\x00\x00\x01}\x01\x02\x03\x00\x04\x11\x05\x12!1A\x06\x13Qa\x07"q\x142\x81\x91\xa1\x08#B\xb1\xc1\x15R\xd1\xf0$3br\x82\t\n\x16\x17\x18\x19\x1a%&\'()*456789:CDEFGHIJSTUVWXYZcdefghijstuvwxyz\x83\x84\x85\x86\x87\x88\x89\x8a\x92\x93\x94\x95\x96\x97\x98\x99\x9a\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xff\xc4\x00\x1f\x01\x00\x03\x01\x01\x01\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\xff\xc4\x00\xb5\x11\x00\x02\x01\x02\x04\x04\x03\x04\x07\x05\x04\x04\x00\x01\x02w\x00\x01\x02\x03\x11\x04\x05!1\x06\x12AQ\x07aq\x13"2\x81\x08\x14B\x91\xa1\xb1\xc1\t#3R\xf0\x15br\xd1\n\x16$4\xe1%\xf1\x17\x18\x19\x1a&\'()*56789:CDEFGHIJSTUVWXYZcdefghijstuvwxyz\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x92\x93\x94\x95\x96\x97\x98\x99\x9a\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xff\xda\x00\x0c\x03\x01\x00\x02\x11\x03\x11\x00?\x00\xf5\x01#r\xc0\x1c\x01\x92q\xd0S\x9a\xea+x\x1a{\xa9\x92(\x82\x16R\xc7n\xefl\x9e+\x07\xc6z\xf0\xd3$\x16p\xa4A\xf2\xb2d\xb1S\x8eq\xfc\'=\xff\x00:\xcf\x9a\xf7Q\xf1O\x85\x9eDB\xa9\x14\xdbJ\xc7\xceO\xe4\x0f\x7f\xd6\xaeUU\xb4*4\x9bj\xfb\x1d5\x9e\xadk}m\xba\x19\xe3\x92U8a\x1b\x02\x05`k\xfe\'m1\x84\x0bl\x1d\x87F.F>\xb8\xebShKi\xa0\xe9-4\xf8I\xe7E\r\xba,\x98\xd8\x03\x81\x8c\xe4\xf5\xcf^A\x14\x96\x97:>\xb5rl\xae\x00\xbd\x91\x8b"\xbbB\xcaz\xfd\xe1\xe9\xeb\xc1\x1c}1I\xc9\xc9+n5\x15\x17\xaa\xba,\xe9\xda\xb5\xd6\xa3a\r\xdb\xa2\xabH2F\x07c\x8f\xe9Etp\xd9\xc1o\x04p\xc5\x10\x11\xc6\xa1T{\n+U-52v\xbe\x86\x0f\x8c\xbc2\xfa\xcc\x90\xdc@3 \xc4dd\x0f\xa7\xf3\xadm\x13H\x87C\xd2\xa2\xb2\x1f31\xdc\xe4\x0e\x0b\x1cg\xf9\x01Z\x8e\xe7#\x18\x1e\xe6\xa2\xbb\xbb\x8a\xd9Y\x9d\x86\xc03\x9a\xc9E\'r\xdc\xdb\x8f)\xc6\xfcF\xd3e\xb9\xb3\x82\xea0\xc7h*v\xfey\xff\x00>\x95\x93\xf0\xfbIxo\x1e\xfex\xdbj\x02\xa8I\xfe#\xd7\xf4\xcf\xe7]\xcc\x97\xd1\xdd\xda\xc8\x8a\x98S\xf2\xe5\xfe\\\xfd;\xf1\x8c\xfe\x1d\xba\xd3\x86AX\xc4,\x15F7\xed\x00\x13\xdf\x8c\xf1\xcei{?{\x98~\xd3\xdc\xe5,1%\x89\x07\x03\xd0QF(\xadL\xc9\xd9\xc6*\xa5\xec"x\n\xed\xdcr\x1b\x1e\xb84QR\x80\xa0\xc8\xb3C\xf6i"|0\xc6\x0eG\x1f^\xb9\xabS\\}\x968`p\xca\xa3\x01X\xe4\x8f\xc4\xff\x00\x8d\x14U\x89\n\xf7r+m\x8ebT\x01\x8c-\x14QH\x0f\xff\xd9'
 
 class TestMoreDataStuff (DBTest):
-
-    @pytest.mark.skip("Broken as of 20220813")
     def test_image_data (self):
         r = self.db.add_rec({'image': img})
         self.assertEqual(r.image, img)
 
-    @pytest.mark.skip("Broken as of 20220813")
     def test_update (self):
         r = self.db.add_rec({'title':'Foo','cuisine':'Bar','source':'Z'})
         self.db.update_by_criteria(self.db.recipe_table,{'title':'Foo'},{'title':'Boo'})
         self.assertEqual(self.db.get_rec(r.id).title, 'Boo')
 
-    @pytest.mark.skip("Broken as of 20220813")
     def test_modify_rec (self):
         orig_attrs = {'title':'Foo','cuisine':'Bar','yields':7,'yield_unit':'cups'}
         new_attrs =  {'title':'Foob','cuisine':'Baz','yields':4,'yield_unit':'servings'}
@@ -214,7 +201,6 @@ class TestMoreDataStuff (DBTest):
             # Change back our recipe
             r = self.db.modify_rec(r,{attr:orig_attrs[attr]})
 
-    @pytest.mark.skip("Broken as of 20220813")
     def test_modify_ing (self):
         r = self.db.add_rec({'title':'itest'})
         orig_attrs = {'item':'Foo','ingkey':'Bar','amount':7,'unit':'cups','optional':True,'rangeamount':None,'recipe_id':r.id}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,3 @@
-import tempfile
 import pytest
 
 from gourmand.backends import db
@@ -14,8 +13,7 @@ def database():
     ml.active_plugins = []
     ml.active_plugin_sets = []
     # Done knocking out plugins...
-    tmpfile = tempfile.mktemp()
-    return db.get_database(file=tmpfile)
+    return db.get_database(custom_url="sqlite:///:memory:")
 
 
 def test_recipe_basics(database):

--- a/tests/test_exportManager.py
+++ b/tests/test_exportManager.py
@@ -3,7 +3,6 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-import pytest
 
 import gourmand.backends.db
 import gourmand.gglobals
@@ -122,7 +121,6 @@ class TestExports (unittest.TestCase):
         self.db = gourmand.backends.db.get_database()
         print("finish setUp", file=sys.stderr)
 
-    @pytest.mark.skip("Broken as of 20220813")
     def testMultipleExporters(self):
 
         def fail_on_fail(thread, errorval, errortext, tb):
@@ -147,7 +145,6 @@ class TestExports (unittest.TestCase):
             exporter.connect('done', done)
             exporter.do_run()
 
-    @pytest.mark.skip("Broken as of 20220813")
     def testSingleExport(self):
         for format, plugin in list(self.em.plugins_by_name.items()):
             filters = plugin.saveas_single_filters

--- a/tests/test_exportManager.py
+++ b/tests/test_exportManager.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+import pytest
 
 import gourmand.backends.db
 import gourmand.gglobals
@@ -121,6 +122,7 @@ class TestExports (unittest.TestCase):
         self.db = gourmand.backends.db.get_database()
         print("finish setUp", file=sys.stderr)
 
+    @pytest.mark.skip("Broken as of 20220813")
     def testMultipleExporters(self):
 
         def fail_on_fail(thread, errorval, errortext, tb):
@@ -145,6 +147,7 @@ class TestExports (unittest.TestCase):
             exporter.connect('done', done)
             exporter.do_run()
 
+    @pytest.mark.skip("Broken as of 20220813")
     def testSingleExport(self):
         for format, plugin in list(self.em.plugins_by_name.items()):
             filters = plugin.saveas_single_filters

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,5 +1,4 @@
 import unittest
-import pytest
 
 from gourmand.importers import importer
 
@@ -12,7 +11,6 @@ class TestImporter (unittest.TestCase):
     def _get_last_rec_ (self):
         return self.i.added_recs[-1]
 
-    @pytest.mark.skip("Broken as of 20220813")
     def testRecImport (self):
         self.i.start_rec()
         attrs = [('title','Foo'),('cuisine','Bar'),('yields',3),('yield_unit','cups')]
@@ -23,7 +21,6 @@ class TestImporter (unittest.TestCase):
         for att,val in attrs:
             self.assertEqual(getattr(rec,att),val)
 
-    @pytest.mark.skip("Broken as of 20220813")
     def testIngredientImport (self):
         self.i.start_rec()
         self.i.rec['title']='Ingredient Import Test'

--- a/tests/test_interactive_importer.py
+++ b/tests/test_interactive_importer.py
@@ -9,7 +9,6 @@ class TestConvenientImporter (unittest.TestCase):
     def setUp (self):
         self.ci = interactive_importer.ConvenientImporter()
 
-    @pytest.mark.skip("Broken as of 20220813")
     def testImport (self):
         self.ci.start_rec()
         self.ci.add_attribute('title','Test')

--- a/tests/test_web_importer.py
+++ b/tests/test_web_importer.py
@@ -5,7 +5,6 @@ gi.require_version("Gtk", "3.0")
 from gourmand import gglobals  # noqa: import not at top
 from gourmand.importers.web_importer import import_urls  # noqa
 
-@pytest.mark.skip("Broken as of 20220813")
 @pytest.mark.parametrize(
     'urls, expected_pass, expected_fails',
     [


### PR DESCRIPTION
## Description
Reactivates some of Gourmand's unit tests, largely by picking up some work-in-progress by @MrShark.

## How Has This Been Tested?
Run locally using `pytest`; some test modules were run individually to check whether they pass in isolation from the rest of the test suite (not all do: some of the Importer modules in particular seem to rely on database setup that occurs when other Python modules are loaded during test suite run)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
