### PR TITLE
Drop dependency on pkg_resources

### DIFF
--- a/src/gourmand/plugin_loader.py
+++ b/src/gourmand/plugin_loader.py
@@ -5,8 +5,6 @@ import sys
 import traceback
 from typing import Dict, List
 
-import pkg_resources
-
 from gourmand import gglobals
 from gourmand.prefs import Prefs
 
@@ -14,9 +12,9 @@ from .defaults.defaults import loc
 from .gdebug import debug
 
 if sys.version_info < (3, 10):
-    from importlib_metadata import entry_points
+    from importlib_metadata import distribution, entry_points
 else:
-    from importlib.metadata import entry_points
+    from importlib.metadata import distribution, entry_points
 
 PRE = 0
 POST = 1
@@ -247,15 +245,19 @@ class Plugin:
         self.api_version = 2.0
         self.copyright = plugin_class.COPYRIGHT
         self.website = plugin_class.WEBSITE
-        attrs = pkg_resources.require(self.name)[0]
-        self.version = attrs.version
+        dist = distribution(self.name)
+        self.version = dist.version
 
+        # TODO: Evaluate if we really need this code. Ideally, the package
+        #       already takes care of it automatically without us having to
+        #       do more complex requirement parsing and marker evaluation.
         # The following is a backward compatibility hack: pip took care to
         # install the plugin and its dependencies.
         # Moreover, Gtk bindings are packaged as pygobject but installed as gi.
         # We have it anyway.
-        self.dependencies = [r.name for r in attrs.requires()]
-        self.dependencies.remove("pygobject")
+        # self.dependencies = [r.name for r in attrs.requires()]
+        # self.dependencies.remove("pygobject")
+        self.dependencies = []
 
         self.module = plugin_class.__module__
         self.plugins = [plugin_class]


### PR DESCRIPTION
## Description

`pkg_resources` is deprecated and should not be used anymore. Replace its usage where possible and testable.

## How Has This Been Tested?

The tests still run successfully and the application is able to start.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
