### PR TITLE
Fixed two issues adding recipe as ingredient to others

### DIFF
--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -1776,6 +1776,7 @@ class IngredientController (plugin_loader.Pluggable):
                               amount: Optional[float] = None,
                               unit: Optional[str] = None,
                               item: Optional[str] = None,
+                              refid: Optional[int] = None,
                               optional: Optional[bool] = None):
         if amount is not None:
             self.imodel.set_value(iter, 1, str(amount))
@@ -2934,7 +2935,7 @@ class RecSelector(RecIndex):
     @property
     def sort_by(self):
         preferences = self.prefs['sort_by']
-        column, ascending = preferences.values()
+        column, ascending = next(iter(preferences.items()))
         ascending = 1 if ascending else -1
         return ([column, ascending],)
 


### PR DESCRIPTION
Adresses two issues in reccard.py preventing a recipe from being added as an ingredient to another one.

## Description
Tried adding a recipe as an ingredient to another:
Recipe -> Edit ingredients -> Add recipe

This raised:
`Traceback (most recent call last):
  File "/home/flo/Projekte/gourmand/fork/gourmand/src/gourmand/reccard.py", line 1139, in <lambda>
    _('Add another recipe as an ingredient in this recipe'), lambda *args: RecSelector(self.rg, self)),
  File "/home/flo/Projekte/gourmand/fork/gourmand/src/gourmand/reccard.py", line 2926, in __init__
    RecIndex.__init__(self,
  File "/home/flo/Projekte/gourmand/fork/gourmand/src/gourmand/recindex.py", line 64, in __init__
    self.setup_widgets()
  File "/home/flo/Projekte/gourmand/fork/gourmand/src/gourmand/recindex.py", line 139, in setup_widgets
    self.setup_search_views()
  File "/home/flo/Projekte/gourmand/fork/gourmand/src/gourmand/recindex.py", line 211, in setup_search_views
    sort_by=self.sort_by)
  File "/home/flo/Projekte/gourmand/fork/gourmand/src/gourmand/reccard.py", line 2937, in sort_by
    column, ascending = preferences.values()
ValueError: not enough values to unpack (expected 2, got 1)`

Found the culprit in reccard.py, Line 2937, incompatible assignment:
`column, ascending = preferences.values()`

Fixed that and got a list of recipes to select. Selecting one and choosing an amount yielded a text box
"Sie haben keien Rezepte ausgewählt!" (You didn't choose a recipe) and after clicking "OK":

`Traceback (most recent call last):
  File "/home/flo/Projekte/gourmand/fork/gourmand/src/gourmand/reccard.py", line 2977, in rec_tree_select_rec
    self.ok()
  File "/home/flo/Projekte/gourmand/fork/gourmand/src/gourmand/reccard.py", line 2998, in ok
    self.ingEditor.ingtree_ui.ingController.add_ingredient_from_kwargs(
  File "/home/flo/Projekte/gourmand/fork/gourmand/src/gourmand/reccard.py", line 1752, in add_ingredient_from_kwargs
    self.update_ingredient_row(
TypeError: IngredientController.update_ingredient_row() got an unexpected keyword argument 'refid'`

Found that compared to older versions, def update_ingredient_row() omitted "refid" in its named parameters. It seemed ok for update_ingredient_row() to not actually handle "redid" as it seems to be done one up in add_ingredient_from_kwargs(), so I just added "refid" back to the parameters.

It seems to work well again. However I observed one new issue: Adding another recipe to the ingredients only, the "Save" button on the containing recipe stays grayed out. Adding and removing any other normal ingredient enables the button. The recipe can then be saved and works including the sub recipe reference.

## How Has This Been Tested?
Created two test recipes with one simple ingredient each and yield property "1 Portion". Then tried adding one to the other as sub recipe.

## Types of changes
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
