### PR TITLE
Fixes issue in GourmandRecipeManager#147.

### DIFF
--- a/src/gourmand/importers/interactive_importer.py
+++ b/src/gourmand/importers/interactive_importer.py
@@ -491,7 +491,7 @@ def import_interactivally(uris: List[str]):
         soup = BeautifulSoup(resp.text, "html.parser")
         text = soup.get_text().replace("  ", "\n")  # Make the text more readable
         importer = InteractiveImporter()
-        importer.images = [img["src"] for img in soup.find_all("img") if img["src"].startswith("http")]
+        importer.images = [img["src"] for img in soup.find_all("img") if (("src" in img) and (img["src"].startswith("http")))]
         importer.set_text(text)
         importer.do_run()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A single line was changed:
`
<img width="1026" height="228" alt="image" src="https://github.com/user-attachments/assets/a70bb3aa-1e8a-4a94-a626-91921296f9ef" />

The web import in an unsupported website leads to a KeyError if there are no images on the recipe page.  This commit adds a precondition to the if statement in a list comprehension that checks to make sure the dictionary key is present.  This prevents trying to access a key which is not present in the dictionary.

The change fixes issue #147. 

## How Has This Been Tested?
This was tested by starting gourmand and importing [the recipe](https://www.webtenerifefr.com/propos-tenerife/gastronomie/produits/recettes/garbanzas-compuestas/).

## Screenshots (if appropriate):
<img width="978" height="501" alt="image" src="https://github.com/user-attachments/assets/6dcf2537-3d68-4304-8c7a-ea13fb012d55" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
