### PR TITLE
Build updates

### DIFF
--- a/.flatpak/io.github.GourmandRecipeManager.Gourmand.yml
+++ b/.flatpak/io.github.GourmandRecipeManager.Gourmand.yml
@@ -17,8 +17,8 @@ modules:
       - -DENABLE_CPP=OFF
       - -DENABLE_QT5=OFF
     sources:
-      - url: https://poppler.freedesktop.org/poppler-20.10.0.tar.xz
-        sha256: 434ecbbb539c1a75955030a1c9b24c7b58200b7f68d2e4269e29acf2f8f13336
+      - url: https://poppler.freedesktop.org/poppler-23.12.0.tar.xz
+        sha256: beba398c9d37a9b6d02486496635e08f1df3d437cfe61dab2593f47c4d14cdbb
         type: archive
 
   - name: cpython

--- a/.flatpak/io.github.GourmandRecipeManager.Gourmand.yml
+++ b/.flatpak/io.github.GourmandRecipeManager.Gourmand.yml
@@ -16,6 +16,7 @@ modules:
       - -DENABLE_UTILS=OFF
       - -DENABLE_CPP=OFF
       - -DENABLE_QT5=OFF
+      - -DENABLE_QT6=OFF
     sources:
       - url: https://poppler.freedesktop.org/poppler-23.12.0.tar.xz
         sha256: beba398c9d37a9b6d02486496635e08f1df3d437cfe61dab2593f47c4d14cdbb

--- a/.flatpak/io.github.GourmandRecipeManager.Gourmand.yml
+++ b/.flatpak/io.github.GourmandRecipeManager.Gourmand.yml
@@ -1,6 +1,6 @@
 app-id: io.github.GourmandRecipeManager.Gourmand
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '45'
 sdk: org.gnome.Sdk
 command: gourmand
 

--- a/.flatpak/io.github.GourmandRecipeManager.Gourmand.yml
+++ b/.flatpak/io.github.GourmandRecipeManager.Gourmand.yml
@@ -13,6 +13,7 @@ modules:
   - name: poppler
     buildsystem: cmake-ninja
     config-opts:
+      - -DENABLE_BOOST=OFF
       - -DENABLE_UTILS=OFF
       - -DENABLE_CPP=OFF
       - -DENABLE_QT5=OFF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup build environment
       run: |
@@ -31,7 +31,7 @@ jobs:
           mv dist/gourmand-*-py3-none-any.whl dist/gourmand-${GITHUB_SHA::8}-py3-none-any.whl
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: gourmand
           path: ./dist/gourmand-*

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   flatpak:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Flatpak
       run: |
         sudo apt install flatpak flatpak-builder
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Flatpak
       run: |
         flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install flathub org.gnome.Platform//42 org.gnome.Sdk//42 -y
+        flatpak install flathub org.gnome.Platform//45 org.gnome.Sdk//45 -y
 
     - name: Build Flatpak
       run: |
@@ -31,7 +31,7 @@ jobs:
         flatpak build-bundle repo gourmand-${GITHUB_SHA::8}.flatpak io.github.GourmandRecipeManager.Gourmand
 
     - name: Upload Flatpak
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: gourmand.flatpak
         path: ./gourmand-*.flatpak

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   flatpak:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get update -q && sudo apt-get install
           --no-install-recommends -y xvfb python3-dev python3-gi
           python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev
-          intltool enchant python3-enchant gir1.2-poppler-0.18 python3-gst-1.0
+          intltool enchant-2 python3-enchant gir1.2-poppler-0.18 python3-gst-1.0
           python3-testresources
 
       - name: Install build dependencies


### PR DESCRIPTION
I've notice the flatpak version complaining about deprecated platform versions.  I've only been able to do some mild testing, but just bumping the versions and disabling some poppler options seems to get an updated flatpak version working for me.  Is there a maintainer left? 