### PR TITLE
Tests: reactivate two more skipped tests

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,7 +1,5 @@
 import unittest
 
-import pytest
-
 from gourmand import convert
 
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -13,7 +13,6 @@ class ConvertTest(unittest.TestCase):
     def test_equal(self):
         self.assertEqual(self.c.convert_simple("c", "c"), 1)
 
-    @pytest.mark.skip("Broken as of 20220813")
     def test_density(self):
         self.assertEqual(self.c.convert_w_density("ml", "g", item="water"), 1)
         self.assertEqual(self.c.convert_w_density("ml", "g", density=0.5), 0.5)
@@ -46,7 +45,6 @@ class ConvertTest(unittest.TestCase):
         ]:
             self.assertEqual(convert.frac_to_float(s), n)
 
-    @pytest.mark.skip("Broken as of 20220813")
     def test_ingmatcher(self):
         for s, a, u, i in [
             ("1 cup sugar", "1", "cup", "sugar"),


### PR DESCRIPTION
## Description
Some tests in the unit test suite had previously been marked as skipped; some of these were re-enabled recently.  This changeset enables two more of them, to improve test coverage.  I think these are the last two remaining skipped tests.

Resolves #137.

## How Has This Been Tested?
I've run each of these two tests locally to confirm that they pass (using Python 3.13 and with a fairly minimal set of dependencies installed).

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.