### PR TITLE
Change link text color in dark mode so it is more readable.

### DIFF
--- a/src/gourmand/gglobals.py
+++ b/src/gourmand/gglobals.py
@@ -105,18 +105,24 @@ for filename, stock_id, label, modifier, keyval in [
 ]:
     add_icon(load_pixbuf_from_resource(filename), stock_id, label, modifier, keyval)
 
-
 # Color scheme preference
-LINK_COLOR = "blue"
-star_color = "blue"
+def get_link_and_star_color(bgcolor, fgcolor):
+    total_bg = sum([bgcolor.red, bgcolor.green, bgcolor.blue])
+    total_fg = sum([fgcolor.red, fgcolor.green, fgcolor.blue])
+    # Dark mode
+    if total_bg < total_fg:
+        link_color = "deeppink"
+        star_color = "gold"
+    else: # Light mode
+        link_color = "blue"
+        star_color = "blue"
+    return (link_color, star_color)
 
-style = Gtk.StyleContext.new()
-_, bg_color = style.lookup_color("bg_color")
-_, fg_color = style.lookup_color("fg_color")
-
-if sum(fg_color) > sum(bg_color):  # background is darker
-    LINK_COLOR = "deeppink"
-    star_color = "gold"
+dummy_tv = Gtk.TextView()
+style = dummy_tv.get_style_context()
+bgcolor = style.get_background_color(Gtk.StateType.NORMAL)
+fgcolor = style.get_color(Gtk.StateType.NORMAL)
+LINK_COLOR, star_color = get_link_and_star_color(bgcolor, fgcolor)
 
 NO_STAR = Path(__file__).parent / "data" / "images" / "no_star.png"
 HALF_STAR = Path(__file__).parent / "data" / "images" / f"half_{star_color}_star.png"

--- a/tests/test_gglobals.py
+++ b/tests/test_gglobals.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import patch
+
+from gourmand.gglobals import get_link_and_star_color
+
+
+class TestLinkColor(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @patch("gourmand.gglobals.fgcolor")
+    @patch("gourmand.gglobals.bgcolor")
+    def test_dark_mode_link_color(self, dark_bgcolor, fgcolor):
+        # Closer to 0 is darker.  So in dark mode the background
+        # will be a smaller value than the foreground color.
+        fgcolor.red = 1
+        fgcolor.green = 1
+        fgcolor.blue = 1
+        dark_bgcolor.red = 0.18
+        dark_bgcolor.green = 0.18
+        dark_bgcolor.blue = 0.19
+        link_color_actual, star_color_actual = \
+            get_link_and_star_color(dark_bgcolor, fgcolor)
+        self.assertEqual("deeppink", link_color_actual)
+        self.assertEqual("gold", star_color_actual)
+
+    @patch("gourmand.gglobals.fgcolor")
+    @patch("gourmand.gglobals.bgcolor")
+    def test_light_mode_link_color(self, light_bgcolor, fgcolor):
+        # Closer to 0 is darker.  So in light mode the background
+        # will be a larger value than the foreground color.
+        fgcolor.red = 0.13
+        fgcolor.green = 0.13
+        fgcolor.blue = 0.13
+        light_bgcolor.red = 1
+        light_bgcolor.green = 1
+        light_bgcolor.blue = 1
+        link_color_actual, star_color_actual = \
+            get_link_and_star_color(light_bgcolor, fgcolor)
+        self.assertEqual("blue", link_color_actual)
+        self.assertEqual("blue", star_color_actual)


### PR DESCRIPTION
## Description
Update link color in gglobals.py based on window color.  The Gtk window will query itself and look at the background and foreground colors.  If the background is darker than the foreground then the link color will be pink and if the background is lighter than the foreground the link color will be blue.  The color does not update if the user changes the color theme during the program, instead a restart is required.

Add mock test to simulate light and dark mode.  The mock test color values are based on the values given in a test run in light and dark mode.  A new file named test_gglobals.py was added to the tests directory.

Related to #162.

## How Has This Been Tested?
I have only tested this on Ubuntu (standalone and WSLg).  I manually tested the link color changes when dark mode is applied before the program is started.  After starting the program I open a recipe and observe the color of the automatic timer link.  The automated tests included in the PR only look at the return values for LINK_COLOR and star_color.

## Screenshots (if appropriate):
See #162.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
