### PR TITLE
scrape_me removed from recipe_scrapers v15+

### DIFF
--- a/src/gourmand/importers/web_importer.py
+++ b/src/gourmand/importers/web_importer.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 from urllib.parse import urlparse
 
 from gi.repository import Gtk
-from recipe_scrapers import SCRAPERS, scrape_me
+from recipe_scrapers import SCRAPERS, scrape_html
 from recipe_scrapers._exceptions import SchemaOrgException
 
 from gourmand.image_utils import ImageBrowser, image_to_bytes, make_thumbnail
@@ -41,7 +41,7 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
             urls.remove(url)
 
     for url in urls:
-        recipe = scrape_me(url)
+        recipe = scrape_html(html,org_url=url)
         # Fetch the image if available, or else open an ImageBrowser
         # to let the user select one.
         image = thumbnail = None

--- a/src/gourmand/importers/web_importer.py
+++ b/src/gourmand/importers/web_importer.py
@@ -41,7 +41,7 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
             urls.remove(url)
 
     for url in urls:
-        recipe = scrape_html(html,org_url=url)
+        recipe = scrape_html(html=None, org_url=url)
         # Fetch the image if available, or else open an ImageBrowser
         # to let the user select one.
         image = thumbnail = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace scrape_me with scrape_html
Closes https://github.com/GourmandRecipeManager/gourmand/issues/171

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on Fedora 42 with recipe-scrapers 15.2.1

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
