### PR TITLE
Modernize commands

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2014-05-08 12:18+0000\n"
 "Last-Translator: Chris Hand <chris.hand@neotel.co.za>\n"
 "Language-Team: Afrikaans <af@li.org>\n"
@@ -19,64 +19,64 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Resep Indeks"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nuwe Resep"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Voeg by _Inkopieslys"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "_Besigtig Resep"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Soek vir:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Soek vir resepte soos u tik"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_in"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Soek deur middel van ander kriteria binne die huidige soek resultate."
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Voeg Soek Kriteria"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Beperk Soektog tot:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Soektog Resultate"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Stel Velde vir Geselekteerde Resepte"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -84,129 +84,132 @@ msgstr ""
 "<span size=\\\"large\\\" weight=\\\"bold\\\">Stel Resep Velde vir "
 "geselekteerde resepte</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Voeg Beeld By"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Verwyder Beeld:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "_Bron"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Gradering:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "Kook Kultuur"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Kategorie:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "_Voorbereidingstyd:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Gaarmaak Tyd:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Webblad:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Beeld:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Oplewering:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Opleweringseenheid"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "_Stel alle waardes vir geselkteerde resepte"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (by verstek gestoor in 'n lokale lêer)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (gestoor in 'n lokalelêer)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (benodig koppeling aan 'n databasis)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Kies Databasis"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Kies Databasis Stelsel vir Gourmet om te Gebruik</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "_Databasis Stelsel"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "Bediener:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Gebruikersnaam:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Wagwoord:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Wagwoord vir u gebruikersnaam op die databasis."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "_Databasis Naam:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Lêer"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -215,11 +218,11 @@ msgstr ""
 "databasisbediener op die lokalestelsel bedryf word, gebruik die "
 "lokalebediener."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "lokalebediener"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -227,11 +230,11 @@ msgstr ""
 "Stoor die wagwoord vir volgende keer. Dit beteken dat die wagwoord onveilig "
 "in u konfigurasielêer gestoor sal word."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "_Stoor Wagwoord"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -239,302 +242,303 @@ msgstr ""
 "Naam van die databasis waar Gourmet sy informasie behoort  te stoor. Gourmet "
 "sal probeer om hierdie databasis te skep indien dit nie alreeds bestaan nie."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "resep"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "U gebruikersnaam op die databasis."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Blaai"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Besonderhede"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Gourmet Resep Bestuurder Voorkeure"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Indeks Aansig Voorkeure</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "_Wys Keuses"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Resepte per bladsy:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 "<i>Konfigureer watter kolomme ingesluit moet word in die resep indeks aansig."
 "</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Indeks Aansig"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Kaart Aansig Voorkeure</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "_Laat eenhede verander wanneer daar gemenigvuldig word"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Gebruik breuke"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Waar moontlik gebruik breuke vir vertoon"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 "<i>Verwyder items van die Resepkaartkoppelvlak wat u nie gebruik nie .</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Kaart Aansig"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Inkopieslys Voorkeure</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Wat moet Gourmet met Opsionele Bestandele doen wanneer resepte tot die "
 "inkopieslys bygevoeg word?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "_Vra of opsionele bestandele bygevoeg moet word"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "_Onthou gebruikerskeuses by verstek"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "_Vee opsionel bestandele wat onthou is uit"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "_Voeg opsionele bestandele altyd by"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Voeg opsionele bestandele nooit by nie"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Inkopieslys"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "porsies"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Titel"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Titel:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "_Voorbereidingstyd:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategorie"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "gradering"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Oplewering"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Opleweringseenheid"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Aankoop"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Redigeer_beskrywing"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Gaarmaaktyd:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Voorbereidingstyd:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Kook Kultuur</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Kategorie:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Webblad:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>Oplewerings:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Link</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Bron:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Gradering:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Vermenigvuldig met:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Aanwysings</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Redigeer_instruksies"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Notas</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Redigeer_notas"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Resep"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Bestandele</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Redigeer_bestandele"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Voeg_bestandeel_by:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Bestandele"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Voeg resep by inkopieslys"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "_Voeg by inkopieslys"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Gaan na resep in Resep Kaart Aansig"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Verwyder geslekteerde resep"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Verwyder resep"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Redigeer eienskappe van geslekteerde resep"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "_Grootmaatredigering van resepte"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "E-Pos gelekteerde resep"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Maak geselekteerde resep oop"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "_E-Pos resep"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Maak resep oop"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Druk geslekteerde resep"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "_Druk resep"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -546,31 +550,31 @@ msgstr ""
 "nodig het, maar dit sal nie ingesluit word sodra u die lys stoor of druk "
 "nie, tensy u aanwys dit moet gekoop word."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "_Voeg by Spens"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "_Wys Keuses"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "_Soek in"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "_Gebruik algemene uitdrukkings (gevorderde soektog)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "_Soek soos u tik"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Soek Opsies</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategorie"
 
@@ -579,288 +583,290 @@ msgstr "Kategorie"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Sleutel"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Kategorie Redigerder"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Soek deur middel van"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Soek soos u tik"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Gebruik gewone uitdrukkings"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Gevorderde Soek"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Voeg Kategorie by: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Tydsaanwyser"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Tydsaanwyser</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Tydsaanwyser Klaar!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Tydsaanwyser sal aanhou aanwys totdat hierdie dialoog toegemaak is of die "
 "tydsaanwyser herstel is."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "_Stel Tydsaanwyser "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Herstel"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Begin"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "_Klank"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Nota"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Herhaal alarm totdat ek dit afskakel"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Instellings"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Redigeer velde regdeur databasis</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "_Veld om te Redigeer:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Vir elke geselekteerde waarde:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "_Los waarde soos dit is"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 "<i>Nuwe waarde sal aan die einde van enige huidige teks bygevoeg word</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Nuwe waarde sal enige huidige waardes vervang</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Veld:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Waarde:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "_Verander ander veld:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "_Verander waarde tot: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "_Verwyder waarde"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Hoeveelheid:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Eenheid:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet Resep Bestuurder"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -875,662 +881,613 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Kies Databasis Lêer"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Besig on databasis op te gradeer"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Nuwe Resep"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "_Databasis Naam:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"Afhangend van die groote van u databasis, kan hierdie 'n intensiewe proses "
-"wees en mag dalk 'n bietjie tyd neem. U data is outomaties gerugsteun in "
-"geval iets verkeerds loop. Gaan drink solank 'n koppie koffie."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Besonderhede"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "'n Rugsteun is gemaak in %s in geval iets verkeerds loop. Sou hierdie "
 "opgradering nie werk nie, kan u die rugsteun lêer na resepte.db hernoem om "
 "dit  met 'n ouer weergawe van Gourmet te gebruik."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Nuwe Resep"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Redigeer"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Hulp"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Gaan na"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Voeg by _Inkopieslys"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Beskrywing"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instruksies"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notas"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Resepte"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Byvoegings"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Byvoegings verskaf addisionele funknaliteit aan Gourmet."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Byvoeging word benodig vir ander byvoegings. Maak byvoeging onaktief in elk "
 "geval?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Die volgende byvoegings benodig %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Deaktiveer in elk geval?"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Hou byvoeging aktief"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "of"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "'n Fout het onstaan met die aktivering van die byvoeging."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "'n Fout het onstaan met die deaktivering van die byvoeging."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Gradering"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Bron"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Webblad"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Voorbereidingstyd"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Gaarmaaktyd"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Aanpassings"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Ongeldige inset."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Nie 'n nommer nie."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pouse"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stop"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Moenie weer vra nie."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Wil u dit rêrig doen?"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "uitstekend"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "wonderlik"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "goed"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "nie te sleg nie"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "swak"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Skakel graderings om na 'n 5 ster skaal toe"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Skakel graderings om."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Gee asseblief elkeen van die graderings 'n gelykmatige gradering op 'n skaal "
 "van 1 to 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Huidige Gradering"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Gradering uit 5 Sterre"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Geen lêer geselekteer nie"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "_Kies Lêersoort"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Geen lêer was geselekteer nie, dus is die aksie gekanseleer"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr "Ek is jammer, ek verstaan nie die hoeveelheid \"%s\" nie."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Hoeveelhede moet nommers (breuke of desimale), groepe nommers of skoon wees."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1550,86 +1507,86 @@ msgstr ""
 "Om 'n reeks nommers te gebruik, gebruik 'n \"-\" om hulle te skei.\n"
 "Byvoorbeeld, u kon 2-4 of 1 1/2-3 1/2 gebruik.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Gebruikersnaam:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Wagwoord:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Die volgende byvoegings benodig %s:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Kies enkodering"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1637,364 +1594,350 @@ msgstr ""
 "Ons kan nie die korrekte enkodering bepaal nie. Kies asseblief die korrekte "
 "enkodering van die volgende lys af."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "_Sien lêer met enkodering"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Invoer tydelik gestaak"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Beïndig invoer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Resep Indeks"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Inkopieslys"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Chris Hand https://launchpad.net/~chris-hand\n"
 "  Marius Loots https://launchpad.net/~mloots"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Gestoor!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Stoor u regie by %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "'n Invoer is aan die gang."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "'n Uitvoer is aan die gang."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "'n Verwydering is aan die gang."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Verlaat program in elk geval?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Moenie verlaat nie!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "%s Van %s resepte permanent verwyder"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Asblik"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Blaai, permanent verwyder of herwin verwyderde resepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Herwinde resepte "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Hoeveelheid van %(unit)s vir %(title)s om aan te koop"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Vermegigvuldig %s met:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Stel %(attributes)s vir %(num)s geselekteerde resep?"
 msgstr[1] "Stel %(attributes)s vir %(num)s geselekteerde resepte?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Enige vorige bestaande waardes sal nie verander word nie."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Die nuwe waardes sal enige  vorige waardes oorskryf."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Hierdie verandering kan nie herstel word nie."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Stel waardes vir geselekteerde resepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Soek resepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Maak resep oop"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Maak geselekteerde resep oop"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Verwyder resep"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Verwyder geselekteerde resepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Redigeer resep"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Maak geselekteerde resepte in resepredigeerder aansig oop"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "_Voer geselekteerde resepte uit"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Voer geselekteerde resepte uit na lêer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Druk"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "resepte"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Redigeer resepte op grootmaat"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nuut"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Voer lêer in"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Voer Resep In"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Voer resep in van lêer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "_Voer webblad in"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "Verwyder resep"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Voer resep in vanaf webblad"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "_Voer alle resepte uit"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Voer alle resepte uit na lêer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Beëindig"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Aksies"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "_Maak Asblik Oop"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Asblik"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Voorkeure"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Aanvulprogramme"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Bestuur aanvulprogramme wat bykomende funksionaliteit gee aan Gourmet."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "_Stellings"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Aangaande"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Gereedskap"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Tydsaanwyser"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Wys tydsaanwyser"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Opsoekbare indeks van resepte in die databasis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Verwyder %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "U het ongestoorde veranderings aan %s. Is u seker u wil dit verwyder?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Verwyder"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Ongetiteld"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Verwyder resepte permanent?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Verwyder resep permanent?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Is u seker u wil die resep <i>%s</i> verwyder?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Is u seker u die volgende resepte wil verwyder?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Is u seker u wil die %s geselekteerde resepte verwyder?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Sien resepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Verwyder Resepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Resep Indeks"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Resep %s verwyder"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Klaar!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Besig om in te voer..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2002,12 +1945,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2015,78 +1958,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2095,129 +2038,129 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Sterre"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s gelede"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Outo-Saamvoeg resepte"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Gebruik altyd die nuutste resep"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Gebruik altyd die oudtse resep"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Geen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2225,97 +2168,97 @@ msgstr ""
 "Sommige van die ingevoerde resepte blyk om duplikate te wees. U kan hulle "
 "hier saamvoeg, of hierdie dialoog los om hulle onverander te laat."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Vind_duplikaat resepte"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Vind en verwyder duplikaat resepte"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Resepte met dieselfde resep informasie"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Resepte met dieselfde bestandele"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Resepte met dieselfde resep informarsie en bestandele"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "_Sluit resepte in asblik in"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Wys:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Voeg_alle duplikate saam"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Voeg resepte saam</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "_Outo-saamvoeg"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Vir elke geselekteerde warde"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Waar %(field)s %(value)s is"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Verandering sal %s resep affekteer"
 msgstr[1] "Verandering sal %s resepte affekteer"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Verwyder %s waar dit %s is?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Verander %s van %s tot %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i> Hierdie verandering is onomkeerbaar.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Veld Redigeerder"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Redigeer velde oor veelvuldige resepte op 'n slag"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "E-Pos resepte"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "E-Pos alle geselekteerde resepte (of alle respte indien geen resepte "
@@ -2324,162 +2267,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Wil u rêrig alle %s geselekteerde resepte E-Pos?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Ja, E-Pos hulle"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Kan nie %s na %s omskakel nie"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Benodig digtheidsinformasie"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Eenheidsverwerker"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Van</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "_Item:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Digtheid:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Digtheids_Informasie"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Tot</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Uitslag:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Argief (zip, tarball)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Laai zip argief"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Ontsluit van zip argief"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML Webblad"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Voer Webblad Uit"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Voer resepte uit na HTML lêers in omslag %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Resep gestoor as HTML lêer %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Oorspronklike Bladsy vanaf %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "Opsioneel"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Voer Webblad Uit"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Voer resepte uit na HTML lêers in omslag %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Resep gestoor as HTML lêer %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2487,81 +2418,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Laai %s af"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Haal %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML Lêer"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML Uitvoer"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Voer resepte uit na Gourmet XML lêer %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Resep gestoor in Gourmet XML lêer %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML Lêer (Verouderd)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML Lêer"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2570,882 +2474,899 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "porsie"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Lêer"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "HTML Uitvoer"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Voer resepte uit na Gourmet XML lêer %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Resep gestoor in Gourmet XML lêer %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3459,60 +3380,60 @@ msgstr "Gereedskap"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "sterre"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "%(number)s van %(total)s resepte uitgevoer"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Uitvoer klaar."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 "Sluit Resep in Hoofteks van E-Pos in ('n Goeie idee maak nie saak wat nie)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "E-Pos Resep as HTML Aanhangsel"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "E-Pos Resep as PDF Aanhangsel"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "E-Pos Keuses"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Moenie vra voor u E-Pos stuur nie."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-Pos nie suksesvol gestuur nie"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3520,233 +3441,186 @@ msgstr ""
 "U het versuim om die resep in die hoofteks van die boodskap of as 'n "
 "aanhangsel in te sluit"
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Stoor resep as..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gormet kan nie tipe lêer \"%s\" uitvoer nie"
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Voer resepte uit"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "resepte"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Kan nie uitvoer nie: onbekende lêer tipe \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "Veseker u kies 'n lêer tipe van die aftrek spyskaart wanneer u stoor."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Voer uit"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Druk %s resep"
 msgstr[1] "Druk %s resepte"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Haal lêer"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "Porsie"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Voorsien die URL van 'n resep argief of resep webblad"
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Voorsien webblad addres"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Voorsien URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Vorsien die addres van 'n webblad of resep argief."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Ons kan nie die URL invoer nie"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet het nie bykomstighede wat die URL kan laat invoer nie"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Ons kan nie die URL %(url)s of mimetype %(type)s invoer nie. Lêer is tydelik "
-"by %(fn)s gestoor"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Maak resep oop..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Voorsien webblad addres"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Aanpassings"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Vorsien die addres van 'n webblad of resep argief."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Voer In"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Alle invoerbare lêers"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "%s Resepte ingevoer."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "porsie"
 msgstr[1] "porsies"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "%s van %s resepte ingevoer."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "Dis reg"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-"Ons herken nie hierdie webblad nie. ONs gebruik 'n generiese invoerder..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Invoer klaar."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Voer resep in"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Verwerk bestandele"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Verwerk bestandele."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Porsies"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Bestandeel Sub-Groep"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Versteek"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Teks"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Aksies"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Voer resep in"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Maak_Tags Skoon"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Voer Resep In"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3755,104 +3629,98 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "KRecipe invoer"
 msgstr[1] "KRecipe invoer"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "sekond"
 msgstr[1] "sekondes"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuut"
 msgstr[1] "minute"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "ure"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "uur"
 msgstr[1] "ure"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
 msgstr[1] "dae"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
 msgstr[1] "weke"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -3861,7 +3729,7 @@ msgstr[1] "maande"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"
@@ -3873,72 +3741,30 @@ msgstr[1] "jare"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " en "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "en"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "tot"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML Lêer"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet Resep Bestuurder"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organiseer resepte, stel inkopieslyste op, bepaal voedingswaardes, en meer."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Blaai deur Resepte"
@@ -3948,7 +3774,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Resepte word gekies deur om te blaai by kategorie, tipe, ens."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Hoof"
@@ -3962,38 +3787,6 @@ msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 "'n Towenaar om duplikaat of saamgevoegde resepte te vind en te verwyder."
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Stuur na E-Pos"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "E-Pos resepte vanuit Gourmet"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Zip, Gzip, en Tarball ondersteuning"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Voer resepte vanaf zip en tar argiewe in"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Invoerder/Uitvoerder"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4003,6 +3796,18 @@ msgstr "Voer uit"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Skep resep webblad vanuit resepte."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Invoerder/Uitvoerder"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4015,14 +3820,6 @@ msgid ""
 msgstr ""
 "Voer resepte in- en uit- as Gourmet XML lêers, geskik for rugsteun of "
 "uitruil met ander Gourmet gebruikers."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "HTML Uitvoer"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Skep resep webblad vanuit resepte."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4081,22 +3878,6 @@ msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
 msgstr ""
 
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr ""
-
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
 "Assign and edit ingredient keys (unique identifiers for ingredients, used "
@@ -4153,6 +3934,132 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "E-Pos gelekteerde resep"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "_E-Pos resep"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Besig on databasis op te gradeer"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Afhangend van die groote van u databasis, kan hierdie 'n intensiewe "
+#~ "proses wees en mag dalk 'n bietjie tyd neem. U data is outomaties "
+#~ "gerugsteun in geval iets verkeerds loop. Gaan drink solank 'n koppie "
+#~ "koffie."
+
+#~ msgid "No file selected"
+#~ msgstr "Geen lêer geselekteer nie"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Geen lêer was geselekteer nie, dus is die aksie gekanseleer"
+
+#~ msgid "_Import file"
+#~ msgstr "_Voer lêer in"
+
+#~ msgid "Import _webpage"
+#~ msgstr "_Voer webblad in"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Voer resep in vanaf webblad"
+
+#~ msgid "Open _Trash"
+#~ msgstr "_Maak Asblik Oop"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Argief (zip, tarball)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Laai zip argief"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Ontsluit van zip argief"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Laai %s af"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Haal %s"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Haal lêer"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Voorsien die URL van 'n resep argief of resep webblad"
+
+#~ msgid "Enter URL:"
+#~ msgstr "Voorsien URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Ons kan nie die URL invoer nie"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet het nie bykomstighede wat die URL kan laat invoer nie"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Ons kan nie die URL %(url)s of mimetype %(type)s invoer nie. Lêer is "
+#~ "tydelik by %(fn)s gestoor"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr ""
+#~ "Ons herken nie hierdie webblad nie. ONs gebruik 'n generiese invoerder..."
+
+#~ msgid "Import complete."
+#~ msgstr "Invoer klaar."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Voer resep in"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Verwerk bestandele"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Verwerk bestandele."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML Lêer"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet Resep Bestuurder"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organiseer resepte, stel inkopieslyste op, bepaal voedingswaardes, en "
+#~ "meer."
+
+#~ msgid "Send to Email"
+#~ msgstr "Stuur na E-Pos"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "E-Pos resepte vanuit Gourmet"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Zip, Gzip, en Tarball ondersteuning"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Voer resepte vanaf zip en tar argiewe in"
+
+#~ msgid "HTML Export"
+#~ msgstr "HTML Uitvoer"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Skep resep webblad vanuit resepte."
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4244,9 +4151,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "_Porsies"
-
-#~ msgid "Select File_type"
-#~ msgstr "_Kies Lêersoort"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "'n Lêer met die naam %s bestaan reeds."

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-07-08 18:15+0000\n"
 "Last-Translator: Ibrahim Saed <ibraheem5000@gmail.com>\n"
 "Language-Team: Arabic <ar@li.org>\n"
@@ -21,508 +21,511 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "و_صفة جديدة"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "أضف إلى قائمة _المشتريات"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "ا_بحث عن:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_في"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "الحد من البحث إلى:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "_نتائج البحث"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "ال_تقييم:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "الصورة:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "وحدات المحصول"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_ملف"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "وصفة"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_تفاصيل"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "مدير الوصفات قورمية"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "عرض المؤَقّت"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "قائمة المشتريات"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "العنوان"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "تصنيف"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "المحصول"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "وحدات المحصول"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "وصفة"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "المقادير"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "ا_حذف الوصفة"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "افتح الوصفة المحددة"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "اختر وصفة"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -530,31 +533,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "الفئة"
 
@@ -563,286 +566,288 @@ msgstr "الفئة"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "مفتاح"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "البحث فيما انت تكتب"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "مؤقت"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "وحدة"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "معلومات القيمة الغذائية"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "مدير الوصفات قورمية"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -864,212 +869,167 @@ msgstr ""
 "مخصص للتبادل مع مستخدمين قورمية اخرين. يدعم قورمية ربط الصور بالوصفة, يستطيع "
 "قورمية ايضا حساب معلومات القيمة الغذائية حسب المقادير."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (مساعد النقل الي منصات واندوس)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (مثبت مناصات واندوس)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (تحسينات واجهة محول الوحدات)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (تحسينات الي مصدر Mealmaster ميل ماستر)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (الشعار و شاشة الولوج)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (القيمة الغذائية و ايقونة اضف الي قائمة المشتريات)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (تحسين التدويل (العولمة) و "
-"معالجة بعض العلل)"
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "اختر ملف قواعد البينات"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "ترقية قاعدة البيانات"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "وصفة جديدة"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
 msgstr ""
-"قد يكون هذا الاجاراء مكثف وقد يستهلك بعض الوقت, اعتمادا على حجم قاعدة "
-"البيانات. علي اي حال لقد تم حفظ نسخة احتياطية من معلوماتك في حالة حدوث خطاء "
-"ما"
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "تفاصيل"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "لقد تم حفظ نسخة احتياطية من معلوماتك في %s في حالة حدوث خطاء ما. اذا تعثرت "
 "الترقية, تستطيع يدويا تغير اسم ملف النسخة الاحتياطية الي recipes.db لكي "
 "تستطيع استخدامها مع نسخة قورمية الاقدم"
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "وصفة جديدة"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "غير _الفئة"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "انشئ فئة جديدة"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "غير الفئة للعنصر المختار"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "مخزن"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "انتقل الي _قائمة المشتريات"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl> لا"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "انقل الي _المخزن"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl> ي"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "ازل من قائمة المشتريات"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "انقل العنصر المختار الي %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "قائمة المشتريات"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "بالفعل موجود (عناصر _المخزن)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "ادخل الفئة"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "تضاف الفئة  %s الي"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "الفئة:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_وصفات"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_اضف عنصر"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "ازل الوصفات"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "ازل الوصفات من قائمة المشتريات"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_تحرير"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_مساعدة"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "اضف عناصر"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "اضف عناصر اعتباطية الي قائمة المشتريات"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "ء"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "لم يتيم تحديد اي وصفة. هل تريد ازالة جميع مافي القائمة"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "احفظ قائمة المشتريات بأسم"
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "حدد المقادير الاختيارية"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1078,55 +1038,57 @@ msgstr ""
 "المشتريات"
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_وصفة"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_اذهب"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "صدر الوصفة"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "صدر الوصفة المحددة (احفض في ملف)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_امسح الوصفة"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "امسح هذة الوصفة"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "عدل الوحدات عند المضاعفة"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr "غير الوحدات حسب الحاجة عن المضاعفة"
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "اطبع الوصفة"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "أضف إلى قائمة _المشتريات"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "انسى المقادير الالختيارة الموجودة في الذاكرة"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1134,150 +1096,144 @@ msgstr ""
 "قبل الاضافة الي قائمة المشتريات, اسأل عن المقادير الاختيارية, حتي أولأك "
 "الذين طلبت ان اتذكرهم"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "صدر الوصفة"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "يوجد تغيرات لم تحفظ"
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "هل يوجد تغيرات قبل الطباعة"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "هل يوجد تغيرات قبل الطباعة"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(اختياري)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "تعثر ايجاد الوصفة %s في قواعد البينات"
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "حرر الوصفة :"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "احفظ التعديلات الي قواعد البينات"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "اعرض بطاقة الوصفة"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "حرّر"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "احفظ التغيرات الي %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "اضف مقدار"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "اضف مجموعة"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "الصق المقادير"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "استورد من ملف"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "اضف _وصفة"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "اضف وصفة اخري كمقدار لهذة الوصفة"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "احذف"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "رفع"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "أسفل"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "اختر ملف يحتوي علي قائمة المقادير"
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "الوصف"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "التعليمات"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "ملاحظات"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "الكمية"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "وحدة"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "عنصر"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "إختياري"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "الوصفة %s (ID %s) غير موجودة في قواعد البينات."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "تم تحويل: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "لم يتم تحويل: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "غير الوحدة"
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1286,232 +1242,231 @@ msgstr ""
 "لقد غيرت الوحدة لي %(item)s من %(old)s الي %(new)s. هل ترغب بتحويل الكمية "
 "ايضا؟"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "تم تحويل %(old_amt)s %(old_unit)s الي %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "فشل التحويل من %(old_unit)s الي %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "اضافة مجموعة للمقادير"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "ادخل الاسم لمجموعة متفرعة جيدية من القادير"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "ايم المجموعة :"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "اختر وصفة"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "الوصفة لاتستطيع ان تدعو نفسها كمقدار"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "التكرار الي مالانهاية غير مسموح بة في الوصفات"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "لم تختار اي وصفة"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "كم من %(title)s تحتاج في وصفتك؟"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "وصفات"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "صوت رنين"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "صوت الانذار"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "صوت الخطاء"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "اوقف المؤقت ؟"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "اوقف _المؤقت"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_استمر باستخدام المؤقت"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "إضافات"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
-msgstr ""
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
+msgstr "ادر الاضافات و التي تزيد من وظائف قورمية"
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "لابد من توفر الاضافة التي تحتاجها الاضافات الخري. عطل الاضافات علي اي حال"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "الاضافات التالية تحتاج %s :"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "عطل علي اي حال"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "ابقي الاضافات فعالة"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "أو"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "حذث خطأ اثناء تفعيل الاضافة"
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "حذث خطأ اثناء تعطيل الاضافة"
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "المطبخ"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "تقييم"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "المصدر"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "موقع على الإنترنت"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "مدة الاعداد"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "مدة الطبخ"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "التعديلات"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "إدخال غير صحيح"
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "ليس رقم"
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_إيقاف مؤقت"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_توقّف"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "لا تسألني عن هذا مرة اخرى"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "هل تود فعلا القيام بهاذا"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "ممتاز"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "عظيم"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "جيد"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "مقبول"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "رديء"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "حول التقيم الي مقياس الخمس نجوم"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "حول التقيم"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "الرجاء منح كل تقيم ما يعادلها على المقياس من 1 إلى 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "التقيم الحالي"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "التقيم من حمس نجوم"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "لم يتم تحديد الملف"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "حدد _نوع الملف"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "لم يتم تحديد الملف, لذلك تم الغاء الاجراء"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1520,12 +1475,12 @@ msgstr ""
 "عذرا لم افهم\n"
 "الكمية \"%s\""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr "الكميات لابد ان تكون رقمية (كسر او عشرى) او تسلسل اعداد, او فارغ"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1545,113 +1500,112 @@ msgstr ""
 "لكي تدخل مجموعة من القيم لابد ان تفصل كل قيمة عن الاخرى بالمز \"-\"\n"
 "مثلا, تستطيع ادخال 2-4 او 1 1/2 - 3 1/2\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "طحين (دقيق) متعدد الاستعمال"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "سكر"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "ملح"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "فلف اسود, مطحون"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "ثلج"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "ماء"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "زيت خضار"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "زيت زيتون"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "مجهول"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "الوصفة تطلب نفسها كمقدار"
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "سوف يتم تجاهل وصفة %s"
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "قائمة المشتريات لي %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "خاص بالوصفات التالية"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " ء%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "خاص بالوصفات التالية"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "حدد الترميز"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 "لم استطيع تحديد الترميز الملائم, الرجاء تحديد الترميز من القائمة التالية"
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "اعرض الملف مع الترميز"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "علق الاستيراد"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "اوقف الاستيراد"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_فهرسة الوصفات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_قائمة المشتريات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1663,334 +1617,321 @@ msgstr ""
 "  zeyad alhendi https://launchpad.net/~all4tux\n"
 "  صقر بن عبدالله https://launchpad.net/~agari"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "حفظ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "حفظ التعديلات في %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "استيراد قيد التنفيذ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "تصدير قيد التنفيذ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "الإلغاء قيد التنفيذ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "اخرج من البرنامج علي اي حال"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "لا تخرج"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "امسح %s من وصفات %s  كليا"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "نفاية"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "تصفح,كليا امسح او ابقي الوصفات المحذوفة"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "وصفات لم تحذف "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "عدد %(unit)s من %(title)s للتبضع"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "ضاعف %s بمقدار :"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "حدد %(attributes)s لكل %(num)s الوصفات المختارة؟"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "اي قيمة موجودة حاليا لن تتغير"
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "القيم الجديدة سوف تحل محل القيم الموجودة حاليا"
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "لايمكن القيام بالتغير"
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "حدد القيم للوصفات المختارة"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "البحث في الوصفات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "افتح الوصفة"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "افتح الوصفة المحددة"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "امسح الوصفة"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "احذف الوصفات المختارة"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "ص_در الوصفات المختارة"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "صدر الوصفات المختارو الي ملف"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "ا_طبع"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "الوصفات"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "_حرر الوصفات دفعة واحدة"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_جديد"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_استورد ملف"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "استيراد الوصفة"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "استورد وصفة من ملف"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "استودر _صفحة علي الانترنت"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s وصفة"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "استودر وصفة من صفحة علي الانترنت"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "صدر _جميع الوصفات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "صدر جميع الوصفات الي ملف"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_إنهاء"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "الإ_جراءات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "افتح _النفايات"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "نفاية"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_تفضيلات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_إضافات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "ادر الاضافات و التي تزيد من وظائف قورمية"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "الاعدا_دات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_عنْ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "أد_وات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "المؤقت"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "عرض المؤَقّت"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "فهرسة يمكن البحث فيها في قواعد البينات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "امسح %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "يوجد تعديلا لم تحفظ لي %s هل انت متأكد من عملية المسح"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "محذوف"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "بدون عنوان"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "احذف الوصفات قطعيا ؟"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "احذف الوصفة قطعيا ؟"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "هل انت متأكد من مسح الوصفة <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "هل انت متأكد من مسح الوصفات التالية ؟"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "هل انت متأكد من انك تريد مسح الوصفات المختارة %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "اعرض الوصفات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "امسح الوصفات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "_فهرسة الوصفات"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "امسح الوصفة %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "تم!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "جاري الاستيراد..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "محرر _مفتاح المقادير"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "حرر مفاتيح المقادير جملة"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "مفتاح"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "عنصر"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "حقل"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "قيمة"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "عد"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "حول جميع المفاتيح \"%s\" الي \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2000,27 +1941,27 @@ msgstr ""
 "لن تستطيع التراجع عن هذة الخطوة. اذا كان هناك مقادير مضافة للمفتاح \"%s\", "
 "لن تستطيع ان تفرق بين تلك العناصر و العناصر التيتغيرها الان"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "غير جميع العناصر \"%s\"  الي  \"%s\" ?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
 "the item \"%s\", you won't be able to distinguish between those items and "
 "the items you are changing now."
 msgstr ""
-"لن تستطيع التراجع عن هذة الخطوة. اذا كانت هناك مقادير ملحقة مع العنصر \"%s"
-"\", لن تستطيع ان تفرق بين تلك العناصر و العناصر التي تغيرها الان"
+"لن تستطيع التراجع عن هذة الخطوة. اذا كانت هناك مقادير ملحقة مع العنصر "
+"\"%s\", لن تستطيع ان تفرق بين تلك العناصر و العناصر التي تغيرها الان"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "حول _جميع النماذج من \"%(unit)s\"الي \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2029,12 +1970,12 @@ msgstr ""
 "حول \"%(unit)s\" الي \"%(text)s\" فقط لل_مقادير \"%(item)s\" والتي تحتوي علي "
 "المفتاح \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr "حول جميع النماذج \"%(amount)s\" %(unit)s الي %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2043,7 +1984,7 @@ msgstr ""
 "حول \"%(amount)s\" %(unit)sالي \"%(text)s\" %(unit)s فقط _عندما يكون "
 "المفتاح  %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2052,11 +1993,11 @@ msgstr ""
 "حول \"%(amount)s\" %(unit)s الي \"%(text)s\" %(unit)s فقط عندما يكون مفتاح "
 "المقادير  %(key)s _و عندما يكون العنصر هو %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "غير جميع الصفوف المختارة ؟"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2065,7 +2006,7 @@ msgstr ""
 "هذا العمل لن يمكن التراجع عنة, هل انت متأكد من ان الصفوف المختارة %s , تريد "
 "تحديد القيم التالية"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2074,7 +2015,7 @@ msgstr ""
 "\n"
 "المفتاح الي %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2083,7 +2024,7 @@ msgstr ""
 "\n"
 "العناصر الي %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2092,7 +2033,7 @@ msgstr ""
 "\n"
 "الوحدات الي %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2101,8 +2042,8 @@ msgstr ""
 "\n"
 "الكميات الي %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2115,23 +2056,23 @@ msgstr[5] "%s ingredients"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "عرض المقاير %(bottom)s الي %(top)s من %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "الكمية"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "مفاتيح المقادير"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2139,109 +2080,109 @@ msgstr ""
 "مفاتيح المقادير هيا اسماء المقادير الطبيعية و التي تستخدم في قائمة المشتريات "
 "و الحسابات"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "تخمين المفاتيح"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 "خمن افضل القيم لجميع مفاتيح المقادير بناء علي القيم الموجودة في قواعد البينات"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "حرر مفاتيح الترابط"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "حرر الترابط بين المفاتيح و سمات المتواجدة في قواعد البينات"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "فئة التسوق"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "اعرض الوحدات للوصفات كما هيا (بدون تغير)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "دائما استعرض الوحدات الامريكية"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "استعرض دائما الوحدات المترية"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "عدل الوحدات تلقائيا"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "حدد تفضيلات عرض _الوحدات"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 "حول الوحدات تلقائيا حسب التفضيل (متري, إمبريالي, الخ....) عند امكانية ذلك"
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "نجوم"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "منذ %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "ادمج الوصفات تلقائيا"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "استحدم الوصفات الجديدة دائما"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "استحدم الوصفات القديمة دائما"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "لايوجد"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2249,61 +2190,61 @@ msgstr ""
 "يبدو ان بعض الوصفات المستوردة مكررة, تستطيع دمجهم هنا, او اغلق هذا الحوار "
 "لتبقيهم كما هم"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "ابحث عن الوصفات _المكررة"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "ابحث عن الوصفات المكررة و ازلها"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "لكل قيمة مختارة"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "حيث %(field)sهو %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
@@ -2314,36 +2255,36 @@ msgstr[3] "Change will affect %s recipes"
 msgstr[4] "Change will affect %s recipes"
 msgstr[5] "Change will affect %s recipes"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "احذف %s عندما تكون %s ?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "غير %s  من %s الي \"%s\" ?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>هذا التغير لا يمكن التراجع عنة</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "محرر الحقول"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "حرر حقول مجموعة من الصفات تبعا و في نفس الوقت"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "ارسل الوصفة بالبريد الالكتروني"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "ارسل الوصفات المختارة بالبريد الالكتروني (او ارسل جميع الوصفات اذا لم يتم "
@@ -2352,162 +2293,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "هل تريد ان ترسال جميع الوصفات المختارة بالبريد الالكتروني %s"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "نعم, ا_رسلهم بالبريد الالكتروني"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "لا يمكن تحويل %s  الي %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "بحاجة الي معلومات الكثافة"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "محول الوحدات"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "احسب تحويل الوحدات"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>من</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>إلى</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "؟"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "يتم تحميل ارشيف zip"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "فك ضغط ارشيف zip"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "صفحة انترنت HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "يتم تصدير صفحة انترنت"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "تصدير الوصفات بصيغة HTML في المجلد  %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "حفظت الملفات بصيغة HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "الصفحة الاصلية من %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "اختياري"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "يتم تصدير صفحة انترنت"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "تصدير الوصفات بصيغة HTML في المجلد  %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "حفظت الملفات بصيغة HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "ملف نصي"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "صدر النصوص"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "تصدير الوصفات بصيفة ملف نصي text file %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "حفظ الوصفات بصيغة ملف نصي text file %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "ملف كبير"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "الملف %s كبير جدا لايمكن استيرادة"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2518,81 +2447,54 @@ msgstr ""
 "تستوردة علي اي حال, اذا كنت تريد ان تستوردة, استخدم محرر نصوص لتجزئة الملف "
 "الي ملفات اصغر ثم حاول ان تستوردة مرة اخرى."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "صفحة علي الانترنت"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "تحميل %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "قائمة المشتريات لي %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "استرداد %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "ملف XML لقورمية"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "تصدير XML لقورمية"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "تصدير الوصفات الي ملف XML  %(file)s"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "الوصفة حفظت في ملف قورمية XML %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "ملف قورمية XML  (بائد)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "ملف ال XML الخاص بماستركوك (Mastercook)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "ملف نصي الخاص بماستركوك (Mastercook)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "انتها الاستيراد من ماستركوك (Mastercook)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "ملفات XML لكي رسبي KRecipe"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2601,106 +2503,119 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "تنسيق الصفحة"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "اطبع الوصفة"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF ( نسق ملف PDF)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "صدر لي PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "صدر الوصفات بصيغة PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "الوصفات حفظت بصيغة PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "رسالة"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "بورتريه"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "عادي"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "سنتيمتر"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "نقاط"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x7 بوصة"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "فهرس الكروت (3.5x5) بوصة"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "بطاقة الفهرس (4x6 بوصة)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "بطاقة الفهرس (5x8 بوصة)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "بطاقة الفهرس (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "رسالة"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "قانوني"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "بطاقات الفهرس (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "بطاقات الفهرس (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "بطاقات الفهرس (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "مستعرض"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "عادي"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "عمود %s"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "عمود %s"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "عمود %s"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "عمود %s"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
@@ -2711,168 +2626,176 @@ msgstr[3] "%s Columns"
 msgstr[4] "%s Columns"
 msgstr[5] "%s Columns"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "بورتريه"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "مستعرض"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "_مقاس الورق"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_توجيه"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_حجم الخط"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "_استعراض الصفحة"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_حجم الخط"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "الهامش الأيسر"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "الهامش الأيمن"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "الهامش العلوي"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "الهامش السّفلي"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "ملف ميل ماستر (MealMaster)"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "تصدير لميل ماستر (MealMaster)"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "صدر الوصفة الي ملف ميل ماستر MealMaster  %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "الوصفة حفظت كملف ميل ماستر MealMaster  %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "وجبة"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "ملف كبير"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "صدِّر"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "تصدير الوصفات الي ملف XML  %(file)s"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "الوصفة حفظت في ملف قورمية XML %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "مدخر قائمة المشتريات"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "احفض القائمة كوصفة"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift> س"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "احفظ قائمة المشتريات الحالية كوصفة لكي تستخدم لاحقا"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "القائمة لي %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "القائمة"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "معلوات القيمة الغذائية تنعكس بالقيمة لكل %s"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "معلومات القيمة الغذائية تعكس القيمة للوصفة كاملة"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "معلومات القيمة الغذائية ناقصة لي %s مقادير : %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "اي مجموعة غذائية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "الخيار"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ملم"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "حول الوحدة لي %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "من اجل حساب معلومات القيمة الغذائية. قورمية يحتاج ان تحول \"%s\" الي وحدة "
 "معروفة لدي قورمية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "غير مفتاح المقدار"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2881,27 +2804,27 @@ msgstr ""
 "غير مفتاح المقادير من %(old_key)s الي %(new_key)s في كل مكان او للوصفة  "
 "%(title)s؟"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "غير في كل مكان"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_فقط في وصفة %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "غير مفاتح المقادير من  %(old_key)s الي %(new_key)s في كل مكان؟"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "غير الوحدة"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2910,11 +2833,11 @@ msgstr ""
 "غير الوحدة من %(old_unit)s الي %(new_unit)s لكل المقادير %(ingkey)s او فقط "
 "للوصفة  %(title)s؟"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2922,197 +2845,198 @@ msgstr ""
 "قورمية يحتاج ان الكثافة بحيث قواعد بينات القيمة الغذائية تحتوي علي اكثر من "
 "وصف لهذا الطعام بكثافات مختلفة. الرجاء تحديد القيمة المناسبة ادناة."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "لتطبيق معلومات القيمة الغذائية, قورمية يحتاج قيمة صحيحة للمقدار و الوحدة"
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "التغذية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "المقدار"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "مرادف قواعد البينات لي (USDA) وزارة الزراعة الامريكية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 غرام"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "سعرات حرارية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "جملة الدهون"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "الدهون المشبعة"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "كوليسترول"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "صوديوم"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "جملة الكربوهيدرات"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "الألياف الغذائية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "سكر"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "بروتين"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "ألفا كاروتين"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "رماد"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "بيتا كاروتين"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "كريبتوزينثن بيتا"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "كالسيوم"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "نحاس"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "مجموع الفولات"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "حمض الفوليك"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "حمض الفوليك الغذائي"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "بدائل لحمض الفوليك"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "حديد"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "الليكوبين"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "وتين + زيازينثن"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "مغنيزيوم"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "منغنيز"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "النياسين"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "حمض البانتوثنيك"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "فوسفور"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "بوتاسيوم"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "فيتامين (أ)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "ريتينول"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "ريبوفلافين"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "سيلينيوم"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "الثيامين"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "فيتامين (أ) (وحدة دولية)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "فيتامين (أ) (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "فيتامين B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "فيتامين B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "فيتامين ج (سي)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "فيتامين (ه)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "فيتامين ك"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "زنك"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "الفيتامينات والمعادن"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3121,11 +3045,11 @@ msgstr ""
 "معلومات القيمة الغذائية مفقودة\n"
 "لي %(missing)s من %(total)s المقادير."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% القيمة _اليومية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3134,369 +3058,369 @@ msgstr ""
 "النسبة المقترحة للقيمة اليومية مبنية علي %i  السعرات الحرارية لكل يوم. انقر "
 "لتحرير كمية السعرات الحرارية لكل يوم"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "الكمية حسب %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "الكمية حسب الوصفة"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "يتم تحميل معلومات القيمة الغذائية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "انتها استيراد قواعد بينات معلومات القيمة الغذائية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 "يتم جلب معلومات قواعد البينات للقيمة الغذائية من ملف الارشيف المضغوط %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "استخراج %s من الارشيف المضغوط"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "تحليل معلومات القيمة الغذائية"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "يتم قراءة معلوات القيمة الغذائية: تم استيراد %s  من  %s ادخال"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "تحليل معلومات الاوزان"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "يتم قراءة معلوات الاوزان لعناصر القيمة الغذائية: تم استيراد %s  من  %s ادخال"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "ماء"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "كم للسعرات الحرارية"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "جرام بروتين"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "جرام دهون"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "جرام رماد"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "جرام كربوهيدرات"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "جرام الياف"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "جرام سكر"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "مليجرام كالسيوم"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "مليجرام حديد"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "مليجرام مغنيزيوم"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "مليجرام فسفور"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "مليجرام بوتاسيوم"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "مليجرام صوديوم"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "مليجرام زنك"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "مليجرام نحاس"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "مليجرام منغنيز"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "ميكروجرام سيلينيوم"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "مليجرام فيتامين ج"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "مليجرام ثيامين"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "مليجرام ريبوفلافين"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "مليجرام نياسين"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "مليجرام حمض البانتوثنيك"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "مليجرام فيتامين B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "ميكروجرام حمض الفوليك المجموع"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "ميكروغرام حامض الفوليك"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "ميكروجرام حمض الفوليك الغذائية"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "ميكروجرام مرادفات حمض الفوليك الغذائية"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "ميكروجرام فيتامين B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "فيتامين (أ) وحدة دولية"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "فيتامين أ (مايكروجرام معادل لنشاط شبكية العين)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "مايكروجرام الريتينول"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "ميكروجرام ألفا كاروتين"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "ميكروجرام بيتا كاروتين"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "ميكروجرام بيتا كريبتوزينثن"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "ميكروجرام الليكوبين"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "ميكروجرام  وتين + زيازانثن"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "مليجرام فيتامين (ه)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "مليجرام فيتامين ك"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "جرام الأحماض الدهنية المشبعة"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "جرام الأحماض الدهنية غير المشبعة الاحادية"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "جرام الأحماض الدهنية المتعددة غير المشبعة"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "مليجرام كوليسترول"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "نسبة الرفض"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "الألبان ومنتجات البيض"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "التوابل والأعشاب"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "أغذية أطفال"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "الدهون والزيوت"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "الدواجن"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "الحساء والصلصات"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "النقانق واللحوم الباردة"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "حبوب الافطار"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "الفاكهة وعصائر الفاكهة"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "خنزير"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "خضروات"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "المكسرات و البذور"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "لحوم البقر"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "مشروبات"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "السمك و القشريات"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "البقوليات"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "لحم الخروف ، لحم العجل"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "المنتجات المخبوزة"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "الحلويات"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "الحبوب والمكرونة"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "وجبات سريعة"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "وجبات الطعام ، وجبات خفيفة ، والأطباق الجانبية"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "وجبات خفيفة"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "الأطعمة العرقية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "قواعد البنات كاملة"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "مفتاح المقدار"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "لرقم التعريفي لي (USDA) وزارة الزراعة الامريكية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "شرح عنصر (USDA) وزارة الزراعة الامريكية"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "الكثافة المكافئة"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "معرف (USDA) وزارة الزراعة الامريكية #"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3510,106 +3434,106 @@ msgstr "ادوات"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "اجلب معلومات القيمة الغذائية للقائمة الحالية"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "الكمية لقائمة المشتريات"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "ابداء"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "صدرت %(number)s من %(total)s الوصفات"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "تم التصدير"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "اضف الوصفة في قلب البيرد الالكتروني (هذة فكرة جيدة علي اي حال)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "ارسل الوصفة بالبريد الالكتروني كملحق HTML"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "ارسل الوصفة بالبريد الالكتروني كملحق PDF"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "خيارات البريد الالكتروني"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "لا تسأل قبل ارسال البريد الالكتروني"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "البريد الالكتروني لم يرسل"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr "انت لم تختار ان تضمن الوصفة في قلب البريد الالكتروني او كملحق"
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "احفظ الوصفة باسم ...."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "قورمية لايستطيع تصدير الملف الي نوع \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "صدر الوصفات"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "الوصفات"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "لايمكن التصدير: نوع الملف غير معروف \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "الرجاء التأكد من اختيار نوع الملف من القائمة المنسدلة عن الحفظ"
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "صدِّر"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "لايمكن اجارء الطباعة: لايوجد اضافة طابعة مفعلة"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
@@ -3620,66 +3544,42 @@ msgstr[3] "Print %s recipes"
 msgstr[4] "Print %s recipes"
 msgstr[5] "Print %s recipes"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "استرداد  الملف"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "محصول"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "ادخل رابط الانترنت لي ارشيف الوصفة او موقع الوصفة علي الانترنت"
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "ادخل عنوان (رابط) صفحة الانترنت"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "أدخل الرابط:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "ادخل عنوان الموقع علي الانترنت او ارشيف الوصفة"
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "تعثر الاستيراد من رابط الانترنت"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "قورميو لايحتوي علي الاضافة الخاصة باستيراد روابط الانترنت"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"لم استطع استيراد العنوان %(url)s من نوع %(type)s. الملف حفظ في مكان مؤقت "
-"الموقع %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "افتح الوصفة...."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "ادخل عنوان (رابط) صفحة الانترنت"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "التعديلات"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "ادخل عنوان الموقع علي الانترنت او ارشيف الوصفة"
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "إستراد"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "جميع الملفات لايمكن استيرادها"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "الوصفات %s المستوردة"
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "وجبة"
@@ -3689,119 +3589,97 @@ msgstr[3] "servings"
 msgstr[4] "servings"
 msgstr[5] "servings"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "استيراد %s من وصفات %s"
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "حسنا"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "لا استطيع التعرف علي صفحة الانترنت هذة. بداء باستخدام مستورد عام"
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "اكتمل الاستيراد"
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "استيراد الوصفة"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "تحميض المقادر"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "تحميض المقادر."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "الوجبات"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "المقادير الفرعية"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "إخفاﺀ"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "استيراد الوصفة"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "ازل _السمات"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "اي مكان"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "عنوان"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "مقدار"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "تعليمات"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "ملاحظات"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "مطبخ"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "مصدر"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "استخدم العبارات الاعتيادية في البحث"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr "استخدم العبارات الاعتيادية في البحث (لغة بحث متقدمة) في البحث النصي"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "البحث فيما انت تكتب (اغلق الخاصية اذا كان البحث بطي)"
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "اعرض _خصائص البحث"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "اعرض خصائص البحث المتقدمة"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3814,21 +3692,21 @@ msgstr[5] "%s recipes"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "عرض وصفات %(bottom)s الي %(top)s الي %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s في %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "إيقاف مؤقت"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
@@ -3838,43 +3716,37 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "ايقاف مؤقت"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "انتهى"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "خطأ: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "خطأ"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "خطاء %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "تتبع"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "ثانية"
@@ -3885,11 +3757,11 @@ msgstr[4] "seconds"
 msgstr[5] "seconds"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "دقيقة"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "دقيقة"
@@ -3900,11 +3772,11 @@ msgstr[4] "minutes"
 msgstr[5] "minutes"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "ساعة"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ساعة"
@@ -3914,7 +3786,7 @@ msgstr[3] "hours"
 msgstr[4] "hours"
 msgstr[5] "hours"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "يوم"
@@ -3924,7 +3796,7 @@ msgstr[3] "days"
 msgstr[4] "days"
 msgstr[5] "days"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "أسبوع"
@@ -3934,7 +3806,7 @@ msgstr[3] "weeks"
 msgstr[4] "weeks"
 msgstr[5] "weeks"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "شهر"
@@ -3947,7 +3819,7 @@ msgstr[5] "months"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "سنه"
@@ -3963,71 +3835,30 @@ msgstr[5] "years"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " و "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ". "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "و"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "إلى"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "ملف XML لقورمية"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "مدير الوصفات قورمية"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr "تنسيق الوصفات, انشاء قائمة مشتريات, حساب القيمة الغذائية, و المزيد"
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -4037,7 +3868,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -4050,38 +3880,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4089,6 +3887,18 @@ msgstr "صدر لي PDF"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -4099,14 +3909,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4160,22 +3962,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4234,6 +4020,145 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (مساعد النقل الي منصات واندوس)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (مثبت مناصات واندوس)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (تحسينات واجهة محول الوحدات)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (تحسينات الي مصدر Mealmaster ميل ماستر)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (الشعار و شاشة الولوج)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (القيمة الغذائية و ايقونة اضف الي قائمة المشتريات)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (تحسين التدويل (العولمة) و "
+#~ "معالجة بعض العلل)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "ترقية قاعدة البيانات"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "قد يكون هذا الاجاراء مكثف وقد يستهلك بعض الوقت, اعتمادا على حجم قاعدة "
+#~ "البيانات. علي اي حال لقد تم حفظ نسخة احتياطية من معلوماتك في حالة حدوث "
+#~ "خطاء ما"
+
+#~ msgid "Paste ingredients"
+#~ msgstr "الصق المقادير"
+
+#~ msgid "Import from file"
+#~ msgstr "استورد من ملف"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "اختر ملف يحتوي علي قائمة المقادير"
+
+#~ msgid "No file selected"
+#~ msgstr "لم يتم تحديد الملف"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "لم يتم تحديد الملف, لذلك تم الغاء الاجراء"
+
+#~ msgid "_Import file"
+#~ msgstr "_استورد ملف"
+
+#~ msgid "Import _webpage"
+#~ msgstr "استودر _صفحة علي الانترنت"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "استودر وصفة من صفحة علي الانترنت"
+
+#~ msgid "Open _Trash"
+#~ msgstr "افتح _النفايات"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "يتم تحميل ارشيف zip"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "فك ضغط ارشيف zip"
+
+#~ msgid "Webpage"
+#~ msgstr "صفحة علي الانترنت"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "تحميل %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "قائمة المشتريات لي %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "استرداد %s"
+
+#~ msgid "ml"
+#~ msgstr "ملم"
+
+#~ msgid "Retrieving file"
+#~ msgstr "استرداد  الملف"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "ادخل رابط الانترنت لي ارشيف الوصفة او موقع الوصفة علي الانترنت"
+
+#~ msgid "Enter URL:"
+#~ msgstr "أدخل الرابط:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "تعثر الاستيراد من رابط الانترنت"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "قورميو لايحتوي علي الاضافة الخاصة باستيراد روابط الانترنت"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "لم استطع استيراد العنوان %(url)s من نوع %(type)s. الملف حفظ في مكان مؤقت "
+#~ "الموقع %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "لا استطيع التعرف علي صفحة الانترنت هذة. بداء باستخدام مستورد عام"
+
+#~ msgid "Import complete."
+#~ msgstr "اكتمل الاستيراد"
+
+#~ msgid "Importing recipe"
+#~ msgstr "استيراد الوصفة"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "تحميض المقادر"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "تحميض المقادر."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "ملف XML لقورمية"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "مدير الوصفات قورمية"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr "تنسيق الوصفات, انشاء قائمة مشتريات, حساب القيمة الغذائية, و المزيد"
 
 #~ msgid "Select recipe image"
 #~ msgstr "اختر صورة الوصفة"
@@ -4326,9 +4251,6 @@ msgstr ""
 #~ msgstr ""
 #~ "لقد طلبت اغلاق نافذة تحتوي علي مؤقت فعال. تستطيع ايقاف المؤقت, او تستطيع "
 #~ "ان تغلق النافذة. اذا اغلقت النافذة سوف تعود النافذة عند انتهاء المؤقت"
-
-#~ msgid "Select File_type"
-#~ msgstr "حدد _نوع الملف"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "الملف %s موجود"

--- a/po/az.po
+++ b/po/az.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2011-03-22 20:43+0000\n"
 "Last-Translator: Rashid Aliyev <Unknown>\n"
 "Language-Team: Azerbaijani <az@li.org>\n"
@@ -19,506 +19,507 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Qurman Resept İdarə edicisi"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+msgid "Copy selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -526,31 +527,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -559,285 +560,287 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Qurman Resept İdarə edicisi"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -852,650 +855,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 msgid "Add to Shopping List"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr ""
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Fayl_növünü seç"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1507,444 +1462,424 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Rashid Aliyev https://launchpad.net/~rashid"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+msgid "_Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1952,12 +1887,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1965,78 +1900,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2045,386 +1980,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2432,81 +2355,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2515,880 +2411,897 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3402,288 +3315,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3692,103 +3559,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3797,7 +3658,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3809,72 +3670,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Qurman Resept İdarə edicisi"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Reseptlərin yer-bə-yer edilməsi, alış-veriş siyahısının yaradılması, "
-"nurtonal məlumatın hesablanması və daha bir çox şey."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3884,7 +3703,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3897,44 +3715,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3945,14 +3743,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4006,22 +3796,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4081,8 +3855,16 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
-#~ msgid "Select File_type"
-#~ msgstr "Fayl_növünü seç"
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Qurman Resept İdarə edicisi"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Reseptlərin yer-bə-yer edilməsi, alış-veriş siyahısının yaradılması, "
+#~ "nurtonal məlumatın hesablanması və daha bir çox şey."
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "%s adlı faylartıq mövcuddur."

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gourmet Recipe Manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2014-06-02 09:03+0000\n"
 "Last-Translator: Svetoslav Stefanov <svetlisashkov@yahoo.com>\n"
 "Language-Team: Bulgarian <dict@fsa-bg.org>\n"
@@ -20,64 +20,64 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Списък с рецепти"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Нова рецепта"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Добавяне към _списъка за пазаруване"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Преглед на рецепта"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Търсене за:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Търсене по време на писане"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "в"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Търсене по друг критерий в рамките на текущите резултати."
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "_Добавяне на критерий за търсене"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Ограничаване на търсене до:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "_Резултати от търсенето"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Задаване на полета за текущите рецепти"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -85,130 +85,133 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Задаване на полета за избраните "
 "рецепти</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Добавяне на изображение"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Премахване на изображение"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "_Източник:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Оценка:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "_Кухня:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Категория:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "Време за _приготвяне:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Време за приготвяне:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Уеб страница:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Изображение:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Количество:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Мерна единица на порцията"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "Задаване на стойности само при празно поле"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Задаване на стойности за всички избрани рецепти"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (стандартно, съхранявана в локален файл)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (съхранявана в локален файл)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (изисква връзка към база данни)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Изберете база данни"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 "<b>Изберете система на базата данни, която да се използва от Gourmet</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "Система на базата данни"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Адрес:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Потребителско име:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Парола:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Парола за вашето потребителско име за базата данни."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Име на базата данни:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Файл"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -216,11 +219,11 @@ msgstr ""
 "Името на системата, на която работи сървъра за базата данни. Ако той е на "
 "вашата локална система, използвайте localhost."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -228,11 +231,11 @@ msgstr ""
 "Запазване на паролата за следващия път. Това означава, че паролата ви ще "
 "бъде запазена несигурно във вашия конфигурационен файл."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "Запазване на паролата"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -240,301 +243,302 @@ msgstr ""
 "Име на базата данни, в която Gourmet ще съхранява информацията си. Ако тя не "
 "съществува програмата ще се опита да я създаде."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "рецепта"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Потребителското ви име за базата данни."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Преглед"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "По_дробности"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Настройки на мениджъра на рецепти"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Настройка на изгледа Списък с рецепти</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Показване на _настроките"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Рецепти на страница:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr "<i>Настройте включените колони в списъка с рецепти.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Списък с рецепти"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Настройка на изгледа Единична рецепта</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "При умножение мерните единици да се сменят"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Използване на дроби"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Позволяване на дроби при възможност за показване"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 "<i>Премахнете елементи, които не използвате от интерфейса за единична "
 "рецепта.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Единична рецепта"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Настройки на списъка за пазаруване</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Какво да прави Gourmet с незадължителните съставки при добавяне на "
 "рецепти към списъка за пазаруване?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "_Питане дали да се включват незадължителни съставки"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "По _подразбиране да се запомня избраното от потребителя"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "_Изчистване на запомнените незадължителни съставки"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "_Винаги да се добавят незадължителни съставки"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Никога да не се добавят незадължителни съставки"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Списък за пазаруване"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "порции"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Заглавие"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Заглавие:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Време за приготвяне:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "категория"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "оценка"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Порция"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Мерна единица на порцията"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Пазаруване"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Редактиране на _описание"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Време за приготвяне:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Време за приготвяне:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Кухня:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Категория:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Уеб страница:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Количества:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Връзка</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Източник:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Оценка:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Умножение по:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Инструкции</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Редактиране на _инструкции"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Бележки</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Редактиране на _бележки"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Рецепта"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Съставки</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Редактиране на _съставки"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Добавяне на _съставка:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Съставки"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Добавяне на рецепта към списъка за пазаруване"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Добавяне към _списъка за пазаруване"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Преглеждане на рецептата"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Изтриване на избраната рецепта"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Изтриване на рецепта"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Редактиране свойствата на избраните рецепти"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "_Пакетно редактиране на рецепти"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Изпращане на избраната рецепта по е-поща"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Отваряне на избраната рецепта"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "Изпращане на рецепта по _е-поща"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Изберете рецепта"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Отпечатване на избраната рецепта"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "_Отпечатване на рецепта"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -546,31 +550,31 @@ msgstr ""
 "няма да бъде включен при запис или печат, освен ако не кажете, че трябва да "
 "го купите."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Добавяне в _килера"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Показване на _настроките"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Търсене _в"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "_Използване на регулярни изрази (разширено търсене)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Търсене при писане"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Настройки на търсене</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Категория"
 
@@ -579,291 +583,293 @@ msgstr "Категория"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Ключ"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Редактор на категории"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Търсене по"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Търсене по време на въвеждане"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Използване на регулярни изрази"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Разширено търсене"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Добавяне на категория: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Таймер"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Таймер</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Таймерът приключи!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Таймерът ще продължи  да се изключва, докато не затворите този прозорец или "
 "не го занулите."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Задаване на _таймер: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Нулиране"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Старт"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "_Звук"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Бележка"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Повторение на алармата до изключване"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Настройки"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Редактиране на полетата в базата данни</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Поле за _редактиране:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "За всяка избрана стойност:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "_Запазване на текущата стойност"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>В краят на всеки текст ще бъде добавена нова стойност</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Новата стойност ще замени всяка съществуваща</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Поле:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Стойност:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Промяна на _другото поле:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "_Промяна на стойността на: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "_Изтриване на стойност"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Изберете еквивалент на</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>от базата данни USDA</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "_Промяна на съставка"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>или</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "_Търсене на съставка в базата данни USDA:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Търсене при писане"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Показване само на храната в групата:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Резултати от търсенето:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>От:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Количество:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Единица:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "единица"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "_Промяна на мерна единица"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "_Записване на новата единица"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>До:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Мерна единица:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Въведете хранителната информация за </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Изберете плътност</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Ключ на съствка: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>USDA елемент: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "Редактиране на _USDA асоциация"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Хранителна информация</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "Редактиране на _информацията"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "_Хранителна информация"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Плътност:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "USDA еквиваленти:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Потребителски еквиваленти:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "Информация за _плътността"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Известна хранителна информация</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "_Разширено търсене"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Хранителна информация"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "_Игнориране"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet мениджър на рецепти"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Авторски права (c) 2004,2005,2006,2007,2008,2009,2010,2011 Thomas M. Hinkle. "
 "GNU GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -886,210 +892,168 @@ msgstr ""
 "поддържа свързването на изображения с рецепти. Gourmet също така изчислява "
 "хранителната информация за рецептите, изхождайки от съставките."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (помощ при портването към Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows инсталатор)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (подобрения по интерфейса на конвертора на единици)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (подобрения към изнасянето в Mealmaster формат)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo and splash screen)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Избор на файл с база данни"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Надграждане на базата данни"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Нова рецепта"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Име на базата данни:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"В зависимост от размера на вашата база данни, това може да интензивен "
-"процес, отнемащ известно време. На вашите данни бе създадено резервно копие, "
-"в случай че нещо се обърка."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Подробности"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "В %s беше направено резервно копие, в случай, че нещо се обърка. Ако това "
 "надграждане се провали, можете ръчно да преименувате файла recipes.db, за да "
 "го възстановите за използване с по-стара версия на програмата."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Нова рецепта"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Промяна на _категорията"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Създаване на нова категория"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Промяна на категорията на текущо избрания артикул"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Провизии"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Премести в Списъка за _Пазар"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Преместване при провизиите"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Премахване от списъка за пазаруване"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Преместване на избраните артикули в %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Списък за пазаруване"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Вече го има (_Провизии)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Въведете категория"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Категория, към която да се добави %s"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Категория:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Рецепти"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Добавяне на артикули:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Махни рецептите"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Махни рецептите от пазарския лист"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Редактиране"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Помощ"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Добавяне на артикули"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Добавяне на задължителни елементи към списъка за пазаруване"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Не са избрани рецепти, да изтрия ли целия лист?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Запазване на списъка за пазаруване като..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Избиране на допълнителни съставки"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1098,57 +1062,59 @@ msgstr ""
 "в списъка си за пазаруване."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Рецепта"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Отиване"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Изнасяне на рецепта"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Изнасяне на избраната рецепта (запис във файл)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Изтриване на рецептата"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Изтриване на тази рецепта"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Нагаждане на единиците при умножаване"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Промяна на единиците, за да се направят по-четими, където е възможно, при "
 "умножаване."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Печат на рецепта"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Добавяне към _списъка за пазаруване"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Забравяне на запомнените допълнителни съставки"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1156,150 +1122,144 @@ msgstr ""
 "Преди добавяне в списъка за пазаруване, питане за всички допълнителни "
 "съставки, дори и за предишно запомнените"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Изнасяне на рецептата"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Имаш незашпазени промени."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Да приложа ли промените преди печат?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Да приложа ли промените преди печат?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Допълнително)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Рецептата %s не може да бъде открита в базата данни."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Редактирай рецепта:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Запазване на редактиранията в базата данни"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Преглед на картата за рецептата"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Редактиране"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Запазване на промените в %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Добавяне на съставка"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Добавяне на група"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Поставяне на съставки"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Внасяне от файл"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Добавяне на  _рецепта"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Добавяне на друга рецепта като съставка на тази"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Изтриване"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Нагоре"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Надолу"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Изберете файл съдържащ списъка със съставки."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Описание"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Инструкции"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Бележки"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Количество"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Единица"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Артикул"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Незадължителни"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Рецептата %s (ID %s) не е в нашата база данни."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Конвертирани %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Неконвертирани %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Променена единица."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1308,232 +1268,231 @@ msgstr ""
 "Вие променихте единицата за %(item)s от %(old)s на %(new)s. Желаете ли да се "
 "конвертира количеството или не?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Конвертирано %(old_amt)s %(old_unit)s в %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Не може да се конвертира от %(old_unit)s в %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Добавяне на група съставки"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Въведете име за новата подгрупа съставки"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Име на групата:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Изберете рецепта"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Рецептата не може да се използва себе си като съставка"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Безкрайните рекурсии не са разрешени в рецептите!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Не сте избрали нито една рецепта!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "От колко %(title)s се нуждае рецептата ви?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Рецепти"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Звук за звънене"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Звук за предупреждение"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Звук за грешка"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Спиране на таймера?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Спиране на  _таймера"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Запазване на времето"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Приставки"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Приставките добавят допълнителна функционалност към Gourmet."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Приставката е необходима за други приставки. Да се изключи ли въпреки това?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Следните приставки изискват %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Изключване въпреки това"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Задържане на приставката активна"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "или"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Възникна грешка при включването на приставката."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Възникна грешка при изключването на приставката."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Национална кухня"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Оценка"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Източник"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Уебстраница"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Време за приготвяне"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Време за готвене"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Промени"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Грешно въвеждане."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Не е номер"
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Пауза"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Спиране"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Не ме питай отново."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Наистина ли желаете да направите това"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "отлично"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "велико"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "добро"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "безпристрастно"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "слабо"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Конвертиране на рейтинга към петзвездна скала."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Конвертиране на рейтингите."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Моля дайте на всеки от рейтингите еквивалент по скалата от 1 до 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Текущ рейтинг"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Рейтинг от 5 звезди"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Няма избран файл"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Избор на _вид файл"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Нямаше избран файл, затова действието беше прекъснато"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1542,14 +1501,14 @@ msgstr ""
 "Съжалявам, не мога да разбера\n"
 "количеството \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Количеството трябва да е цифра (дроб или десетична), област от номера, или "
 "празно"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1570,86 +1529,86 @@ msgstr ""
 "разделите.\n"
 "На пример можете да въведете 2-4 или 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Потребителско име:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Парола:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "брашно, за всякакви цели"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "захар"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "сол"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "черен пипер"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "лед"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "вода"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "олио"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "зехтин"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Непознато"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Рецептата търси себе си като съставка."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Съставката %s ще бъде игнорирана."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Лист за пазаруване за %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "За следните рецепти:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "За следните рецепти:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Избор на кодова таблица"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1657,29 +1616,28 @@ msgstr ""
 "Не може да се определи правилното кодиране. Моля изберете правилното "
 "кодиране от следния списък."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Виж _файл с кодиране"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Внасянето е на пауза"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Спиране на внасянето"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Списък с рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Списък за п_азаруване"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1691,338 +1649,325 @@ msgstr ""
 "  Yasen Pramatarov https://launchpad.net/~yasen\n"
 "  usmiv4o https://launchpad.net/~usmiv4o"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Запазено!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Запазва вашите редакции в %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Извършва се внасяне."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Извършва се изнасяне."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Извършва се изтриване."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Изход от програмата въпреки това?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Не излизай!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Окончателно са изтрити %s от общо %s рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Кошче"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 "Разглеждане, окончателно изтриване или възстановяване на изтрити рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Възстановени рецепти "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Номер %(unit)s от %(title)s които да купите"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Умножаване %s по:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Задаване на %(attributes)s за %(num)s избрана рецепта?"
 msgstr[1] "Задаване на %(attributes)s за %(num)s избрани рецепти?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Всякакви по-рано съществуващи стойности няма да бъдат променени."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 "Новите стойности ще презапишат всякакви по-рано съществуващи стойности."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Тази промяна не може да бъде отменена."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Задаване на стойности за избраните рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Търсене на рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Отваряне на рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Отваряне на избраната рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Изтриване на рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Изтриване на избраните рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Редактиране на рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Отваряне на избраната рецепта в редактора на рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "_Изнасяне на избраните рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Изнасяне на избраните рецепти във файл"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Печат"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "рецепти"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Пакетно _редактиране на рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Нов"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Внасяне на файл"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Внасяне на рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Внасяне на рецепта от файл"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Внасяне на уебстраница"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Внасяне на рецепта от уебстраница"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Изнасяне на вси_чки рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Изнасяне на всички рецепти във файл"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "Из_ход"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Действия"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Отваряне на _кошчето"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Кошче"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Предпочитания"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Приставки"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 "Управление на приставки, осигуряващи допълнителни възможности на Gourmet."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "_Настройки"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Относно"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "Инструмен_ти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Таймер"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Показване на таймера"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Индескс за търсене на рецепти в базата данни."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Изтриване на %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Имате незапазени промени на %s. Сигурен ли си че искаш да го изтриеш?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Изтрито"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Неозаглавено"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Окончателно изтриване на рецептите?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Окончателно изтриване на рецептата?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "сигурен ли си че искаш да изтриеш рецептата <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Сигурен ли си че искаш да изтриеш следните рецепти?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Сигурен ли си че искаш да изтриеш %s избрани рецепти?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Преглед на рецептите"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Изтриване на рецептите"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Списък с рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Рецептата %s е изтрита"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Готово!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Внасяне..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Редактор на ключове на съставки"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Редактирай ключовете за съставки в маса"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "ключ"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "артикул"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Поле"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Стойност"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Брой"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Промяна на всички ключове \"%s\"  на \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2033,12 +1978,12 @@ msgstr ""
 "\"%s\", няма да можете да направите разлика между тях и тези, които в "
 "момента променяте."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Промяна на всички артикули \"%s\" на \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2049,12 +1994,12 @@ msgstr ""
 "\"%s\", няма да можете да направите разлика между тях и тези, които в "
 "момента променяте."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Промени _всички случаи от \"%(unit)s\" на \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2063,13 +2008,13 @@ msgstr ""
 "Промяна на \"%(unit)s\" на \"%(text)s\" само за _съставките \"%(item)s\" с "
 "ключа \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Промяна на  _всички инстанции на \"%(amount)s\" %(unit)s на %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2078,7 +2023,7 @@ msgstr ""
 "Смени \"%(amount)s\" %(unit)s на \"%(text)s\" %(unit)s само _където ключа на "
 "съставките е %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2087,11 +2032,11 @@ msgstr ""
 "Смени \"%(amount)s\" %(unit)s на \"%(text)s\" %(unit)s само където ключа на "
 "съставките е %(key)s _и където артикула е %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Промяна на всички избрани редове?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2100,7 +2045,7 @@ msgstr ""
 "Това действие не може да бъде отменено. Сигурни ли сте, че за всички избрани "
 "%s реда, желаете да зададете следните стойности:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2109,7 +2054,7 @@ msgstr ""
 "\n"
 "Ключ към %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2118,7 +2063,7 @@ msgstr ""
 "\n"
 "Артикул на %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2127,7 +2072,7 @@ msgstr ""
 "\n"
 "Единици към %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2136,8 +2081,8 @@ msgstr ""
 "\n"
 "Количество към %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2146,23 +2091,23 @@ msgstr[1] "%s съставки"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Показва  съставки %(bottom)s към %(top)s от %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Количество"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Ключове за съставки"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2170,11 +2115,11 @@ msgstr ""
 "Ключове за съставки са нормализирани имена на съставки използвани за лист за "
 "пазаруване и калкулации."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Познаване на ключовете"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2182,57 +2127,57 @@ msgstr ""
 "Опитва се да познае най-добрите стойности за всички ключове на съставки "
 "базирани на стойности, които вече са във вашата база от данни."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Редактиране на асоциациите на ключовете"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Редактиране на асоциациите с ключ и други атрибути в база данни"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Редактор на ключове"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "_Eлемент:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Ключ:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>_Промяне на избраните съставки</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Категория за пазаруване"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 "Показване на единиците както са записани за всяка рецепта (без промяна)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Винаги да се показвата американски единици"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Винаги да се показват метрични единици"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Автоматично нагаждане на единиците"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Задаване на предпочитания за показване на _мерните единици"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2240,42 +2185,42 @@ msgstr ""
 "Автоматично конвертиране на единици към предпочитана система (метрична, "
 "имперска и т. н.), където е възможно."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Оценка"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "преди %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Автоматично сливане на рецепти"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Винаги да се използва най-новата рецепта"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Винаги да се използва най-старата рецепта"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Няма"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2283,97 +2228,97 @@ msgstr ""
 "Изглежда, че някои от внесените рецепти се повтарят. Може да ги слеете тук "
 "или да затворите този прозорец и да ги оставите както са си."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Откриване на _повтарящи се рецепти"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Откриване и премахване на повтарящи се рецепти"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Рецепти със сходна информация"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Рецепти със сходни съставки"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Рецепти със сходна информация и съставки"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Повтарящи се рецепти</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "_Включване на рецепти от кошчето"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Показване:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Сливане на _всички дубликати"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Сливане на рецепти</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "_Автоматично сливане"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "За всяка избрана стойност"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Където %(field)s е %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Промяната ще се отрази на %s рецепта"
 msgstr[1] "Промяната ще се отрази на %s рецепти"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Изтриване на %s, където е %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Промяна на %s от %s на \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Тази промяна е необратима.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Редактор на полета"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Едновременно редактиране на полета на множество рецепти"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Изпращане на рецептите по е-поща"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Изпращане по е-поща на всички избрани рецепти (или на всички, ако няма "
@@ -2382,162 +2327,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Наистина ли желаете да изпратите по е-поща всички %s избрани рецепти?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Изпращане"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Не може да конвертира %s в %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Нужна е информацията за плътността."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Прео_бразуване на единици"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Конвертиране на единици"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Конвертор на мерни единици"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>От</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "_Елемент:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Плътност:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "_Информация за плътността"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>До</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Резултат:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Ар (zip, tarball)хив"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Зареждане на zip архив"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Разархивиране на zip архива"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML уебстраница"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Изнасяне на уебстраница"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Изнасяне на рецептите към HTML файлове в папката %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Рецептата е запазена като HTML файл %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Оригинална страница от %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "незадължително"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Изнасяне на уебстраница"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Изнасяне на рецептите към HTML файлове в папката %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Рецептата е запазена като HTML файл %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Обикновен текстов файл"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Изнасяне към текст"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Изнасяне на рецептите в текстов файл %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Рецептата е запазена като обикновен текстов файл %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Голям файл"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Файлът %s е прекалено голям за внасяне"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2549,81 +2482,54 @@ msgstr ""
 "използвайте текстов редактор за да го разделите на по-малки части и опитайте "
 "да ги внесете повторно."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Уеб страница"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Изтегляне на %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Лист за пазаруване за %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Получаване на %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "XML файл на Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML изнасяне"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Изнасяне на рецепти към XML файл на Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Рецептата е запазена в Gourmet XML file %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "XML файл на Gourmet (остарял)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "XML файл на Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Текстов файл на Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Mastercook внасянето завърши."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Подреждане на XML кода"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "XML файл на KRecipe"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2632,275 +2538,296 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Ориентация на страницата"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Разпечатване на рецепти"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (формат за преносими документи)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF експорт"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Експортиране на рецептите към PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Рецептата е запазена като PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Letter"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Портрет"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Обикновен"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "см"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "точки"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Index Card (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Index Card (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Index Card (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Index Card (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Letter"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Index Cards (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Index Cards (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Index Cards (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Пейзаж"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Обикновен"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s колона"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s колона"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s колона"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s колона"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s колона"
 msgstr[1] "%s колони"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Портрет"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Пейзаж"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Размер на хартията"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Ориентация"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Размер на шрифта"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Ориентация на _страницата"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Размер на шрифта"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Поле отляво"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Поле отдясно"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Поле отгоре"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Поле отдолу"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "Настройки на PDF"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster файл"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Изнасяне в MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Изнасяне на рецептите във файл за MealMaster %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Рецептата е запазена като файл за MealMaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "порция"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Голям файл"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Изнасяне като HTML"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Изнасяне на рецепти към XML файл на Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Рецептата е запазена в Gourmet XML file %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Запазване на списък за пазаруване"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Заразване на списък като рецепта"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 "Запазване на текущия списък за пазаруване като рецепта за бъдещо използване"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Меню за %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Меню"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Хранителната информация отразява количество за %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Хранителната информация е сумарна за цялата рецепта"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Липсва хранителна информация за %s съставки: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Всяка хранителна група"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "избор"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "мл"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Конвертиране на единица за %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "За да изчисли хранителната информация, Gourmet се нуждае от помощта ви за "
 "превръщане на \"%s\" в известна на програмата единица."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Промяна на ключа на съставка"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2909,28 +2836,28 @@ msgstr ""
 "Промяна на ключът на съставката от %(old_key)s на %(new_key)s навсякъде или "
 "само в рецептата %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Промяна _навсякъде"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Само в рецептата %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 "Промяна на ключът на съставката от %(old_key)s на %(new_key)s навсякъде?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Промяна на единицата"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2939,11 +2866,11 @@ msgstr ""
 "Промяна на единицата от %(old_unit)s на %(new_unit)s за всички съставки "
 "%(ingkey)s или само в рецептата %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2952,198 +2879,199 @@ msgstr ""
 "база данни съдържа няколко описания на тази храна с различна плътност. Моля "
 "изберете вярната по-долу."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "За да приложи хранителна информация, Gourmet се нуждае от валидно количество "
 "и единица."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Хранене"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Съставка"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Еквивалент на базата данни USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 грама"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Калории"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Общо мазнини"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Наситени мазнини"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Холестерол"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Натрий"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Общо Карбонхидрат"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Диетични влакна"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Захари"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Протеин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Алфа-Каротин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Пепел"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Бета-каротин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Бета Криптоксантин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Калций"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Мед"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Фолиева киселина общо"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Фолиева киселина"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Хранителна фолиева киселина"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Диетични еквиваленти на фолиева киселина"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Желязо"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Ликопен"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Лутеин+Зеаксантин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Магнезий"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Манган"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Ниацин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Калциев пантотенат"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Фосфор"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Сода"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Витамин А"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Ретинол"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Рибофлавин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Селен"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Тиамин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Витамин А (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Витамин А (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Витамин B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Витамин B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Витамин С"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Витамин Е"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Витамин К"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Цинк"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Витамини и минерали"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3152,11 +3080,11 @@ msgstr ""
 "Липсва хранителна информация за\n"
 " %(missing)s на %(total)s съставки"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Дневна стойност"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3165,369 +3093,369 @@ msgstr ""
 "Процент от препоръчителна дневна доза, на база %i калории дневно. Натиснете, "
 "за да редактирате дневния обем калории."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Количество %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Количество за рецепта"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Зареждане на хранителната информация"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Завърши въвеждането на хранителните качества в базата данни!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Получаване на хранителната база данни от zip архива %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Разархивиране %s от zip архив."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Обработка на данните за храненето..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Прочитане на данните за храненео: внесени са %s от %s елемента."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Обработка на информацията за теглото"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Прочитане на данните за тегло на хранителните елементи: внесени са %s of %s "
 "елемента"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Вода"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Килокалории"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "гр протеин"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "гр липид"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "гр пепел"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "гр карбохидрати"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "гр влакна"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "гр захар"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "мг калций"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "мг желязо"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "мг магнезий"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "мг фосфор"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "мг калий"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "мг натрий"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "мг цинк"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "мг селен"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "мг манган"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "микрограм селен"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "мг витамин C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "мг тиарин"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "мг рибофлавин"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "мг риацин"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "мг калциев пантотенат"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "мг витамин B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "микрограма фолиева киселана общо"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "микрограма Фолиева Киселина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "мигрограма хранителна фолиева киселина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "микгрограма диетични еквиваленти на фолиева киселина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Холин, общо"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "микрограма Витамин B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Витамин A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "микрограма Ретинол"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "микрограма Алфа-каротин"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "микрограма Бета-каротин"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "микрограма Бета Криптоксантин"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "микрограма Ликопен"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "микрограма Лутеин+Зеаксантин"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "мг витамин Е"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "мг Витамин К"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "грама Наситена мастна киселина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "грама Мононенаситени мастни киселини"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "грама Полиненаситени мастни киселини"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "мг Холестерол"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Процент откази"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Млечни и яйчени продукти"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Подправки и билки"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Бебешка храна"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Масла и мазнини"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Домашни птици"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Супи и Сосове"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Сосове и Обедни менюта"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Зърнени закуски"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Плодове и плодови сокове"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Свинско"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Зеленчуци"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Ядки и семена"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Говеждо"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Напитки"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Риба и Ракообразни"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Зеленчуци"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Агнешко, телешко и дивеч"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Печени продукти"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Сладки неща"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Зърнени и паста"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Бързи храни"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Основни, предястия и гарнитури"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Снакове"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Национална кухня"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "цялата база данни"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Ключ на съставка"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "USDA ИД номер"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "Описание на USDA елемент"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Еквивалент на плътност"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ИД#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3541,59 +3469,59 @@ msgstr "Инструменти"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Получаване на хранителната информация за текущия списък"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Количество за списъка за пазаруване"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "Редактиране на _хранителната информация"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "звезди"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Експортирани %(number)s от %(total)s рецепти"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Изнасянето завърши."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Включване на рецептата в тялото на e-писмото (добра идея)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Изпращане на е-писмо с рецептата като прикачен HTML файл"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Изпращане на е-писмо с рецептата като прикачен PDF файл"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Опции за електронната поща"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Не питай преди изпращане на e-поща."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Електронното писмо не е изпратено"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3601,235 +3529,189 @@ msgstr ""
 "Не избрахте да включите рецептата в тялото на съобщението или като прикачен "
 "файл."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Запазване на рецептата като..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet не може да изнесе файл от вида \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Изнасяне на рецепти"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "рецепти"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Не може да се изнесе: непознат вид на файла \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Моля уверете се, че при запазване сте избрали вид на файла от падащото меню."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Изнасяне"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Невъзможност за печат: няма активни приставки за печат!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Печат на %s рецепта"
 msgstr[1] "Печат на %s рецепти"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Получаване на файла"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "порция"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Въведете адрес на архива на рецептата или страницата на рецептата."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Въведете адреса на сайта"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Въведете адрес:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Въведете адреса на сайта или архива с резепти."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Адресът не може да се внесе"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet не разполага с приставка за внясане на URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Неуспешна импортация на URL %(url)s от файлов тип%(type)s. Файловете са "
-"запазени във временно местонахождение %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Отваряне на рецепта..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Въведете адреса на сайта"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Промени"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Въведете адреса на сайта или архива с резепти."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Внасяне"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Всички възможни за внасяне файлове"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Внесени са %s рецепти"
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "порция"
 msgstr[1] "порции"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Внесени са %s от общо %s рецепти."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "добре"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Тази уебстраница не е разпозната. Използва се обикновеното внасяне..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Внасянето завърши."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Внасяне на рецепта"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Обработване на съставките"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Обработване на съставките."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Порции"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Подгрупа на съставката"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Скриване"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Текст"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Действия"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Внасяне на рецепта"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Изчистване на _етикетите"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Внасяне на рецепта"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "навсякъде"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "заглавие"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "съставка"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "инструкции"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "бележки"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "национална кухня"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "източник"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Използване на регулярни изрази в търсенето"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Използване на регулярни изрази (разширен език за търсене) в търсенето на "
 "текст"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Търсене при въвеждане (изключете го, ако търсенето е прекалено бавно)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "_Настройки на търсенето"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Показване на разширени настройки за търсене"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3838,104 +3720,98 @@ msgstr[1] "%s рецепти"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "покажи рецепти %(bottom)s до %(top)s от %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s в %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "На пауза"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "Внасяне от KRecipe"
 msgstr[1] "Внасяне от KRecipe"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "На пауза"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Готово"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Грешка: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Грешка"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Грешка %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Проследяване"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "секунда"
 msgstr[1] "секунди"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "мин"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "минута"
 msgstr[1] "минути"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "ч."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "час"
 msgstr[1] "часа"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "ден"
 msgstr[1] "дни"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "седмица"
 msgstr[1] "седмици"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месец"
@@ -3944,7 +3820,7 @@ msgstr[1] "месеца"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "година"
@@ -3956,73 +3832,30 @@ msgstr[1] "години"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " и "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "и"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "до"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "XML файл на Gourmet"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet мениджър на рецепти"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Организиране на рецепти, създаване на списъци за покупки, изчисляване на "
-"хранителна информация и още."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Разглеждане на рецепти"
@@ -4032,7 +3865,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Избиране на рецепти, чрез разглежда по категория, кухня и т.н."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Основни"
@@ -4046,38 +3878,6 @@ msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 "Помощник за откриване и премахване или сливане на повтарящи се рецепти."
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Изпращате по е-поща"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Изпращане на рецепти от Gourmet"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Поддръжка на Zip, Gzip и Tarball"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Внасяне на рецепти от zip и tar архиви"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Внасяне/изнасяне"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4087,6 +3887,18 @@ msgstr "PDF експорт"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Създаване на уеб страници от рецепти."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Внасяне/изнасяне"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4099,14 +3911,6 @@ msgid ""
 msgstr ""
 "IВнасяне и изнасяне на рецепти като XML файлове на Gourmet, подходящи за "
 "резервно копие или обмен с други потребители на програмата."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "Изнасяне като HTML"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Създаване на уеб страници от рецепти."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4169,22 +3973,6 @@ msgstr ""
 "Помага на потребителя да избере и внесе обикновен текст. Предлага и изнасяне "
 "към обикновен текст."
 
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Внасяне на уеб страница"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Внасяне на рецепти от Интернет."
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Внасяне от уеб сайтове"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "IВнасяне от about.com, www.foodnetwork.com и др. подобни"
-
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
 "Assign and edit ingredient keys (unique identifiers for ingredients, used "
@@ -4246,6 +4034,178 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Изпращане на избраната рецепта по е-поща"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "Изпращане на рецепта по _е-поща"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (помощ при портването към Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows инсталатор)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr ""
+#~ "Richard Ferguson (подобрения по интерфейса на конвертора на единици)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (подобрения към изнасянето в Mealmaster формат)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo and splash screen)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Надграждане на базата данни"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "В зависимост от размера на вашата база данни, това може да интензивен "
+#~ "процес, отнемащ известно време. На вашите данни бе създадено резервно "
+#~ "копие, в случай че нещо се обърка."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Поставяне на съставки"
+
+#~ msgid "Import from file"
+#~ msgstr "Внасяне от файл"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Изберете файл съдържащ списъка със съставки."
+
+#~ msgid "No file selected"
+#~ msgstr "Няма избран файл"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Нямаше избран файл, затова действието беше прекъснато"
+
+#~ msgid "_Import file"
+#~ msgstr "_Внасяне на файл"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Внасяне на уебстраница"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Внасяне на рецепта от уебстраница"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Отваряне на _кошчето"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Ар (zip, tarball)хив"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Зареждане на zip архив"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Разархивиране на zip архива"
+
+#~ msgid "Webpage"
+#~ msgstr "Уеб страница"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Изтегляне на %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Лист за пазаруване за %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Получаване на %s"
+
+#~ msgid "ml"
+#~ msgstr "мл"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Получаване на файла"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Въведете адрес на архива на рецептата или страницата на рецептата."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Въведете адрес:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Адресът не може да се внесе"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet не разполага с приставка за внясане на URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Неуспешна импортация на URL %(url)s от файлов тип%(type)s. Файловете са "
+#~ "запазени във временно местонахождение %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr ""
+#~ "Тази уебстраница не е разпозната. Използва се обикновеното внасяне..."
+
+#~ msgid "Import complete."
+#~ msgstr "Внасянето завърши."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Внасяне на рецепта"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Обработване на съставките"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Обработване на съставките."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "XML файл на Gourmet"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet мениджър на рецепти"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Организиране на рецепти, създаване на списъци за покупки, изчисляване на "
+#~ "хранителна информация и още."
+
+#~ msgid "Send to Email"
+#~ msgstr "Изпращате по е-поща"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Изпращане на рецепти от Gourmet"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Поддръжка на Zip, Gzip и Tarball"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Внасяне на рецепти от zip и tar архиви"
+
+#~ msgid "HTML Export"
+#~ msgstr "Изнасяне като HTML"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Създаване на уеб страници от рецепти."
+
+#~ msgid "Webpage import"
+#~ msgstr "Внасяне на уеб страница"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Внасяне на рецепти от Интернет."
+
+#~ msgid "Website Importers"
+#~ msgstr "Внасяне от уеб сайтове"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "IВнасяне от about.com, www.foodnetwork.com и др. подобни"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4380,9 +4340,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "Пор_ции"
-
-#~ msgid "Select File_type"
-#~ msgstr "Избор на _вид файл"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Вече има файл с име %s."

--- a/po/bs.po
+++ b/po/bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-08 08:38+0000\n"
 "Last-Translator: Kenan Hadžiavdić <kenanh@gmail.com>\n"
 "Language-Team: Bosnian <bs@li.org>\n"
@@ -15,511 +15,513 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Novi recept"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Dodaj u listu za _kupovinu"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Datoteka"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recepti"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detalji"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Naslov"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategorija"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recept"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Sastojci"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Izbriši recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Obrisati izabrane recepte"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "%s recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +529,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategorija"
 
@@ -560,285 +562,287 @@ msgstr "Kategorija"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Ključ"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "Jedinica:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
-msgstr ""
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
+msgstr "Recept"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,651 +857,604 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Novi Recept"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Lista za kupovinu"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Unesite Kategoriju"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategorija:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recepti"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Izmijeni"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Pomoć"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recept"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Dodaj u listu za _kupovinu"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Imate nespremljene promjene."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Primijeni promjene prije štampanja?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Primijeni promjene prije štampanja?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instrukcije"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Bilješke"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Kol."
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Jedinica"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Opcionalno"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Pretvoreno: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Nije pretvoreno: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Naziv grupe"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Niste izabrali nijedan recept!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recepti"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "ili"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Ocjena"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Izvor"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Vrijeme Pripreme"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Vrijeme Kuhanja"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Izmjene"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Nevažeći unos."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Nije broj."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pauza"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stop"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Ne pitaj me ovo ponovo."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Da li stvarno hoćeš da ovo uradiš"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "fantastično"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "odlično"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "dobro"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "prolazno"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "slabo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Nije odabrana nijedna datoteka"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1509,112 +1466,111 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "brašno, višenamjensko"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "šećer"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sol"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "crni biber, mljeveni"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "led"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "voda"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "ulje, biljno"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "ulje, maslinovo"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Nepoznat"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Za slijedeće recepte:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Za slijedeće recepte:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Uvoz pauziran"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Zaustavi uvoz"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1623,335 +1579,319 @@ msgstr ""
 "  Sanel https://launchpad.net/~sanel-bih\n"
 "  medina https://launchpad.net/~manija843"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Spremljeno!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Uvoz je u toku."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Izvoz  je u toku."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Pomnoži %s sa:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Obrisati izabrane recepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "Š_tampaj"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "recepti"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Uvoz recepta"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Radnje"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_O"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Alati"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "Š_toperica"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Obriši %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Obrisano"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Bez naslova"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Pogledajte recepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Recepti"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Obriši recept %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Gotovo!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Uvoz..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "ključ"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "stavka"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Polje"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Vrijednost"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Broj"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1959,12 +1899,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1972,78 +1912,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2053,387 +1993,375 @@ msgstr[2] "%s sastojaka"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Količina"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Nijedan"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Pretvarač mjernih jedinica"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML Web Stranica"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "opcionalno"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Uvoz recepta"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Izvoz Teksta"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2441,81 +2369,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML Datoteka"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML Izvoz"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2524,882 +2425,899 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Štampaj Recepte"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF Izvoz"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Pismo"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Portret"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Običan"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Pismo"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Pejzaž"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Običan"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Portret"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Pejzaž"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientacija"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Veličina _Slova"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Veličina _Slova"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Lijeva Margina"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Desna Margina"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Gornja Margina"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Donja Margina"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Datoteka"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "PDF Izvoz"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Promijeni _svugdje"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Samo u receptu %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Sastojak"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 grama"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalorije"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Ukupno Masti"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Holesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Ukupno Karbohidrata"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Šećer"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteini"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Kalcijum"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Bakar"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Željezo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnezijum"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamin A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamin A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamin A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamin C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Cink"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamini i Minerali"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Dnevna Vrijednost"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Količina po receptu"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Voda"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalorije"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g proteina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipid"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g karbohidrata"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g šećera"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg kalcijuma"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg željeza"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnezijuma"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosfora"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg cinka"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg bakra"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg mangana"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamina c"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mikrograma Vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamin A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Kolesterola"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Hrana za Bebe"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Masti i Ulja"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Piletina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Supe i Sosovi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Voće i Voćni Sokovi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Svinjetina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Povrće"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Govedina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Napitci"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Jagnjetina, Teletina i Divljač"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Slatkiši"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3413,288 +3331,243 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "zvjezdice"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Izvoz završen."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Posalji opcije e-mailom"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Nepitaj prije slanja e-maila"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-mail nije poslat"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Spremi recept kao..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Izvezi recepte"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recepti"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Unesi URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Izmjene"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Uveženo %s od %s recepata."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "u redu"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Uvoz završen."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Uvoz recepta"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Obrada sastojaka"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Obrada sastojaka."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "naslov"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "sastojak"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instrukcije"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "bilješke"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "kuhinja"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "izvor"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3704,64 +3577,58 @@ msgstr[2] "%s recepata"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "sekunda"
@@ -3769,11 +3636,11 @@ msgstr[1] "sekunde"
 msgstr[2] "sekundi"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuta"
@@ -3781,32 +3648,32 @@ msgstr[1] "minute"
 msgstr[2] "minuta"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "sati"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "sat"
 msgstr[1] "sata"
 msgstr[2] "sati"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dan"
 msgstr[1] "dana"
 msgstr[2] "dana"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "nedjelja"
 msgstr[1] "nedjelje"
 msgstr[2] "nedjelja"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mjesec"
@@ -3816,7 +3683,7 @@ msgstr[2] "mjeseci"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "godina"
@@ -3829,71 +3696,30 @@ msgstr[2] "godina"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " i "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "i"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "do"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML Datoteka"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Recept"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3903,7 +3729,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3916,38 +3741,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -3955,6 +3748,18 @@ msgstr "PDF Izvoz"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3965,14 +3770,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4026,22 +3823,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4100,6 +3881,25 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "No file selected"
+#~ msgstr "Nije odabrana nijedna datoteka"
+
+#~ msgid "Enter URL:"
+#~ msgstr "Unesi URL:"
+
+#~ msgid "Import complete."
+#~ msgstr "Uvoz završen."
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Obrada sastojaka"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Obrada sastojaka."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML Datoteka"
 
 #~ msgid "Select recipe image"
 #~ msgstr "Izaberi sliku recepta"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2011-04-30 06:55+0000\n"
 "Last-Translator: Lanthera Mobbery <Unknown>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -20,507 +20,510 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nova recepta"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Afegeix a la _llista de la compra"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Unitat de rendiment"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Fitxer"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recepta"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detalls"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gestor de receptes Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Llista de la compra"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Títol"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "categoria"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Rendiment"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Unitat de rendiment"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recepta"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredients"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Elimina la recepta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Obrir la recepta seleccionada"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Obrir recepta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -528,31 +531,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Categoria"
 
@@ -561,286 +564,288 @@ msgstr "Categoria"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Clau"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Temporitzador"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "unitat"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gestor de receptes Gourmet"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -864,211 +869,168 @@ msgstr ""
 "Gourmet pot calcular informació nutricional de les receptes en base als "
 "ingredients."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (assistència en el port a Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (instaŀlador per a Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (millores en la interfície del convertidor d'unitats)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (millores en l'exportació a Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo i pantalla de presentació)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-"Yula Zubritsky (icones de nutrició i d'afegeix a la llista de la compra)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (millores en la "
-"internacionalització, diverses correccions d'errades)"
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Nova recepta"
+
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Detalls"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "La copia de seguretat s'ha creat en %s en cas de que qualsevol cosa vagi "
 "malament. Si aquesta actualizació falla, pots manualment renombrar la teva "
 "copia de seguretat de l'archiu recipes.db per recuperar-lo per poder usar un "
 "Gourmet anterior."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Nova recepta"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Mou a la _llista de la compra"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Llista de la compra"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Ja en teniu (elements del _rebost)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Introduïu la categoria"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Categoria a la qual afegir %s"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Categoria:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Receptes"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Elimina les receptes"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Elimina les receptes de la llista de la compra"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Edita"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "A_juda"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "No heu seleccionat cap recepta. Voleu netejar la llista sencera?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Anomena i desa la llista de la compra..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1077,204 +1039,200 @@ msgstr ""
 "llista de la compra."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recepta"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "Vé_s"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Imprimeix la recepta"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Afegeix a la _llista de la compra"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Teniu canvis sense desar."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Voleu aplicar els canvis abans d'imprimir?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Voleu aplicar els canvis abans d'imprimir?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Opcional)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "No s'ha pogut trobar la recepta %s a la base de dades."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Edita la recepta:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Visualitza la targeta de la recepta"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Trieu un fitxer que contingui la llista d'ingredients."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instruccions"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notes"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Quantitat"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Unitat"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Element"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Opcional"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "La recepta %s (ID %s) no és a la base de dades."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "S'ha convertit: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "No s'ha convertit: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "S'ha canviat la unitat."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1283,233 +1241,231 @@ msgstr ""
 "Heu canviat la unitat de %(item)s de %(old)s a %(new)s. Voleu convertir la "
 "quantitat?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "S'ha convertit %(old_amt)s %(old_unit)s a %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "No s'ha pogut convertir de %(old_unit)s a %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "S'està afegint el grup d'ingredients"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Introduïu un nom per al nou subgrup d'ingredients"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Nom del grup:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "La recepta no es pot cridar a ella mateixa com a ingredient."
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "La recurrència infinita no està permesa en les receptes."
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "No heu seleccionat cap recepta."
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Receptes"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Timbre"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "So d'avís"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "So d'error"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Voleu aturar el temporitzador?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Atura el _temporitzador"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Continua comptant"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "o"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Cuina"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Puntuació"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Font"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Web"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Temps de preparació"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Temps de cocció"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Modificacions"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Entrada no vàlida."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "No és un nombre."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "Fes una _pausa"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Atura"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "No ho tornis a demanar."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "De debò voleu fer-ho?"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "exceŀlent"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "molt bo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "bo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "regular"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "pobre"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Converteix les puntuacions a una escala de 5 estrelles."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Converteix les puntuacions."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Proporcioneu a cadascuna de les puntuacions un equivalent en una escala d'1 "
 "a 5."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Puntuació actual"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Puntuació sobre 5 estrelles"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "No heu seleccionat cap fitxer"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Seleccioneu el _tipus de fitxer"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Com que no heu seleccionat cap fitxer, s'ha canceŀlat l'acció."
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1518,14 +1474,14 @@ msgstr ""
 "Malauradament, no s'ha pogut\n"
 "interpretar la quantitat «%s»."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Les quantitats han de ser nombres (fraccions o decimals), rangs de nombres o "
 "s'han de deixar en blanc."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1545,84 +1501,84 @@ msgstr ""
 "Per a introduir un rang de nombres, empreu «-» per a separar-los.\n"
 "Per exemple, podeu introduir «2-4» or «1 1/2 - 3 1/2».\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "farina, tots els usos"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "sucre"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sal"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "pebre negre, mòlt"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "gel"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "aigua"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "oli, vegetal"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "oli, oliva"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "La recepta es crida a ella mateixa com a ingredient."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "S'ignorarà l'ingredient %s."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Llista de la compra per a %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Per a les següents receptes:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Per a les següents receptes:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Seleccioneu la codificació"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1630,29 +1586,28 @@ msgstr ""
 "No es pot determinar la codificació adequada. Seleccioneu la codificació "
 "correcta de la llista següent:"
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Mira el _fitxer amb aquesta codificació"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "S'ha aturat la importació"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Atura la importació"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Índex de receptes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Llista de la compra"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1665,335 +1620,320 @@ msgstr ""
 "  dgimeno https://launchpad.net/~info-sima-pc\n"
 "  edu https://launchpad.net/~chefuri"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "S'ha desat."
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Desa les edicions a %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Hi ha una importació en procés."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Hi ha una exportació en procés."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Hi ha una eliminació en procés."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Voleu sortir del programa igualment?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "No surtis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "%s de %s receptes esborrades permanentment"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Paperera"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Cercar, eliminar permanentment o recuperar receptes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Receptes recuperades "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multiplica %s per:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Qualsevol valor anterior existent no es cambiarà."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Els nous valors sobreescriuràn qualsevol valor anterior existent."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Aquest cambi no es pot desfer."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Cercar receptes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Obrir recepta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Obrir la recepta seleccionada"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Elimina les receptes seleccionades"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Exportar les receptes seleccionades a un archiu"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "Im_primeix"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "receptes"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nou"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "S'està important la recepta"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s recepta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Tanca"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Accions"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Obrir _Paperera"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Paperera"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Preferències"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Extensions"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Quant a"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "Ei_nes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Temporitzador"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Voleu eliminar %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Teniu canvis per desar a %s. Segur que voleu eliminar-ho?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "S'ha eliminat"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Sense títol"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Voleu eliminar les receptes permanentment?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Voleu eliminar la recepta permanentment?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "De debò voleu eliminar la recepta <i>%s</i>?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "De debò voleu eliminar les receptes següents?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "De debò voleu eliminar les %s receptes seleccionades?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Mira les receptes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "_Índex de receptes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "S'ha eliminat la recepta %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Fet!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "S'està important..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "clau"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "element"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Camp"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Recompte"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Voleu canviar totes les claus «%s» a «%s»?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2003,12 +1943,12 @@ msgstr ""
 "No podreu desfer aquesta acció. Si ja hi ha ingredients amb la clau «%s», no "
 "podreu distingir entre aquests elements i els que esteu canviant ara."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Voleu canviar tots els elements «%s» a «%s»?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2018,12 +1958,12 @@ msgstr ""
 "No podreu desfer aquesta acció. Si ja hi ha ingredients amb l'element «%s», "
 "no podreu distingir entre aquests elements i els que esteu canviant ara."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Canvia _totes les instàncies de «%(unit)s» a «%(text)s»"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2032,13 +1972,13 @@ msgstr ""
 "Canvia «%(unit)s» a «%(text)s» només per als _ingredients «%(item)s» amb "
 "clau «%(key)s»"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Canvia _totes les instàncies de «%(amount)s» %(unit)s a %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2047,7 +1987,7 @@ msgstr ""
 "Canvia «%(amount)s» %(unit)s a %(text)s %(unit)s només _quan la clau de "
 "l'ingredient és %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2056,11 +1996,11 @@ msgstr ""
 "Canvia «%(amount)s» %(unit)s a %(text)s %(unit)s només quan la clau de "
 "l'ingredient és %(key)s _i quan l'element és %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Voleu canviar totes les files seleccionades?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2069,7 +2009,7 @@ msgstr ""
 "Aquesta acció no es podrà desfer. Confirmeu que, per a les %s files "
 "seleccionades, voleu establir els valors següents:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2078,7 +2018,7 @@ msgstr ""
 "\n"
 "Clau a %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2087,7 +2027,7 @@ msgstr ""
 "\n"
 "Element a %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2096,7 +2036,7 @@ msgstr ""
 "\n"
 "Unitat a %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2105,8 +2045,8 @@ msgstr ""
 "\n"
 "Quantitat a %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2115,387 +2055,375 @@ msgstr[1] "%s ingredients"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Es mostren els ingredients %(bottom)s a %(top)s de %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Quantitat"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Categoria de compra"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Cap"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "No es pot convertir %s a %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Es necessita informació de densitat."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Convertidor d'_unitats"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "S'està carregant l'arxiu zip"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "S'està descomprimint l'arxiu zip"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "Pàgina web HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "S'està exportant la pàgina web"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "S'estan exportant les receptes a fitxers HTML en el directori %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "S'ha desat la recepta en el fitxer HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "opcional"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "S'està exportant la pàgina web"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "S'estan exportant les receptes a fitxers HTML en el directori %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "S'ha desat la recepta en el fitxer HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Exportació a text"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2503,81 +2431,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Llista de la compra per a %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "S'està obtenint %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Fitxer XML del Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Exportació a l'XML del Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "S'estan exportant les receptes al fitxer XML del Gormet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "S'ha desat la recepta al fitxer XML del Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "S'ha finalitzat la importació de MasterCook."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "S'està ordenant l'XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2586,274 +2487,295 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Imprimeix les receptes"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Format de Document Portable)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Exportació a PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "S'estan exportant les receptes al fitxer PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "S'ha desat la recepta al fitxer PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Carta"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Retrat"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Senzill"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Targeta d'índex (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Targeta d'índex (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Targeta d'índex (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Targeta d'índex (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Carta"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Targeta d'índex (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Targeta d'índex (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Targeta d'índex (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Apaïsat"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Senzill"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s columna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s columna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s columna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s columna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s columna"
 msgstr[1] "%s columnes"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Retrat"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Apaïsat"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientació"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Mida del _tipus de lletra"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "_Disposició de la pàgina"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Mida del _tipus de lletra"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Marge esquerre"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Marge dret"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Marge superior"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Marge inferior"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "Fitxer MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Exportació a MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "S'estan exportant les receptes al fitxer MealMaster %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "S'ha desat la recepta al fitxer MealMaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "Racions"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Fitxer"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Exportació a PDF"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "S'estan exportant les receptes al fitxer XML del Gormet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "S'ha desat la recepta al fitxer XML del Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Qualsevol grup de menjar"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Converteix la unitat de %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Per tal de calcular la informació nutricional, el Gourmet necessita que "
 "l'ajudeu a convertir «%s» a una unitat que pugui interpretar."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2862,27 +2784,27 @@ msgstr ""
 "Voleu canviar la clau de l'ingredient de %(old_key)s a %(new_key)s a tot "
 "arreu o només a la recepta %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Canvia-ho a tot _arreu"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "Canvia-ho _només a la recepta %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Canvia la unitat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2891,11 +2813,11 @@ msgstr ""
 "Voleu canviar la unitat de %(old_unit)s a %(new_unit)s per a tots els "
 "ingredients %(ingkey)s o només a la recepta %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2904,198 +2826,199 @@ msgstr ""
 "nutricional té diverses descripcions d'aquest menjar amb diferents "
 "densitats. Trieu l'opció correcta a sota."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Per a aplicar la informació nutricional, el Gourmet necessita una quantitat "
 "i una unitat vàlides."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingredient"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Equivalent a la base de dades de l'USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 grams"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Calories"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Greixos totals"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Greixos saturats"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Colesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sodi"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Hidrats de carboni totals"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Fibra dietètica"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Sucres"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteïnes"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-carotè"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Carbonats"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-carotè"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta-criptoxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Calci"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Coure"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Folats totals"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Àcid fòlic"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Folat alimentari"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Equivalents dietètics de folats"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Ferro"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Licopè"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Luteïna i zeaxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnesi"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Manganès"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Àcid pantotènic"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fòsfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potassi"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamina A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Seleni"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamina A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamina A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zinc"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamines i minerals"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3104,11 +3027,11 @@ msgstr ""
 "Falta informació nutricional\n"
 "per a %(missing)s de %(total)s ingredients."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% Valor _diari"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3117,369 +3040,369 @@ msgstr ""
 "Percentatge de valor diari recomanat basat en %i calories per dia. Feu clic "
 "per a editar el nombre de calories per dia."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Quantitat per recepta"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "S'estan carregant les dades nutricionals"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "S'ha completat la importació de la base de dades nutricional."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "S'està recollint la base de dades nutricional de l'arxiu zip %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "S'està extraient %s de l'arxiu zip."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "S'estan analitzant les dades nutricionals..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "S'han llegit les dades nutricionals: s'han importat %s de %s entrades."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "S'estan analitzant les dades de pes..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "S'han llegit les dades de pes per als elements nutricionals: s'han importat "
 "%s de %s entrades"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Aigua"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilocalories"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g. de proteïnes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g. de lípids"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g. de cendres"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g. d'hidrats de carboni"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g. de fibra"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g. de sucre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg. de calci"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg. de ferro"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg. de magnesi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg. de fòsfor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg. de potassi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg. de sodi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg. de zinc"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg. de coure"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg. de manganès"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "µg. de seleni"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg. de vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg. de tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg. de riboflavina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg. de niacina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg. d'àcid pantotènic"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg. de vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "µg. de folats totals"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "µg. d'àcid fòlic"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "µg. de folat alimentari"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "µg. d'equivalents dietètics de folats"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "µg. de vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamina A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamina A (µg. d'equivalents de l'activitat del retinol)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "µg. de retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "µg. d'alfa-carotè"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "µg. de beta-carotè"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "µg. de beta-criptoxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "µg. de licopè"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "µg. de luteïna i zeaxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg. de vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg. de vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g. d'àcids grassos saturats"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g. d'acids grassos monoinsaturats"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g. d'àcids grassos poliinsaturats"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg. de colesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Percentatge de rebuig"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Productes làctics i ous"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Espècies i herbes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Aliments infantils"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Greixos i olis"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Aviram"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Sopes i salses"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Embotits i carns fredes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Cereals d'esmorzar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Fruites i sucs"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Porc"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Verdures i hortalisses"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Fruita seca i llavors"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Bou"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Begudes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Peix i marisc"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Llegums"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Xai, vedella i caça"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Pastisseria"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Dolços"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Cereals i pastes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Menjar ràpid"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Àpats, entrants i guarnicions"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Mossades"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Aliments ètnics"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3493,291 +3416,245 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "estrelles"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "S'han exportat %(number)s receptes de %(total)s"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "S'ha completat l'exportació."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Inclou la recepta en el cos del missatge (sempre és bona idea)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Envia la recepta com a adjunció en HTML"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Opcions del correu"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "No preguntis res abans d'enviar el correu."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "No s'ha enviat el correu."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 "No heu triat incloure la recepta en el cos del missatge ni com a adjunció."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Anomena i desa la recepta..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "El Gourmet no pot exportar un fitxer del tipus «%s»"
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Exporta receptes"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "receptes"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Imprimeix %s recepta"
 msgstr[1] "Imprimeix %s receptes"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "S'està obtenint el fitxer"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Introduïu l'URL de l'arxiu de receptes o del lloc web de receptes."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Introduïu l'URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Introduïu l'URL de l'arxiu de receptes o del lloc web de receptes."
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Modificacions"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Tots els fitxers importables"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "S'han importat %s receptes."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "S'han importat %s de %s receptes."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "Correcte"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-"No s'ha pogut reconèixer aquesta pàgina web. S'emprarà l'importador "
-"genèric..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "S'ha completat la importació."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "S'està important la recepta"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "S'estan processant els ingredients"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "S'estan processant els ingredients."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Racions"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "títol"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingredient"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instruccions"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "notes"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "cuina"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "font"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3786,103 +3663,97 @@ msgstr[1] "%s receptes"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Es mostren les receptes %(bottom)s a %(top)s de %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Fet"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Error"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Error %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "segon"
 msgstr[1] "segons"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min."
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
 msgstr[1] "minuts"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "h."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "hora"
 msgstr[1] "hores"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
 msgstr[1] "dies"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "setmana"
 msgstr[1] "setmanes"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -3891,7 +3762,7 @@ msgstr[1] "mesos"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "any"
@@ -3903,73 +3774,30 @@ msgstr[1] "anys"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " i "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "i"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "a"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Fitxer XML del Gourmet"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gestor de receptes Gourmet"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organitzeu receptes, realitzeu llistes de la compra, calculeu informació "
-"nutricional i molt més."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3979,7 +3807,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3992,38 +3819,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4031,6 +3826,18 @@ msgstr "Exportació a PDF"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -4041,14 +3848,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4102,22 +3901,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4177,6 +3960,95 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (assistència en el port a Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr ""
+#~ "Daniel Folkinshteyn <nanotube@gmail.com> (instaŀlador per a Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr ""
+#~ "Richard Ferguson (millores en la interfície del convertidor d'unitats)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (millores en l'exportació a Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo i pantalla de presentació)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr ""
+#~ "Yula Zubritsky (icones de nutrició i d'afegeix a la llista de la compra)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (millores en la "
+#~ "internacionalització, diverses correccions d'errades)"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Trieu un fitxer que contingui la llista d'ingredients."
+
+#~ msgid "No file selected"
+#~ msgstr "No heu seleccionat cap fitxer"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Com que no heu seleccionat cap fitxer, s'ha canceŀlat l'acció."
+
+#~ msgid "Open _Trash"
+#~ msgstr "Obrir _Paperera"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "S'està carregant l'arxiu zip"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "S'està descomprimint l'arxiu zip"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Llista de la compra per a %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "S'està obtenint %s"
+
+#~ msgid "Retrieving file"
+#~ msgstr "S'està obtenint el fitxer"
+
+#~ msgid "Enter URL:"
+#~ msgstr "Introduïu l'URL:"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr ""
+#~ "No s'ha pogut reconèixer aquesta pàgina web. S'emprarà l'importador "
+#~ "genèric..."
+
+#~ msgid "Import complete."
+#~ msgstr "S'ha completat la importació."
+
+#~ msgid "Processing ingredients"
+#~ msgstr "S'estan processant els ingredients"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "S'estan processant els ingredients."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Fitxer XML del Gourmet"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gestor de receptes Gourmet"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organitzeu receptes, realitzeu llistes de la compra, calculeu informació "
+#~ "nutricional i molt més."
+
 #~ msgid "Select recipe image"
 #~ msgstr "Seleccioneu la imatge de la recepta"
 
@@ -4231,9 +4103,6 @@ msgstr ""
 #~ "Heu demanat tancar una finestra amb un temporitzador actiu. Podeu aturar "
 #~ "el temporitzador o directament tancar la finestra. Si tanqueu la "
 #~ "finestra, tornarà a aparèixer quan el temporitzador arribi a zero."
-
-#~ msgid "Select File_type"
-#~ msgstr "Seleccioneu el _tipus de fitxer"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Ja existeix un fitxer amb el nom %s."

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gourmet 0.6.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2014-12-10 15:31+0100\n"
 "Last-Translator: Michal Hrušecký <Michal@Hrusecky.net>\n"
 "Language-Team: Czech <cs@li.org>\n"
@@ -20,507 +20,510 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Poedit 1.5.5\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Seznam receptů"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nový recept"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Přidat do nákupního _seznamu"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Zobrazit re_cept"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "Hleda_t"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Pište a vyhledávejte recepty"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_v"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Vyhledávat podle jiných kritérií v současných výsledcích."
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Přid_at vzhledávací criterium"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Omezit vyhledávání na:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Vý_sledky hledání"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "Přid_at obrázek"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "Odeb_rat obrázek"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "Zdr_oj:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Hodnocení:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "K_uchyně:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Kategorie:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "Čas na _přípravu:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Čas _vaření:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Web:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Obrázek:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Jednotka výnosu"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (výchozí, uloženo v souboru)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (uloženo v souboru)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (vyžaduje připojení k databázi)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Vyberte databázi"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Zvolte databázový systém který bude Gourmet používat</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "_Databázový systém"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Uživatelské jméno"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Heslo"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Heslo k uživatelskému jménu od databáze."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Soubor"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recept"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Procházet"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "Po_drobnosti"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Správce receptů Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr "Zobrazi_t nástrojovou lištu"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Receptů na stránku:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Seznamový pohled"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Nastavení kartového pohledu</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "Po_uživat zlomky"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Používat zlomky při zobrazení kdykoliv to je možné"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Kartový pohled"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Možnosti nákupního seznamu</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Nákupní Seznam"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Název"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "Náze_v:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Čas _přípravy:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategorie"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "hodnocení"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Výnos"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Jednotka výnosu"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "_Upravit popis"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Doba vaření:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Čas na přípravu:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Kuchyně:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Kategorie:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Web:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Odkaz</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Zdroj:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Hodnocení:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Vynásobte:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Instrukce</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Upravit _instrukce"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Poznámky</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Upravit poz_námky"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recept"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Přísady"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Smazat vybrané recepty"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "O_dstranit recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Otevřít vybraný recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Vybrat recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Vytisknout vybrané recepty"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -528,31 +531,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Hledat _v"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Možnosti vyhledávání</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategorie"
 
@@ -561,285 +564,288 @@ msgstr "Kategorie"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Klíč"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Editor ketegorií"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Vyhledávat podle"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Vyhledávat v průběhu psaní"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Používat regulární výrazy"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Pokročilé vyhledávání"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Přidat ketegorii:"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Časoměřič"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "jednotka"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Nutriční hodnoty"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Správce receptů Gourmet"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
+#, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -866,213 +872,166 @@ msgstr ""
 "* Podporuje přidávání obrázků k receptům.\n"
 "* Dokáže vypočítat nutriční hodnoty receptu na základě přísad.\n"
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (pomoc při portování pro Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Instalátor pro Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (vylepšení rozhraní převodu jednotek)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (vylepšení exportu do Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo and úvodní obrazovka)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-"Yula Zubritsky (nutriční hodnoty a ikony pro přidání do nákupního seznamu)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (vylepšení překladu, různé "
-"opravy)"
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (správce od verze 0.16.0 a nový design "
-"webu)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Vybrat soubor s databází"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Aktualizuje se databáze"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Nový recept"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
 msgstr ""
-"V závislosti na velikosti databáze to může chvíli trvat. Vaše data byla pro "
-"jistotu automaticky zálohována."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Podrobnosti"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Pro jistotu byla vytvořena záloha v %s. V případě problémů s povýšením "
 "zálohu přejmenujte na recipes.db a můžete ji využívat se starým Gourmetem."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Nový recept"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Změnit _kategorii"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Vytvořit novou kategorii"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Změnit kategorii vybrané položky"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Spíž"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Přesuň do nákupního _seznamu"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Dát do s_píže"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Odstranit z nákupního seznamu"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Přesunout vybrané do %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Nákupní _seznam"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Již máte (_položky spíže)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Vložit kategorii"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Kategorie, do které vložit %s"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategorie:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recepty"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "Přid_at položky"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Odstranit recepty"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Odstranit recepty z nákupního seznamu"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Upravit"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Nápověda"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Přidat položky"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Přidat volitelné přísady do nákupního seznamu"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Nebyl vybrát recept. Chcete vyčistit celý seznam?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Uložit nákupní seznam jako..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Označit volitelné přísady"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1081,56 +1040,58 @@ msgstr ""
 "nákupního seznamu."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recept"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Přejít"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Exportovat recept"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Exportovat vybraný recept (uložit do souboru)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "O_dstranit recept"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Odstranit tento recept"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Upravit jednotky při násobení"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Při násobení upravit jednotky pro lepší přehlednost kdekoliv je to možno."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Vytisknout recept"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Přidat do nákupního _seznamu"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Zapomenout volitelné přísady"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1138,150 +1099,144 @@ msgstr ""
 "Před přidáním do nákupního seznamu potvrzovat všechny volitelné přísady (i "
 "dříve potvrzené)"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Exportovat Recept"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Neuložili jste změny."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Použít změny před vytištěním?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Použít změny před vytištěním?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Volitelné)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Recept %s nebyl nalezen v databázi."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Upravit recept:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Uložit změny do databáze"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Zobrazit kartu receptu"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Upravit"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Uložit změny do %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Přidat přísadu"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Přidat skupinu"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Vložit přísady"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importovat ze souboru"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Přidat _recept"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Přídat jiný recept jako přísadu tohoto"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Odstranit"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Nahoru"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Dolů"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Vyberte soubor obsahující seznam přísad"
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Popis"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Pokyny"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Poznámky"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Množ."
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Jednotka"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Položka"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Volitelné"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "V databázi není recept %s (ID %s)."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Převedeno: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Nepřevedeno: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Jednotky byly změněny."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1289,231 +1244,230 @@ msgid ""
 msgstr ""
 "Změněna jednotka %(item)s z %(old)s na %(new)s. Chcete přepočítat množství?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Převedeno z %(old_amt)s %(old_unit)s na %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Nelze převést z %(old_unit)s na %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Přidává se skupina přísad"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Vložit název podskupiny přísad"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Jméno skupiny:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Vybrat recept"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Recept nemůže mít sám sebe jako přísadu!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Nekonečná rekurze není v receptech povolena!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Nevybrali jste žádný recept!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Kolik %(title)s je třeba pro recept?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recepty"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Zvuk budíku"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Varovný signál"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Zvuk při chybě"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Zastavit časoměřič?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Zas_tavit časoměřič"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "Po_kračovat"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Zásuvné moduly"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
-msgstr ""
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
+msgstr "Spravovat zásuvné moduly, které přidávájí do Gourmetu další funkce."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr "Zásuvný modul je vyžadován jiným modulen. Má být přesto deaktivován?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Následující zásuvné moduly vyžadují %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Přesto deaktivovat"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Ponechat zásuvný modul aktivovaný"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "nebo"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Při aktivaci zásuvného modulu nastala chyba."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Při ukončování zásuvného modulu nastala chyba."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Kuchyně"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Hodnocení"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Zdroj"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Web"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Čas přípravy"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Čas vaření"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Úpravy"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Neplatný vstup."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Není číslo."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Přerušit"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "Za_stavit"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Neptat se mě znovu."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Opravdu provést"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "vynikající"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "skvělé"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "dobré"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "ucházející"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "nic moc"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Změnit hodnocení na 5-ti hvězdičkovou stupnici."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Změnit hodnocení"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Prosím, přidělte každému hodnocení ekvivalent ze stupnice 1 až 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Současné hodnocení"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Hodnocení z 5 hvězdiček"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Nebyl vybrán žádný soubor"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Vybrat _typ souboru"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Nebyl vybrán soubor, proto byla akce zrušena"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1522,13 +1476,13 @@ msgstr ""
 "Promiňte, ale nerozumím\n"
 "množství \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Množství musí být číslo (zlomek nebo decimální), číselný rozsah nebo prázdné."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1548,113 +1502,112 @@ msgstr ""
 "Pro zadání rozsahu čísel použijte znaménko \"-\".\n"
 "Např. můžete zadat 2-4 nebo 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Uživatelské jméno"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Heslo"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "hrubá mouka"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "cukr"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sůl"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "mletý černý pepř"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "led"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "voda"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "olej, rostlinný"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "olej, olivový"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Neznámý"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Recept má sám sebe jako přísadu."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Přísada %s bude ignorována."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Nákupní seznam pro %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr "Pro následující recepty:\n"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Pro následující recepty:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Vybrat kodování"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr "Nelze zjistit správné kódování. Vyberte ho, prosím, ručně ze seznamu."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Zobrazit _soubor v kódování"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Import přerušen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Zastavit import"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Seznam _receptů"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Nákupní Sezna_m"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Zbynek MrkvickaZbynek Mrkvicka <zbynek@oachot.cz>\n"
@@ -1667,82 +1620,63 @@ msgstr ""
 "  Radek Šprta https://launchpad.net/~radek-sprta\n"
 "  Zbynek Mrkvicka https://launchpad.net/~zbynek"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Uloženo!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Uložit změny do %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Probíhá import."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Probíhá export."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Probíhá mazání."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Přesto ukončit program?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Neukončovat!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Nevratně odstraněno %s z %s receptů"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Koš"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Prohlížejte, mažte a obnovujte recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Obnovené recepty "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Nakoupit %(unit)s na %(title)s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Násobit %s:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
@@ -1750,252 +1684,258 @@ msgstr[0] "Nastavit %(attributes)s %(num)s vybranému receptu?"
 msgstr[1] "Nastavit %(attributes)s %(num)s vybraným receptům?"
 msgstr[2] "Nastavit %(attributes)s %(num)s vybraným receptům?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Stávající hodnoty zůstanou nezměněny."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Nové hodnoty přepíšou stávající."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Tato změna je nevratná."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Nastavit hodnoty vybraným receptům"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Hledat recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Otevřít recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Otevřít vybraný recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Odstranit recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Odstranit vybrané recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Upravit recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Otevřít vybrané recepty v editoru"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_xportovat vybrané recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Exportuje vybrané recepty do souboru"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Tisk"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "recepty"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Dávkově upravit r_ecepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nový"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Importovat soubor"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Importovat recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Importovat recept ze souboru"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Importovat _stránku"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Importovat recept ze stránky"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Exportovat všechny recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Exportovat všechny recepty do souboru"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Ukončit"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Akce"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "O_tevřít koš"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Koš"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Předvolby"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Zásuvné moduly"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Spravovat zásuvné moduly, které přidávájí do Gourmetu další funkce."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Nastavení"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "O _aplikaci"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "Nás_troje"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "Č_asoměřič"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Zobrazit časoměřič"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Prohledávatelný seznam receptů v databázi."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Odstranit %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Některé změny nejsou v %s uloženy. Opravdu odstranit?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Odstraněno"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Bez názvu"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Trvale odstranit recepty?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Trvale odstranit recept?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Opravdu chcete odstranit recept <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Opravdu chcete odstranit následující recepty?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Opravdu chcete odstranit %s vybraných receptů?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Zobrazit recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Odstranit recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr "Recepty smazány"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Odstraněn recept %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Hotovo!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importuje se..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Editor _klíčů přísad"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Upravit klíče přísad hromadně"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "klíč"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "položka"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Pole"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Hodnota"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Počet"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Změnit všechny klíče \"%s\" na \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2005,12 +1945,12 @@ msgstr ""
 "Tato akce je nevratná. Jestliže existují přísady s klíčem \"%s\", pak "
 "nebudete moci rozlišit mezi původními položkami a těmi, které právě měníte."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Změnit všechny položky \"%s\" na \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2020,12 +1960,12 @@ msgstr ""
 "Tato akce je nevratná. Jestliže existují přísady s položkou \"%s\", pak "
 "nebudete moci rozlišit mezi původními položkami a těmi, které právě měníte."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Změnit všechny výskyty \"%(unit)s\" na \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2034,12 +1974,12 @@ msgstr ""
 "Změnit \"%(unit)s\" na \"%(text)s\" jen pro  _přísady \"%(item)s\" s klíčem "
 "\"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr "Změnit všechny výskyty \"%(amount)s\" %(unit)s na %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2048,7 +1988,7 @@ msgstr ""
 "Změnit \"%(amount)s\" %(unit)s na \"%(text)s\" %(unit)s jen _kde klíč "
 "přísady je %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2057,11 +1997,11 @@ msgstr ""
 "Změnit \"%(amount)s\" %(unit)s na \"%(text)s\" %(unit)s jen kde klíč přísady "
 "je %(key)s _a kde položka je %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Změnit všechny vybrané řádky?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2070,7 +2010,7 @@ msgstr ""
 "Tato akce je nevratná. Opravdu chcete všechny %s vybrané řádky změnit na "
 "následující hodnoty:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2079,7 +2019,7 @@ msgstr ""
 "\n"
 "Klíč na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2088,7 +2028,7 @@ msgstr ""
 "\n"
 "Položku na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2097,7 +2037,7 @@ msgstr ""
 "\n"
 "Jednotku změnit na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2106,8 +2046,8 @@ msgstr ""
 "\n"
 "Množství změnit na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2117,23 +2057,23 @@ msgstr[2] "%s přísad"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Zobrazené  přísady od %(bottom)s do %(top)s z %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Množství"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Klíče přísad"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2141,67 +2081,67 @@ msgstr ""
 "Klíče přísad jsou normalizovaná jména přísad používaná v nákupních listech a "
 "pro výpočty."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Odhadnout klíče"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 "Odhadne nejlepší hodnoty pro klíče přísad na základě hodnot ve vaší databázi"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Upravit asociace klíčů"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Upravit asociace s klíčem a dalšími atributy v databázi"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Nákupní kategorie"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Zobrazovat jednotky jak jsou v receptu (žádná změna)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Vždy zobrazovat americké jednotky"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Vždy zobrazovat metrické jednotky"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Automaticky upravovat jednotky"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Nastavit předvolby zobrazení _jednotek"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2209,42 +2149,42 @@ msgstr ""
 "Automaticky převádět do preferovaných jednotek (metrické, imerialní, aj.) "
 "kdekoliv je to možné."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Hvězdiček"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "před %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Automaticky spojovat recepty"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Vždy použít nejnovější recept"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Vždy použít nejstarší recept"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Nic"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2252,61 +2192,61 @@ msgstr ""
 "Zdá se, že mezi importovanými recepty jsou duplikáty. Můžete je spojit nebo "
 "ponechat jak jsou."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Najít _duplicitní recepty"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Najít a odstranit duplicitní recepty"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Pro každou vybranou hodnotu"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Kde %(field)s je rovno %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
@@ -2314,36 +2254,36 @@ msgstr[0] "Změna se dotkne %s receptu"
 msgstr[1] "Změna se dotkne %s receptů"
 msgstr[2] "Změna se dotkne %s receptů"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Odstranit %s kde se rovná %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Změnit %s z %s na \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Tato změna je nevratná.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Editor polí"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Upravte pole v několika receptech zároveň."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Zaslat recepty emailem"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Odeslat emailem označené recepty (v případě, že nejsou označené žádné, "
@@ -2352,162 +2292,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Opravdu chcete emailem poslat všech %s vybraných receptů?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Ano, odeslat e_mailem"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Nemohu převést %s na %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Doplňte informaci o hustotě."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Převod jednotek"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Spočítat převod jednotek"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Převodník mezi jednotkami"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Od</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Do</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Načítá se zip archiv"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Rozbaluje se zip archiv"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML stránka"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Exportuji stránku"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Exportuji recepty do HTML v adresáři %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Recept byl uložen jako HTML soubor %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Původní stránka z %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "volitelný"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Exportuji stránku"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Exportuji recepty do HTML v adresáři %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Recept byl uložen jako HTML soubor %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Textový soubor"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "_Exportovat"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Recepty jsou exportovány do textového souboru %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Recept uložen jako textový soubor %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Velký soubor"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Soubor %s je na import příliš velký"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2518,81 +2446,54 @@ msgstr ""
 "jste ani importovat nechtěli. Pokud jej skutečně chcete importovat, rozdělte "
 "jej v textovém editoru na menší soubory a zkuste to znova."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Webová stránka"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Stahuje se %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Nákupní seznam pro %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Získává se %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Soubor Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Export Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Recepty jsou exportovány Gourmet XML souboru %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Recept uložen jako Gourmet XML soubor %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "XML soubor Gourmetu (zastaralý)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML soubor"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook textový soubor"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Import z Mastercook byl dokončen."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Čistím XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML soubor"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2601,106 +2502,119 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Rozvržení stránky"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Tisknout recepty"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF export"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Exportuji recepty do PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Recept uložen jako PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Dopis"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Na výšku"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Jednoduchý"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "body"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Kartička (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Kartička (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Kartička (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Kartička (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Dopis"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Právní (216 × 356 mm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Kartička (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Kartička (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Kartička (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Na šířku"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Jednoduchý"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Sloupec"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Sloupec"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Sloupec"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Sloupec"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
@@ -2708,166 +2622,174 @@ msgstr[0] "%s Sloupec"
 msgstr[1] "%s Sloupce"
 msgstr[2] "%s Sloupců"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Na výšku"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Na šířku"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Veliko_st papíru"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientace"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Velikost _písma"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Vzh_led strany"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Velikost _písma"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Levý okraj"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Pravý okraj"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Horní okraj"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Spodní okraj"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "Soubor Mealmaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Exportovat pro Mealmaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Exportuji recepty pro MealMaster %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Recept byl uložen jako soubor Mealmaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "porce"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr "MCB soubor"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr "MCB Export"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Recepty jsou exportovány Gourmet XML souboru %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Recept uložen jako Gourmet XML soubor %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Uložit nákupní seznam"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Uložit seznam jako recept"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Uložit nákupní seznam pro využití do budoucna jako recept"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr "Nabídka %s (%s)"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Nabídka"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Nutriční hodnoty ukazují množství na %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Nutriční hodnoty jsou pro celý recept"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Chybí nutriční hodnoty pro %s přísady: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Jakákoliv skupina jídel"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "výběr"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Převod jednotky pro %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Pro výpočet nutričních hodnot převěďte \"%s\" na jednotku, které Gourmet "
 "rozumí."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Změnit klíč přísady"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2876,27 +2798,27 @@ msgstr ""
 "Změnit klíč přísady z %(old_key)s na %(new_key)s všude nebo jen v receptu "
 "%(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Změnit všud_e"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Jen v receptu %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Chcete změnit klíč přísady z %(old_key)s na %(new_key)s všude?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Změnit jednotku"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2905,11 +2827,11 @@ msgstr ""
 "Změnit jednotku z %(old_unit)s na %(new_unit)s pro všechny přísady "
 "%(ingkey)s nebo jen pro recept %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2917,196 +2839,197 @@ msgstr ""
 "Gourmet znát hustotu. V databázi je pro tuhle přísadu několik hodnot, zvolte "
 "prosím níže tu správnou."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr "Pro nutniční hodnoty je potřeba zadat množství a jednotku."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Nutriční hodnoty"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Přísada"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Ekvivalent databáze USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gramů"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalorie"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Tuk celkem"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Nasycené tuky"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Cholesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sodík"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Karbohydrátů celkem"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Vlákniny"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Cukry"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Protein"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-karoten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Popel"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-karoten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Provitamin A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Vápník"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Měď"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Celkem folátů"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Vitamín B9"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Foláty v jídle"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Potravinové ekvivalenty folátů"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Železo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Lykopen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Lutein+Zeazantin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Hořčík"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Vitamín B3"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Vitamín B5"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Draslík"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamín A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Vitamín A1"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Vitamín B2"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Vitamín B2"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamín A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamín A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamín B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamín B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamín C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamín E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamín K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zinek"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamíny a minerály"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3115,11 +3038,11 @@ msgstr ""
 "Chybějící nutriční hodnoty\n"
 "pro %(missing)s z %(total)s přísad."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Denní Dávka"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3128,367 +3051,367 @@ msgstr ""
 "Procentuální množství doporučené denní dávky založené na %i kalorií denně. "
 "Počet kalorií na den změníte kliknutím."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Množství na %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Množství na recept"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Nahrávám Nutriční data"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Import nutriční databáze ukončen!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Načítá se databáze nutričních hodnot ze zip archívu %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Rozbaluji %s ze zip archívu."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Analyzují se nutriční hodnoty..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Načítání nutričních hodnot: importováno %s z %s záznamů."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Analyzují se hmotnosti..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr "Načítání hmotností pro nutriční hodnoty: importováno %s z %s záznamů."
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Voda"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalorií"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g proteinů"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipidů"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g popela"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g sacharidů"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g vlákniny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g cukrů"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg vápníku"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg železa"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnézia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosforu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg draslíku"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg sodíku"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg zinku"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg mědi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg manganu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mg selenu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamínu C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg vitamínu B1"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg vitamínu B2"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg vitamínu B3"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg vitamínu B5"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamínu B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "Celkem folátů v mikrogramech"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "Vitamínu B9 v mikrogramech"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "Foláty v jídle v mikrogramech"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "Potravinové ekvivalenty folátů v mikrogramech"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Celkem Cholinu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mg vitamínu B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamín A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamín A (ekvivalent retinal v mg"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "Vitamínu A v mikrogramech"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "mg Alfa-karotenu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "mg Beta-karotenu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "mg Provitamínu A"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "mg Lykopenu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "mg Luteinu a Zeazantinu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg vitamínu E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg vitamínu K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g nasycených mastných kyselin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g mononenasycených mastných kyselin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g polynenasycených mastných kyselin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg cholesterolu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Odmítnuto procent"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Mléčné produkty a vejce"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Koření a bylinky"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Jídla pro děti"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Tuky a oleje"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Drůbež"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Polévky a omáčky"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Uzeniny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Cereálie"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Ovoce a ovocné sťávy"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Vepřové"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Zelenina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Ořechy a semínka"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Hovězí"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Nápoje"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Ryby a mušle"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Lustěniny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Jehněčí, telecí a zvěřina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Pečivo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Sladkosti"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Obilniny a těstoviny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Rychlá jídla"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Hlavní chody, předkrmy a přílohy"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Svačiny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Národní jídla"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "celá databáze"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Klíč přísady"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "ID číslo USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA popisek"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Hustota"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3502,107 +3425,107 @@ msgstr "Nástroje"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Nutriční hodnoty pro tento seznam"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Množství do nákupního seznamu"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "hvězdiček"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Exportováno %(number)s z %(total)s receptů"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Export dokončen."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Vložit recept do těla emailu (dobrý nápad)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Poslat recept jako HTML přílohu"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Poslat recept emailem jako PDF přílohu."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Možnosti emailu"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Neptat se před odesláním emailu."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Email nebyl odeslán"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 "Nebyla zvolena možnost vložení receptu do těla zprávy, ani jako příloha."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Uložit recept jako..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet nemůže exportovat typ souboru \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Exportovat recepty"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recepty"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Export se nezdařil: neznámý typ souboru \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "Při ukládání nezapomeňte vybrat typ souboru."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Export"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Tisk se nezdařil: nejsou aktivní žádné tiskové zásuvné moduly!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
@@ -3610,186 +3533,140 @@ msgstr[0] "Vytisknout %s recept"
 msgstr[1] "Vytisknout %s recepty"
 msgstr[2] "Vytisknout %s receptů"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Získává se soubor"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "výnos"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Zadejte URL archívu receptu nebo stránku s receptem."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Zadejte adresu stránky"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Zadejte URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Zadejte adresu stránky či archívu receptu."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Import URL se nezdařil"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet neobsahuje zásuvný modul umožňující importovat URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Nebylo možno importovat URL %(url)s mimetypu %(type)s. Soubor byl dočasně "
-"uložen do %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Otevřít recept..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Zadejte adresu stránky"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Úpravy"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Zadejte adresu stránky či archívu receptu."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Import"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Všechny importovatelné soubory"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Importováno %s receptů."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "porce"
 msgstr[1] "porce"
 msgstr[2] "porcí"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Importováno %s z %s receptů"
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "v pořádku"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Stránka nebyla rozpoznána. Použit základní import ..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Import kompletní."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Importuje se recept"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Zpracovávají se přísady"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Zpracovávají se přísady."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Porce"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Podskupina přísad"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Skrýt"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Text"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Akce"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importovat recept"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Odstranit ští_tky"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Importovat recept"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "kdekoliv"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "název"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "přísady"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instrukce"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "poznámky"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "kuchyně"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "zdroj"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Používat při vyhledávání regulární výrazy"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr "Používat regulární výrazy a další pokročilé vyhledávání"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 "Vyhledává v průběhu psaní (vypněte, pokud je vyhledávání příliš pomalé)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Zobrazit m_ožnosti vyhledávání"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Zobrazí pokročilé možnosti vyhledání"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3799,64 +3676,58 @@ msgstr[2] "%s receptů"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Zobrazuji recepty %(bottom)s až %(top)s z %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s z %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Přerušeno"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Přerušit"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Dokončeno"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Chyba: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Chyba"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Chyba %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Vysledovat zpětně"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "sekunda"
@@ -3864,11 +3735,11 @@ msgstr[1] "sekundy"
 msgstr[2] "sekund"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuta"
@@ -3876,32 +3747,32 @@ msgstr[1] "minuty"
 msgstr[2] "minut"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "hod."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "hodina"
 msgstr[1] "hodiny"
 msgstr[2] "hodin"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "den"
 msgstr[1] "dny"
 msgstr[2] "dní"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "týden"
 msgstr[1] "týdny"
 msgstr[2] "týdnů"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "měsíc"
@@ -3911,7 +3782,7 @@ msgstr[2] "měsíců"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"
@@ -3924,71 +3795,30 @@ msgstr[2] "let"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " a "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "a"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "do"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr "Gourmet"
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr "Správce receptů"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Správa receptů, vytváření nákupních seznamů, výpočet nutričních hodnot a "
-"mnohem více"
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Procházet recepty"
@@ -3998,7 +3828,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -4011,38 +3840,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Importer/Exporter"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4053,6 +3850,18 @@ msgstr "PDF export"
 msgid "Create an epub book from recipes."
 msgstr "Vytvořit stránku s recepty z receptů."
 
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Importer/Exporter"
+
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
 msgstr ""
@@ -4062,14 +3871,6 @@ msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
 msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "HTML Export"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Vytvořit stránku s recepty z receptů."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4122,22 +3923,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4196,6 +3981,158 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (pomoc při portování pro Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Instalátor pro Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (vylepšení rozhraní převodu jednotek)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (vylepšení exportu do Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo and úvodní obrazovka)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr ""
+#~ "Yula Zubritsky (nutriční hodnoty a ikony pro přidání do nákupního seznamu)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (vylepšení překladu, různé "
+#~ "opravy)"
+
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (správce od verze 0.16.0 a nový design "
+#~ "webu)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Aktualizuje se databáze"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "V závislosti na velikosti databáze to může chvíli trvat. Vaše data byla "
+#~ "pro jistotu automaticky zálohována."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Vložit přísady"
+
+#~ msgid "Import from file"
+#~ msgstr "Importovat ze souboru"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Vyberte soubor obsahující seznam přísad"
+
+#~ msgid "No file selected"
+#~ msgstr "Nebyl vybrán žádný soubor"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Nebyl vybrán soubor, proto byla akce zrušena"
+
+#~ msgid "_Import file"
+#~ msgstr "_Importovat soubor"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Importovat _stránku"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Importovat recept ze stránky"
+
+#~ msgid "Open _Trash"
+#~ msgstr "O_tevřít koš"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Načítá se zip archiv"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Rozbaluje se zip archiv"
+
+#~ msgid "Webpage"
+#~ msgstr "Webová stránka"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Stahuje se %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Nákupní seznam pro %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Získává se %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Získává se soubor"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Zadejte URL archívu receptu nebo stránku s receptem."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Zadejte URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Import URL se nezdařil"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet neobsahuje zásuvný modul umožňující importovat URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Nebylo možno importovat URL %(url)s mimetypu %(type)s. Soubor byl dočasně "
+#~ "uložen do %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Stránka nebyla rozpoznána. Použit základní import ..."
+
+#~ msgid "Import complete."
+#~ msgstr "Import kompletní."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Importuje se recept"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Zpracovávají se přísady"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Zpracovávají se přísady."
+
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet"
+
+#~ msgid "Recipe Manager"
+#~ msgstr "Správce receptů"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Správa receptů, vytváření nákupních seznamů, výpočet nutričních hodnot a "
+#~ "mnohem více"
+
+#~ msgid "HTML Export"
+#~ msgstr "HTML Export"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Vytvořit stránku s recepty z receptů."
 
 #~ msgid "Select recipe image"
 #~ msgstr "Vyberte obrázek k receptu"
@@ -4294,9 +4231,6 @@ msgstr ""
 #~ "Pokoušíte se zavřit okno s aktivním časoměřičemi. Můžete zastavit čas "
 #~ "nebo jen zavřít okno. Jestliže jen zavřete okno, objeví se jakmile se "
 #~ "ozve signál."
-
-#~ msgid "Select File_type"
-#~ msgstr "Vybrat _typ souboru"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Soubor s názvem %s již existuje."

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2013-02-19 18:18+0000\n"
 "Last-Translator: Tine Bisballe Nyeng <tine@aasimon.org>\n"
 "Language-Team: Danish <da@li.org>\n"
@@ -20,64 +20,64 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Opskrift Indeks"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Ny Opskrift"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Tilføj til Indkøbsliste"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Vis Opskrift"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Søg efter:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Søg efter opskrifter mens du taster"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_i"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Søg med andre kriterier indenfor de nuværende søgeresultater"
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Tilføj Søgekriterier"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Begræns Søgning til:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Søge_resultater"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Sæt Felter for Valgte Opskrifter"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -85,129 +85,132 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Sæt Opskrift Felter for de valgte "
 "opskrifter</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Tilføj Billede"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Fjern Billede"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "Kilde:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Bedømmelse:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "Verdenskøkken:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Kategori:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "_Forberedningstid"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Til_beredningstid:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Internetside:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Billede:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Udbytte:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Udbytte Enhed"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "Sæt _kun værdier hvor feltet i forvejen er tomt"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Sæt alle værdier for _alle de valgte opskrifter"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (gemt i en lokal fil)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (behøver forbindelse til en database)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Vælg Database"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Vælg Database System som Gourmet skal bruge</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "_Database System"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Vært:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Brugernavn:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Adgangskode:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Adgangskode for dit brugernavn til databasen."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Database _Navn"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Fil"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -215,11 +218,11 @@ msgstr ""
 "Værtsnavn af det system, hvor din databaseserver kører. Hvis din "
 "databaseserver kører på dit lokale system, brug localhost."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -227,11 +230,11 @@ msgstr ""
 "Gem din adgangskode til næste gang. Det betyder at din adgangskode vil blive "
 "gemt usikret i din konfigurationsfil."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "_Gem Adgangskode"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -239,299 +242,300 @@ msgstr ""
 "Navn på databasen, hvor Gourmet skal lagre sine informationer. Gourmet vil "
 "forsøge at oprette databasen, hvis den ikke allerede eksisterer."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "opskrift"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Dit brugernavn til databasen."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Gennemse"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detaljer"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Gourmet Recipe Manager Opsætning"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Opsætning for Indeks Visning</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Vis _Valgmuligheder"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Opskrifter per side:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr "<i>Opsæt hvilke søjler der inkluderes i opskriftindeks-visningen.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Indeks Visning"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Opsætning for Kort Visning</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "_Tillad enheder at skifte når der ganges"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Brug brøkdele"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Brug brøker til visning hvor det er muligt"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr "<i>Fjern emner, som du ikke bruger, fra opskriftskort-interfacet.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Kortvisning"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "Indkøbsliste Præferencer:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Hvad skal Gourmet gøre med Valgfrie Ingredienser når der tilføjes "
 "opskrifter til indkøbslisten?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "_Husk brugervalg som standard"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "_Slet gemte valgfrie ingredienser"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "_Tilføj altid valgfrie ingredienser"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Tilføj aldrig valgfrie ingredienser"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Indkøbsliste"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "portioner"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Titel"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Titel:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "For_beredningstid:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategori"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "bedømmelse"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Udbytte"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Udbytte Enhed"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Butik"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Rediger _beskrivelse"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Tilberedningstid:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Forberedelsestid:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Køkken:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Kategori:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Internetside:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Portioner</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underlige=\"single\" color=\"blue\">Link</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Kilde:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Bedømmelse:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Gang med:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Instruktioner</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Rediger _instruktioner"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Noter</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Rediger _noter"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Opskrift"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Ingredienser</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Rediger _ingredienser"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Tilføj _ingrediens:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredienser"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Tilføj opskrift til indkøbsliste"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Tilføj til _indkøbsliste"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Gå til opskriften i Opskriftskort visning"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Slet valgte opskrift"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Slet Opskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Rediger egenskaber til valgte opskrifter"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "Redigér opskrifter samlet"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "E-mail valgte opskrift"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Åben valgte opskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "_E-Mail opskrift"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Vælg opskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Udskriv valgte opskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "_Udskriv opskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -539,31 +543,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Tilføj til _Spisekammer"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Vis _Valgmuligheder"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Søg _i"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "_Brug regulære udtryk (avanceret søgning)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Søg i mens du _taster"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Søgemuligheder</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategori"
 
@@ -572,292 +576,294 @@ msgstr "Kategori"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Nøgle"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Kategoriredigering"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Søg af"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Søg mens du taster"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Brug regulære udtryk"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Avanceret Søgning"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Tilføj Kategori: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Stopur"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Stopur</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Stopur Slut!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Minuturet vil blive ved med at ringe, indtil du lukker denne dialog eller "
 "nulstiller uret."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Indstil _Stopur: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Nulstil"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Start"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "Lyd"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Bemærk"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Gen_tag alarm indtil jeg slår den fra"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Indstillinger"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Redigér felter i hele databasen</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Redigér dette felt:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "For hver valgte værdi:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "Ingen ændringer"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 "<i>Den nye værdi vil blive tilføjet til slutningen i eksisterende tekst</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Den nye værdi vil erstatte eksisterende værdier</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Felt:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Værdi:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Skift _andet felt"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "Skift værdi til: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "_Slet værdi"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Vælg hvad der svarer til</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>fra USDA databasen</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "_Udskift ingrediens"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>eller</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "_Søg i USDA Ingrediens-databasen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Søg mens du taster"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Vis kun mad i _gruppe"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Søge_resultater:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>Fra:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Beløb:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Enhed:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "element"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "_Udskift enhed"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "_Gem nye enhed"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>Til:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Enhed:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Indtast ernæringsmæssig information for</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Vælg en Massefylde</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Ingrediensnøgle:</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>USDA Ingrediens: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "Redigér _USAD-tilknytning"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Ernæringsmæssig Information</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "Redigér _information"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "_Erneringsmæssig Information"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Massefylde:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "USDA-ækvivalenter:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Brugerdefineret ækvivalent:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "_Tætheds-information"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Kendt Ernæringsmæssig Information</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "_Avanceret Søgning"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Ernæringsmæssige Oplysninger"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "I_gnorer"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet - Opskrifthåndtering"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Copyright (c) 2004,2005,2006,2007,2008,2009,2010,2011 Thomas M. Hinkle. GNU "
 "GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -880,216 +886,168 @@ msgstr ""
 "Gourmet kan du linke billeder til opskrifterne. Gourmet kan også beregne "
 "næringsværdier for en opskrift beregnet på grundlag af ingredienserne."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Windows porting assistance)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (forbedringer til Enhedsomsætterinterface)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (forbedringer til Mealmaster eksport)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo og splash screen)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-"Yula Zubritsky (ikoner til ernæringsinformation og føj-til-indkøbsliste)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (forbedringer til "
-"internationalisering, forskellige fejlrettelser)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Windows version maintenance and website "
-"re-design)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Vælg database-fil"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Opgraderer database"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Ny Opskrift"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Database _Navn"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"Afhængigt af størrelsen på din database kan dette være en intensiv proces "
-"som kan tage lidt tid. Dine data er automatisk blevet sikkerhedskopieret i "
-"tilfælde af, at noget går galt."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Detaljer"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Der er lavet en sikkerhedskopi i %s i tilfælde af at noget går galt. Hvis "
 "denne opgradering fejler kan du manuelt omdøbe din sikkerhedskopi til "
 "recipes.db for at genskabe den til brug med en ældre version af Gourmet."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Ny Opskrift"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Skift _Kategori"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Opret ny kategori"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Ændre kategorien på den i øjeblikket valgte post"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Spisekammer"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Flyt til Indkøbslisten"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Flyt til _spisekammer"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Fjern fra indkøbsseddel"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Flyt valgte post ind i %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Indkøbsliste"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Har allerede (\"Fadeburs\"-emne)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Skriv Kategori"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Kategori at tilføje %s til"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategori:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "Opskrifter"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Tilføj poster:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Fjern opskrift"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Fjern opskrifter fra indkøbsliste"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Rediger"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Hjælp"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Tilføj poster"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Tilføj vilkårlige poster til indkøbsseddel"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Ingen opskrifter er valgt. Vil du tømme hele listen?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Gem indkøbsliste som..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Vælg valgfrie ingredienser"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1098,57 +1056,59 @@ msgstr ""
 "din indkøbsliste."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Opskrift"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Start"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Eksportér opskrift"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Eksportér valgt opskrift (gem som fil)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Slet opskrift"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Slet denne opskrift"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Justér enheder ved multiplicering"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Ændre enheder for at gøre dem mere læselige når det er muligt ved "
 "multiplicering"
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Udskriv opskrift"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Tilføj til Indkøbsliste"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Glem de huskede valgfri ingredienser"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1156,150 +1116,144 @@ msgstr ""
 "Spørg om alle valgfri ingredienser før tilføjelse til indkøbsseddel, selv "
 "dem du før vil have husket."
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Eksportér opskrift"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Du har ikke-gemte ændringer."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Tilføj ændringer før print?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Tilføj ændringer før print?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Valgfri)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Kunne ikke finde opskriften %s i databasen."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Rediger opskrift:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Gem ændringer i databasen"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Vis opskriftskort"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Redigér"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Gem ændringer til %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Tilføj Ingrediens"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Tilføj gruppe"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Indsæt ingredienser"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importér fra fil"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Tilføj _opskrift"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Tilføj en anden opskrift som ingredisens i denne opskrift"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Slet"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Op"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Ned"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Vælg en fil der indeholder din ingrediensliste."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instruktioner"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Noter"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Mgd"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Enhed"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Vare"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Valgfri"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Opskriften %s (ID %s) er ikke i vores database."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Konverterede: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Ikke konverterede: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Ændret enhed."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1308,234 +1262,233 @@ msgstr ""
 "Du har ændret enheden for %(item)s fra %(old)s til %(new)s. Skal mængden "
 "konverteres?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Konverterede %(old_amt)s %(old_unit)s til %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Kunne ikke konvertere fra %(old_unit)s til %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Tilføjer ingrediensgruppe"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Skriv navn for ny undergruppe af ingredienser"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Navn på gruppe:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Vælg opskrift"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Opskriften kan ikke kalde sig selv for en ingrediens!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Dette er ikke tilladt i opskrifter!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Du har ikke valgte nogle opskrifter!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Hvor meget af %(title)s er din opskrift en opfordring til?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Opskrifter"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Ringelyd"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Advarsels lyd"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Fejl lyd"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "top minutur?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Stop _minutur"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Lad minutur fortsætte"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Udvidelser"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Plugins tilføjer ekstra funktionalitet til Gourmet."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Udvidelse er nødvendig for andre udvidelser. Deaktiver udvidelse alligevel?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "De følgende udvidelser kræver %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Deaktivér alligevel"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Behold udvidelse aktiv"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "eller"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Der opstod en fejl ved aktiveringen af udvidelsen."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Der opstod en fejl ved deaktivéringen af udvidelsen."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Køkken"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Bedømmelse"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Kilde"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Hjemmeside"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Forberedelsestid"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Kogetid"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Modifikationer"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Ugyldig indtastning."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Ikke et tal"
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pause"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stop"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Spørg mig ikke om dette igen."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Vil du virkelig gøre dette"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "fremragende"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "storartet"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "god"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "nogenlunde"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "dårlig"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Konvertér bedømmelser til 5-stjerne-skala."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Konvertér bedømmelser."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Anfør venligst en tilsvarende bedømmelse på en skala fra 1 til 5 for hver af "
 "bedømmelserne"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Aktuel Bedømmelse"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Bedømmelse ud over 5 stjerner"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Ingen fil valgt"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Vælg Filtype"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Ingen fil var valgt, så handlingen blev afbrudt"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1544,13 +1497,13 @@ msgstr ""
 "Beklager, jeg forstår ikke\n"
 "mængden \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Mængder skal være tal (brøker eller decimaltal), række af tal eller blank"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1570,86 +1523,86 @@ msgstr ""
 "Til at angive en række af tal, brug \"-\" for at seperere tallene.\n"
 " F.eks. kan du skrive 2-4 eller 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Brugernavn:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Adgangskode:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "mel"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "sukker"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "salt"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "sort peber, kværnet"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "is"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "vand"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "olie, vegetabilsk"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "olie, oliven"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Ukendt"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Opskrift kalder sig selv for en ingrediens."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Ingrediens %s ignoreres."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Indkøbsliste for %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "For følgende opskrifter:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "For følgende opskrifter:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Vælg tegnsæt"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1657,29 +1610,28 @@ msgstr ""
 "Kan ikke bestemme rigtige tegnsæt. Vælg venligst det rigtige tegnsæt fra den "
 "følgende liste."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Se _fil med tegnsæt"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Import på pause"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Stop import"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Opskriftsindeks"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Indkøbliste"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "oversættelsekredit\n"
@@ -1705,336 +1657,323 @@ msgstr ""
 "  sunsmurf https://launchpad.net/~jot12\n"
 "  tolletrolden https://launchpad.net/~henrik-michelsens"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Gemt!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Gem dine ændringer til %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "En import er i gang."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "En eksport er i gang."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "En sletning er i gang."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Afslut program alligevel?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Afslut ikke!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Slettede permanent %s af %s opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Papirkurv"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Navigér, slet permanent eller gendan slettede opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Gendannede opskrifter "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Antal %(unit)s af %(title)s at købe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multiplicér %s med:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Angiv %(attributes)s for %(num)s valgt opskrift?"
 msgstr[1] "Angiv %(attributes)s for %(num)s valgte opskrifter?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Ingen tidligere eksisterende værdier vil blive ændret."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "De nye værdier vil overskrive alle tidligere eksisterende værdier."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Denne ændring kan ikke fortrydes."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Angiv værdier for valgte opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Søg opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Åben opskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Åben valgte opskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Slet opskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Slet valgte opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Rediger opskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Åben valgte værdier i opskrift redigeringsvisning"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_ksportér valgte opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Eksportér valgte opskrifter til en fil"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Udskriv"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "opskrifter"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Batch-_rediger opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Ny"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Importér fil"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Importer opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Importér opskrift fra fil"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Importér _internetside"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s opskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Importér opskrift fra internetside"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Eksportér _alle opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Eksportér alle opskrifter til en fil"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Afslut"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Handlinger"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Åben _Papirkurv"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Papirkurv"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Indstillinger"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Udvidelser"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Administrer udvidelser som tilføjer ekstra funktionalitet til Gourmet."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "I_ndstillinger"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Om"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Værktøjer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "Stopur"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Vis Stopur"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Søgbart indeks med opskrifter i databasen."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Slet %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "Der er ændringer til %s, som ikke er gemt. Er du sikker på du vil slette dem?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Slettet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Unavngivet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Slet opskrifterne permanent?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Slet opskriften permanent?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Er du sikker på at du vil slette opskriften <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Er du sikker på at du vil slette følgende opskrifter?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Er du sikker du på at vil slette følgende %s opskrifter?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Se opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Slet opskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Opskrift Indeks"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Slettet opskrift %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Færdig!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importerer..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Ingrediens _Nøgle Redigering"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Rediger ingrediensnøgler en masse"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "nøgle"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "vare"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Felt"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Værdi"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Tæl"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Ændre alle nøgler \"%s\" til \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2045,12 +1984,12 @@ msgstr ""
 "er ingredienser med nøglen \"%s\", vil du ikke være i stand til at skelne "
 "mellem disse elementer og de elementer, du er ved at ændre nu."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Ændre alle emnerne \"%s\" til \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2061,12 +2000,12 @@ msgstr ""
 "er ingredienser med punktet \"%s\", vil du ikke være i stand til at skelne "
 "mellem disse elementer og de elementer, du er ved at ændre nu."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Ændre _alle forekomster af \"%(unit)s\" til \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2075,13 +2014,13 @@ msgstr ""
 "Ændre \"%(unit)s\" til \"%(text)s\" kun for _ingredienser \"%(item)s\" med "
 "nøglen \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Ændre _alle forekomster af \"%(amount)s\" %(unit)s til %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2090,7 +2029,7 @@ msgstr ""
 "Ændre \"%(amount)s\" %(unit)s til \"%(text)s\" %(unit)s kun _når "
 "ingrediensens nøgle er %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2099,11 +2038,11 @@ msgstr ""
 "Ændre \"%(amount)s\" %(unit)s til \"%(text)s\" %(unit)s kun når "
 "ingrediensens nøgle er %(key)s _og når emnet er %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Skift alle valgte rækker"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2112,7 +2051,7 @@ msgstr ""
 "Denne handling vil ikke kunne fortrydes. Er du sikker på, at du for alle %s "
 "udvalgte rækker, ønsker at indstille følgende værdier:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2121,7 +2060,7 @@ msgstr ""
 "\n"
 "Nøgle til %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2130,7 +2069,7 @@ msgstr ""
 "\n"
 "Emne til %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2139,7 +2078,7 @@ msgstr ""
 "\n"
 "Enhed til %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2148,8 +2087,8 @@ msgstr ""
 "\n"
 "Mængde til %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2158,23 +2097,23 @@ msgstr[1] "%s ingredienser"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Viser ingredienser %(bottom)s til %(top)s af %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Mængde"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Ingrediens Nøgler"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2182,11 +2121,11 @@ msgstr ""
 "Ingrediens Nøgler er normaliserede navne på ingredienser som bruges til "
 "indkøbssedler og beregninger."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Gæt nøgler"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2194,56 +2133,56 @@ msgstr ""
 "Gæt bedste værdier for alle ingrediens nøgler baseret på de værdier som "
 "allerede findes i din database."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Rediger Nøgle Sammenslutninger"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Rediger sammenslutninger med nøgle og andre attributter i databasen"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Nøgleredigering"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "_Genstand:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Nøgle:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>_Udskift valgte ingredienser</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Handlekategori"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Vis enheder som de er skrevet for hver opskrift (ingen ændring)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Vis altid U.S. enheder"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Vis altid metriske enheder"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Justér automatisk enheder"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Angiv _enhedens visningsindstillinger"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2251,42 +2190,42 @@ msgstr ""
 "Konverter automatisk enheder til foretrukne system (metrisk, empirisk, osv.) "
 "hvor det er muligt."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Stjerner"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s siden"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Auto-Flet opskrifter"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Brug altid nyeste opskrift"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Brug altid ældste opskrift"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Ingen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2294,97 +2233,97 @@ msgstr ""
 "Nogle af de importerede opskrifter ligner duplikater. Du kan flette dem her, "
 "eller lukke denne dialog og lade dem være som de er."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Find_duplikat opskrifter"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Find og fjern duplikat opskrifter"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Opskrifter med ligende opskriftinformation"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Opskrifter med ligende opskrifter"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Opskrifter med ens opskriftsinformationer og ingredienser"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Kopier Opskrifter</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "_Inkludér opskrifter i papirkurv"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Viser:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Sammenknyt _alle kopier"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Sammenknyt opskrifter</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "_Auto-sammenknyt"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "For hver valgte værdi"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Hvor %(field)s er %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Ændring vil påvirke %s opskrift"
 msgstr[1] "Ændring vil påvirke %s opskrifter"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Slet %s hvor den er %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Ændre %s fra %s til \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Denne ændring er ikke reversibel.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Felt Redigering"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Rediger felter på flere opskrifter på én gang."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "E-mail opskrifter"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "E-mail valgte opskrifter (eller alle opskrifter hvis ingen opskrifter er "
@@ -2393,162 +2332,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Ønsker du at e-maile alle %s valgte opskrifter?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Ja, e-_mail dem"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Kan ikke konvertere %s til %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Behøver densitetsinformation."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Enhedskonvertering"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Beregn enhedskonverteringer"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Enhedskonvertering"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Fra</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "Gen_stande:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Tæthed:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Tætheds _Information"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Til</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Resultat:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Arkivér (zip, tarball)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Indlæser zip-arkiv"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Udpakker zip-arkiv"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML Webside"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Eksporterer webside"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Eksporterer opskrifter til HTML-filer i %(file)s biblioteket"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Opskrift gemt som HTML-fil %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Original Side fra %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "valgfrit"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Eksporterer webside"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Eksporterer opskrifter til HTML-filer i %(file)s biblioteket"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Opskrift gemt som HTML-fil %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Almindelig Tekstfil"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Teksteksport"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Eksportering af opskrifter til tesktfil %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Opskriften blev gemt som almindelig tekstfil %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Stor Fil"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Fil %s er for stor til at importere"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2560,81 +2487,54 @@ msgstr ""
 "fil, skal du bruge en teksteditor til at dele den op i mindre filer og prøve "
 "at importere igen."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Webside"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Henter %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Indkøbsliste for %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Modtager %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML-fil"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML-eksport"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Eksporterer opskrifter til Gourmet XML-fil %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Opskrift gemt i Gourmet XML-fil %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML-fil (Forældet)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML-fil"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook Tekstfil"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Mastercook import færdig."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Renser XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML-fil"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2643,274 +2543,295 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Sideopsætning"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Print Opskrifter"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF Eksport"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Eksporterer opskrifter til PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Opskrift gemt som PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Brev"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Stående"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Almindelig"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "punkter"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Indekskort (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Indekskort (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Indekskort(5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Indekskort (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Brev"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Lovligt"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Indekskort (9x13 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Indekskort (10x15 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Indekskort (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Liggende"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Almindelig"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Kolonne"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Kolonne"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Kolonne"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Kolonne"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s Kolonne"
 msgstr[1] "%s Kolonner"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Stående"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Liggende"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Papir _Størrelse"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientering"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Skrift størrelse"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Side _Layout"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Skrift størrelse"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Venstre margen"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Højre margen"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Top margen"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Bund margen"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "PDF Muligheder"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster-fil"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster Eksport"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Eksporterer opskrifter til MealMaster(tm)-fil %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Opskrift gemt som MealMaster(tm)-fil %(file)s."
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "portion"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Stor Fil"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "HTML Eksport"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Eksporterer opskrifter til Gourmet XML-fil %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Opskrift gemt i Gourmet XML-fil %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Indkøbsseddel Gemmer"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Gem Liste som Opskrift"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Gem nuværende indkøbsseddel som en opskrift til fremtidig brug"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Menu for %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Ernæringsmæssige oplysninger afspejler mængde pr. %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Ernæringsmæssige oplysninger afspejler mængden for hele opskriften"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Ernæringsmæssige oplysninger savnes for %s ingredienser: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Alle mad grupper"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "valgt"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Konverterer enhed for %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "For at kunne beregne ernæringsoplysninger så har Gourmet brug for hjælp til "
 "ændre \"%s\" til en enhed den kender."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Ændre ingrediensnøgle"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2919,27 +2840,27 @@ msgstr ""
 "Ændr ingrediens nøgle fra %(old_key)s til %(new_key)s overalt, eller blot i "
 "opskriften %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Udskift _overalt"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Kun i opskrift %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Ændre ingrediensnøgle fra %(old_key)s til %(new_key)s over alt?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Skift enhed"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2948,211 +2869,212 @@ msgstr ""
 "Ændr enheden fra %(old_unit)s til %(new_unit)s for alle ingredienser "
 "%(ingkey)s eller blot i opskriften %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
-"For at kunne udregne næringsinformation for \"%(amount)s %(unit)s %(ingkey)s"
-"\", skal Gourmet kende densiteten. Vores næringsdatabase har flere "
+"For at kunne udregne næringsinformation for \"%(amount)s %(unit)s "
+"%(ingkey)s\", skal Gourmet kende densiteten. Vores næringsdatabase har flere "
 "beskrivelser af denne madvare, med forskellige densiteter. Vælg venligst den "
 "korrekte herunder."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "For at anvende ernæringsmæssige oplysninger, har Gourmet brug for en gyldig "
 "størrelse og enhed."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Ernæring"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingrediens"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Database ækvivalent fra USDA (U.S. Department of Agriculture)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gram"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalorier"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Total mængde fedt"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Mættet fedt"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Kolesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Natrium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Total Kulhydrater"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Kostfibre"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Sukker"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Protein"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-catoten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Aske"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Betacaroten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Calcium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Kobber"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Total Folat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Folinsyre"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Madfolat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Diætale folin ekvilalente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Jern"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Lycopen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Lutein + Zeaxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacin (B3 vitamin)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Pantothensyre"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Kalium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "A vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol (A vitamin)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavin (B2 vitamin)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamin (B1 vitamin)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "A-vitamin (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "A-vitamin (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamin C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zink"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitaminer og mineraler"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3161,11 +3083,11 @@ msgstr ""
 "Mangler information om næringsværdi\n"
 "for %(missing)s af %(total)s ingredienser."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Daglig indtagelse"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3174,368 +3096,368 @@ msgstr ""
 "Procent af anbefalet daglig indtagelse baseret på %i kalorier pr. dag. Klik "
 "for at redigere antal kalorier pr. dag."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Mængde pr. %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Mængde per opskrift"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Indlæser næringsværdier"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Import af ernæringsinformation udført!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Henter næringsdata fra zip-arkiv %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Udpakker %s fra zip-arkiv."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Fortolker ernæringsinformation..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Læser ernæringsinformation: har importeret %s af %s emner."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Fortolker vægtdata..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Indlæser vægt data for ernæringsmæssige emner: Importeret %s af %s poster"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Vand"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalorier"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g protein"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g Lipid (fedtstof)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g aske"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "gram kulhydrat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "gram fiber"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "gram sukker"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg kalcium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg jern"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg kalium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg natrium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg zink"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg kobber"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "microgram selen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamin c"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg Tiamin (B1 vitamin)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg Riboflavin (B2 vitamin)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg Niacin (B3 vitamin)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg Pantothensyre (B5 vitamin)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg B6 vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "µg Folat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "µ Folinsyre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "µg Madfolat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "µg Diætere folatækvilalenter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Cholin, total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mg B12 vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamin A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "A vitamin (µg anbefalet daglig indtagelse)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "µg retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "µg Alpha-caroten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "µg Beta-caroten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "µg Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "µg Lycopen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "µg Lutein + Zeaxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg E vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g Mættede fedtsyrer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g Enkeltmættede fedtsyrer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g Flerumættede fedtsyrer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg kolesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Procent afvis"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Mejeri og æggeprodukter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Krydderier og urter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Babymad"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Fedt og olier"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Fjerkræ"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Supper og sovser"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Pølser og frokostkød"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Morgenmadsprodukter (korn)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Frugter og frugtjuicer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Svinekød"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Grøntsager"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Nødder og frø"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Oksekød"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Drikkevarer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Fisk og Skaldyr"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Bælgplanter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Lam, Kalv og Vildt"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Bagede produkter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Slik"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Korn og pasta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Hurtig mad"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Hovedretter, forretter og småretter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Snacks"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Etnisk mad"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "hele databasen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Ingrediens Nøgle"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "USDA ID Nummer"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA Element Beskrivelse"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Massefylde Ækvivalent"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3549,291 +3471,245 @@ msgstr "Værktøjer"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Få ernæringsmæssig information for nuværende liste"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Mængde for Indkøbsseddel"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "Redigér _ernærings info"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "stjerner"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Eksporterede %(number)s af %(total)s opskrifter"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Eksport fuldført."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Inkludér opskrift i e-mail (altid en god idé)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "E-mail opskrift som vedhæftet html-fil"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "E-mail opskrift som vedhæftet pdf-fil"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "E-mail-indstillinger"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Spørg mig ikke før e-mail sendes."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-mail ikke sendt"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 "Du har valgt ikke at inkludere opskriften i beskeden eller som vedhæftet fil."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Gem opskrift som..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet kan ikke eksportere fil af typen \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Eksportér opskrifter"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "opskrifter"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Ude af stand til at eksportere: ukendt filtype \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "Sørg for at vælge en filtype fra rullemenuen når der gemmes."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Eksportér"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Ude af stand til at udskrive: ingen plugins til udskrivning er aktive!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Print %s opskrift"
 msgstr[1] "Print %s opskrifter"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Modtager fil"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "udbytte"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Indtast URL til  et opskrift-arkiv eller opskrift-internetside."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Indtast internetadresse"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Indtast URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Indtast adressen på en hjemmside eller opskrift arkiv"
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Ude af stand til at importere URL"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet har ikke et plugin der er i stand til at importere URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Ude af stand til at importere URL %(url)s af mimetype %(type)s. Filen er "
-"gemt til midlertidig placering %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Åben opskrift..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Indtast internetadresse"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Modifikationer"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Indtast adressen på en hjemmside eller opskrift arkiv"
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importér"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Alle importérbare filer"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Importerede %s opskrift"
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "portion"
 msgstr[1] "portioner"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Importerede %s af %s opskrifter"
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "okay"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Kan ikke genkende denne internetside. Bruger generel import-metode..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Importering færdig."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Importerer opskrift"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Bearbejder ingredienser"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Bearbejder ingredienser."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Portioner"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Ingrediensundergruppe"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Skjul"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Tekst"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Handlinger"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importér opskrift"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Ryd _mærker"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Importer opskrifter"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "overalt"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "tittel"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrediens"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instruktioner"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "Noter"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "køkken"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "kilde"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Brug regulære udtryk i søgning"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr "Brug regulære udtryk (et avanceret søgesprog) i tekstsøgning"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Søg imens du taster (slå fra hvis søgning er for langsom)"
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Vis Søge_indstillinger"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Vis avancerede søgeindstillinger"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3842,104 +3718,98 @@ msgstr[1] "%s opskrifter"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Viser opskrifter %(bottom)s til %(top)s af %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s i %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "På pause"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "KRecipe importering"
 msgstr[1] "KRecipe importering"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pause"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Udført"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Fejl: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Fejl"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Fejl %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Sporing"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "sekund"
 msgstr[1] "sekunder"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min."
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
 msgstr[1] "minutter"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "tim."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "time"
 msgstr[1] "timer"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
 msgstr[1] "dage"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "uge"
 msgstr[1] "uger"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "måned"
@@ -3948,7 +3818,7 @@ msgstr[1] "måneder"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "år"
@@ -3960,73 +3830,30 @@ msgstr[1] "år"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " og "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "og"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "til"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML-fil"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet - Opskrifthåndtering"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organisér opskrifter, lav indkøbslister, udregn ernæringsmæssig information "
-"og mere."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Gennemse Opskrifter"
@@ -4036,7 +3863,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Hjem"
@@ -4051,38 +3877,6 @@ msgstr ""
 "En guide til finde og fjerne eller sammenslå dobbelte forekomster af "
 "opskrifter."
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Send til Email"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Email opskrifter fra Gourmet"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Zip, Gzip og Tarball understøttelse"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Importér opskrifter fra zip og tar arkiver"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Importér/Eksportér"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4092,6 +3886,18 @@ msgstr "PDF Eksport"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Opret opskrift-webside fra opskrifter."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Importér/Eksportér"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4104,14 +3910,6 @@ msgid ""
 msgstr ""
 "Importér og Eksportér opskrifter som Gourmet XML filer, brugbare til backup "
 "eller udveksling med andre Gourmet brugere."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "HTML Eksport"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Opret opskrift-webside fra opskrifter."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4173,22 +3971,6 @@ msgid ""
 msgstr ""
 "Hjælper brugeren med at markere og importere ren tekst. Giver også mulighed "
 "for eksport af ren tekst."
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Internetside importering"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Importér opskrifter fra internettet."
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Hjemmeside-importværktøjer"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Importværktøjer til about.com, www.foodnetwork.com, med flere"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4255,6 +4037,196 @@ msgstr ""
 "Slå denne til, hvis dine UTF-16 tekstfiler ikke bliver importeret rent ind i "
 "Gourmet. Slå fra, hvis du aldrig bruger UTF-16 og du konstant bliver "
 "irriteret over \"Kodning\"-dialogen når du importerer filer."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "E-mail valgte opskrift"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "_E-Mail opskrift"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Windows porting assistance)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (forbedringer til Enhedsomsætterinterface)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (forbedringer til Mealmaster eksport)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo og splash screen)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr ""
+#~ "Yula Zubritsky (ikoner til ernæringsinformation og føj-til-indkøbsliste)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (forbedringer til "
+#~ "internationalisering, forskellige fejlrettelser)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Windows version maintenance and "
+#~ "website re-design)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Opgraderer database"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Afhængigt af størrelsen på din database kan dette være en intensiv proces "
+#~ "som kan tage lidt tid. Dine data er automatisk blevet sikkerhedskopieret "
+#~ "i tilfælde af, at noget går galt."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Indsæt ingredienser"
+
+#~ msgid "Import from file"
+#~ msgstr "Importér fra fil"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Vælg en fil der indeholder din ingrediensliste."
+
+#~ msgid "No file selected"
+#~ msgstr "Ingen fil valgt"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Ingen fil var valgt, så handlingen blev afbrudt"
+
+#~ msgid "_Import file"
+#~ msgstr "_Importér fil"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Importér _internetside"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Importér opskrift fra internetside"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Åben _Papirkurv"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Arkivér (zip, tarball)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Indlæser zip-arkiv"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Udpakker zip-arkiv"
+
+#~ msgid "Webpage"
+#~ msgstr "Webside"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Henter %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Indkøbsliste for %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Modtager %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Modtager fil"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Indtast URL til  et opskrift-arkiv eller opskrift-internetside."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Indtast URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Ude af stand til at importere URL"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet har ikke et plugin der er i stand til at importere URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Ude af stand til at importere URL %(url)s af mimetype %(type)s. Filen er "
+#~ "gemt til midlertidig placering %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr ""
+#~ "Kan ikke genkende denne internetside. Bruger generel import-metode..."
+
+#~ msgid "Import complete."
+#~ msgstr "Importering færdig."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Importerer opskrift"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Bearbejder ingredienser"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Bearbejder ingredienser."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML-fil"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet - Opskrifthåndtering"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organisér opskrifter, lav indkøbslister, udregn ernæringsmæssig "
+#~ "information og mere."
+
+#~ msgid "Send to Email"
+#~ msgstr "Send til Email"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Email opskrifter fra Gourmet"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Zip, Gzip og Tarball understøttelse"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Importér opskrifter fra zip og tar arkiver"
+
+#~ msgid "HTML Export"
+#~ msgstr "HTML Eksport"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Opret opskrift-webside fra opskrifter."
+
+#~ msgid "Webpage import"
+#~ msgstr "Internetside importering"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Importér opskrifter fra internettet."
+
+#~ msgid "Website Importers"
+#~ msgstr "Hjemmeside-importværktøjer"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Importværktøjer til about.com, www.foodnetwork.com, med flere"
 
 #~ msgid "_Raw recipe:"
 #~ msgstr "_Rå opskrift:"
@@ -4378,9 +4350,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "_Portioner"
-
-#~ msgid "Select File_type"
-#~ msgstr "Vælg Filtype"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "En fil ved navn %s findes allerede."

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gourmet Recipe Manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2014-05-15 12:33+0000\n"
 "Last-Translator: Jessica Eccles <jgit@gringer.org>\n"
 "Language-Team: German <de@li.org>\n"
@@ -20,64 +20,64 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Rezept-Index"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Neues Rezept"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Zur _Einkaufsliste hinzufügen"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "_Rezept anzeigen"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Suche nach:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Nach Rezepten während der Eingabe suchen"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_in"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Das Suchergebnis mit anderen Suchkriterien durchsuchen"
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Suchkriterium h_inzufügen"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Suche wird begrenzt auf:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "_Suchergebnisse"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Felder für ausgewählte Rezepte festlegen"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -85,129 +85,132 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Rezeptfelder für ausgewählte Rezepte "
 "festlegen</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Bild hinzufügen"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Bild entfernen"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "_Quelle:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "Bewe_rtung:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "K_üche"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Kategorie:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "_Zubereitungszeit:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "_Kochzeit:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Webseite:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Bild:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Portionen:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Einhe_it des Ertrags"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "Werte n_ur setzen, wenn das Feld derzeit leer ist"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Alle Werte für _alle gewählten Rezepte festlegen"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (in lokaler Datei gespeichert)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (in lokaler Datei gespeichert)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (erfordert Verbindung zu einer Datenbank)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Wählen Sie eine Datenbank aus"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Wählen Sie ein Datenbanksystem zur Benutzung mit Gourmet</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "_Datenbanksystem"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Rechner"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Benutzername:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Passwort:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Passwort für Ihren Benutzer auf der Datenbank."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Datenbank_name:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Datei"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -215,11 +218,11 @@ msgstr ""
 "Rechnername des Systems, wo der Datenbankserver läuft. Läuft Ihr "
 "Datenbankserver auf Ihrem lokalen Rechner, nehmen Sie localhost."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -227,11 +230,11 @@ msgstr ""
 "Das Passwort wird für zukünftige Zugriffe abgespeichert. Achtung: Das "
 "Passwort wird unverschlüsselt in der Konfigurationsdatei abgelegt."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "Passwort _speichern"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -239,301 +242,302 @@ msgstr ""
 "Name der Datenbank, wo Gourmet seine Informationen speichern soll. Gourmet "
 "wird versuchen, diese Datenbank anzulegen, falls sie nicht existiert."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "Rezept"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Ihr Benutzername auf der Datenbank."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Durchblättern"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Details"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Gourmet Rezept Manager Einstellungen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Index-Ansicht Einstellungen</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Zeige _Optionen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Rezepte pro Seite"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 "<i>Stellen Sie ein, welche Spalten im Rezept Index angezeigt werden sollen.</"
 "i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Index Ansicht"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Ansicht Karten Einstellungen</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "Bei Multiplikation Einheiten_wechsel erlauben"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Nutze Brüche"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Wenn möglich Brüche zur Darstellung benutzen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr "<i>Remove items you don't use from the Recipe Card interface.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Kartenansicht"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Einkaufsliste Einstellungen</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Was soll Gourmet mit optionalen Zutaten tun, wenn Rezepte zur "
 "Einkaufsliste hinzugefügt werden?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "_Fragen, ob optionale Zutaten hinzugefügt werden sollen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "_Speichere Einstellungen des Benutzers standardmäßig"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "_Lösche die gemerkten optionalen Zutaten"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "Optionale Zutaten _immer hinzufügen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "Optionale Zutaten _niemals hinzufügen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Einkaufsliste"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "Portionen"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Titel"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Bezeichnung:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Zubereitungs_zeit:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "Kategorie"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "Bewertung"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Ertrag"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Einheit des Ertrags"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Einkauf"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "_Beschreibung editieren"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Garzeit:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Zubereitungszeit:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Küche:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Kategorie:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Webseite:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "_Ergibt Portionen:"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Link</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Quelle:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Bewertung:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Multipliziere mit:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Anweisungen</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "_Anleitung editieren"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Notizen</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "A_nmerkungen editieren"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Rezept"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Zutaten</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "_Zutaten editieren"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Zutat h_inzufügen:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Zutaten"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Rezept zur Einkaufsliste hinzufügen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Zu _Einkaufsliste hinzufügen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Rezept in Rezeptkarten-Ansicht aufrufen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Ausgewähltes Rezept löschen"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "Rezept _löschen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Attribute zu ausgewählten Rezepten bearbeiten"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "_Stapelverarbeitung von Rezepten"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Ausgewähltes Rezept per E-Mail versenden"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Ausgewähltes Rezept öffnen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "Rezept per E-_Mail versenden"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Rezept auswählen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Ausgewähltes Rezept drucken"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "Rezept _drucken"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -545,31 +549,31 @@ msgstr ""
 "es wird nicht ohne Ihr Zutun beim Speichern oder Drucken auf der "
 "Einkaufsliste erscheinen."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Zu _Speisekammer hinzufügen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Zeige _Optionen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Suche _in"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "Reguläre Ausdrücke verwenden (eine erweiterte Suchmethode)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Suchen während der _Eingabe"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Sucheinstellungen:</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategorie"
 
@@ -578,291 +582,293 @@ msgstr "Kategorie"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Stichwort"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Kategorie-Editor"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Suchen nach"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Suchen während der Eingabe"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Reguläre Ausdrücke benutzen"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Erweiterte Suche"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Kategorie hinzufügen: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Kurzzeitwecker"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Stoppuhr</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Zeit abgelaufen!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Alarmsignal wird ausgelöst, bis dieser Dialog geschlossen oder die Uhr "
 "zurückgesetzt wird."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Uhr s_tellen: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "Zu_rücksetzen"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Start"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "T_on"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Notiz"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Alarm wiederholen, bis er _abgeschaltet wird"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Einstellungen"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Bearbeite Felder in gesamter Datenbank</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Feld zu b_earbeiten:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Für jeden gewählten Wert:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "Wert unverändert _lassen"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>Neuer Wert wird hinter existierenden Text angefügt</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Neuer Wert wird existierenden Wert ersetzen</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Feld:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Wert:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Bearbeite _anderes Feld:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "_Wert ändern zu: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "Wert l_öschen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Wähle Entsprechung von</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>aus USDA Datenbank</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "Zutat _ändern"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>oder</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "Durch_suche USDA Zutaten Datenbank:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "beim _Tippen suchen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Zeige nur Essen in _Gruppe:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Suche_rgebnisse:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>Von:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Menge:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Einheit:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "Einheit"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "_Einheit ändern"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "Neue Einheit _speichern"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>Zu:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Einheit:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Nährwertinformationen eingeben für</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Wählen Sie eine Dichte</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Zutaten-Schlüssel: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>USDA-Artikel: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "_USDA Verbindung bearbeiten"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Nährwertinformationen</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "_Informationen bearbeiten"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "_Nährwertinformationen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Dichte:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "USDA Entsprechungen:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Eigene Entsprechungen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "_Dichte Informationen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "Nährwertinformationen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "_Erweiterte Suche"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Nährwertinformationen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "I_gnorieren"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet Rezepteverwaltung"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Copyright (c) 2004,2005,2006,2007,2008,2009,2010,2011 Thomas M. Hinkle. GNU "
 "GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -886,217 +892,168 @@ msgstr ""
 "Ihres Rezeptes. Gourmet ermittelt den Nährstoffgehalt des Rezeptes auf Basis "
 "der enthaltenen Zutaten."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Unterstützung Windows Portierung)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows Installation)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-"Richard Ferguson (Verbesserungen der Schnittstelle des Einheitenkonverters)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (Verbesserungen des Mealmaster-Exports)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo and splash screen)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-"Yula Zubritsky (Ernährungsexperte und \"zur Einkaufsliste hinzufügen "
-"Piktogramme)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (Verbesserungen an der "
-"Internationalisierung des Programms, verschiedene Fehlerbereinigungen)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Betreuung der Windowsversion und "
-"Überarbeitung der Webseite)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Datenbankdatei auswählen"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Aktualisiere Datenbank"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Neues Rezept"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Datenbank_name:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"Je nach Größe der Datenbank kann dieser Prozess einige Zeit in Anspruch "
-"nehmen. Zur Sicherheit wurde eine automatische Kopie der Datenbank angelegt."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Details"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Eine Sicherheitskopie wurde in %s erstellt. Falls die Aktualisierung "
 "fehlschlägt kann das Backup in recipes.db umbenannt werden, um es mit einer "
 "älteren Version von Gourmet weiterverwenden."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Neues Rezept"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "_Kategorie wählen"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Neue Kategorie erstellen"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Wähle die Kategorie des markierten Artikels"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Vorratskammer"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "In die _Einkaufsliste verschieben"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Strg>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "In die Vorratskammer verschieben"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Strg>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Von der Einkaufsliste entfernen"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Ausgewählte Artikel nach %s verschieben"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Einkaufsliste"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Schon vorhanden (_Speisekammer-Einträge)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Kategorie eingeben"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Kategorie, zu der %s hinzugefügt werden soll"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategorie:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Rezepte"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Artikel hinzufügen:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Rezepte löschen"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Rezepte von Einkaufsliste löschen"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Bearbeiten"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Artikel hinzufügen"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Füge zusätzliche Artikel zur Einkaufsliste hinzu"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Keine Rezepte ausgewählt. Wollen Sie die gesamte Liste löschen?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Einkaufsliste speichern unter..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Optionale Zutaten auswählen"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1105,57 +1062,59 @@ msgstr ""
 "Einkaufsliste mit aufnehmen wollen."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Rezept"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Gehe zu"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Rezept exportieren"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Ausgewähltes Rezept exportieren (In Datei speichern)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "Rezept löschen"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Dieses Rezept löschen"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Einheiten beim Multiplizieren anpassen"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Einheiten, wenn möglich, beim multiplizieren ändern um sie lesbarer zu "
 "machen."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Rezept drucken"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Zur _Einkaufsliste hinzufügen"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Gespeicherte, optionale Zutaten löschen"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1163,150 +1122,144 @@ msgstr ""
 "Vor dem Hinzufügen zur Einkaufsliste nach allen optionalen Zutaten fragen, "
 "auch wenn diese vorher angewählt wurden"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Rezept exportieren"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Sie haben ungespeicherte Änderungen."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Vor dem Drucken die Änderungen anwenden?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Vor dem Drucken die Änderungen anwenden?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Optional)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Rezept %s konnte in der Datenbank nicht gefunden werden."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Rezept bearbeiten:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Speichere Änderungen in der Datenbank"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Ansicht Rezeptkarte"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Speichere Änderungen nach %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Zutat hinzufügen"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Gruppe hinzufügen"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Zutat einfügen"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Datei importieren"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "_Rezept hinzufügen"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Ein anderes Rezept als Zutat zu diesem Rezept hinzufügen"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Hoch"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Runter"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Datei mit der Zutatenliste auswählen."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Anweisungen"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notizen"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Menge"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Einheit"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Artikel"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Optional"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Das Rezept %s (ID %s) ist nicht in der Datenbank enthalten."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Konvertiert: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Nicht konvertiert: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Einheit geändert."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1315,235 +1268,234 @@ msgstr ""
 "Sie haben die Einheiten für %(item)s von %(old)s to %(new)s geändert. Wollen "
 "Sie die Mengen umrechnen oder nicht?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "%(old_amt)s %(old_unit)s zu %(new_amt)s %(new_unit)s konvertiert."
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Konvertierung von %(old_unit)s zu %(new_unit)s nicht möglich."
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Zutatengruppe hinzufügen"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Namen für die neue Zutaten-Untergruppe eingeben"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Name der Gruppe:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Rezept auswählen"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Das Rezept kann nicht selbst als Zutat ausgewählt werden!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Unendliche Rekursionen sind in Rezepten nicht erlaubt!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Sie haben keine Rezepte ausgewählt!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Wie viele %(title)s erfordert das Rezept?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Rezepte"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Klingelton"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Warnton"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Fehlerton"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Kurzzeitwecker anhalten?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Kurzzeitwecker _anhalten"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "Kurzzeitwecker _laufen lassen"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Plugins fügen zusätzliche Funktionen zu Gourmet hinzu."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Dieses Plugin wird von einem anderen Plugin benötigt. Soll das Plugin "
 "trotzdem deaktiviert werden?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Folgende Plugins benötigen %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Trotzdem deaktivieren"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Plugin aktiviert lassen"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "oder"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Ein Fehler trat beim Aktivieren des Plugins auf."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Ein Fehler trat beim Deaktivieren des Plugins auf."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Küche"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Bewertung"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Quelle"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Webseite"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Zubereitungszeit"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Garzeit"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Änderungen"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Ungültige Eingabe."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Das ist keine Zahl."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Unterbrechen"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stop"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Nicht noch einmal nachfragen."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Wollen Sie dies wirklich tun"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "Exzellent"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "Großartig"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "Gut"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "Geht so"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "Schlecht"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "In 5 Sterne-Rating umwandeln"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Konvertiere Bewertungen."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Bitte vergeben Sie jeder Bewertung eine Entsprechung auf der Skala von 1 bis "
 "5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Aktuelle Bewertung"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Bewertung mit 1-5 Sternen"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Keine Datei ausgewählt"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Datei_typ auswählen"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Es wurde keine Datei ausgewählt, daher wurde der Vorgang abgebrochen"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1552,14 +1504,14 @@ msgstr ""
 "Leider verstehe ich die\n"
 "Menge %s nicht."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Mengenangaben müssen Zahlen (Brüche oder Dezimalzahlen), Zahlenreihen oder "
 "leer sein."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1578,86 +1530,86 @@ msgstr ""
 "Für einen Bereich verwenden Sie als Trennzeichen \"-\".\n"
 "Geben Sie z.B.: \"2-4\" oder \"1 1/2 - 3 1/2\" ein.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Benutzername:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Passwort:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "Mehl, Mehrzweck"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "Zucker"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "Salz"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "Schwarzer Pfeffer, gemahlen"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "Eis"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "Wasser"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "Pflanzenöl"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "Olivenöl"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Das Rezept enthält sich selbst als Zutat."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Zutat %s wird ignoriert."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Einkaufsliste für %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Für die folgenden Rezepte:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Für die folgenden Rezepte:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Codierung auswählen"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1665,29 +1617,28 @@ msgstr ""
 "Die Codierung konnte nicht bestimmt werden. Bitte wählen Sie die richtige "
 "Codierung aus der folgenden Liste aus."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Siehe _Datei mit Kodierung"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Import unterbrochen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Import anhalten"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Rezept_index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Einkaufs_liste"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Dank an Übersetzer\n"
@@ -1741,339 +1692,326 @@ msgstr ""
 "  vonshtupp https://launchpad.net/~gilap\n"
 "  willy_94 https://launchpad.net/~selmeier-albin"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Gespeichert!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Änderungen nach %s speichern"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Es läuft gerade ein Import."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Es läuft gerade ein Export."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Es läuft gerade ein Löschvorgang."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Die Anwendung dennoch verlassen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Nicht verlassen!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "%s von %s Rezepten unwiderruflich gelöscht."
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Mülleimer"
 
 # "wieder her" zusammen oder auseinander?
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 "Durchsuche gelöschte Rezepte, lösche sie permanent oder stelle sie wieder her"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Wiederhergestellte Rezepte "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "%(unit)s %(title)s einkaufen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multipliziere %s mit:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "%(attributes)s für %(num)s gewähltes Rezept setzen?"
 msgstr[1] "%(attributes)s für %(num)s ausgewählte Rezepte setzen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Kein vorheriger Wert wird geändert."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Die neuen Werte überschreiben jeweils die alten."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Diese Änderung kann nicht rückgängig gemacht werden."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Werte für gewählte Rezepte setzen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Rezepte suchen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Rezept anzeigen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Ausgewähltes Rezept öffnen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Rezept _löschen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Ausgewählte Rezepte löschen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Rezept bearbeiten"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Gewähltes Rezept im Editor öffnen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "Ausgewählte Rezepte e_xportieren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Ausgewählte Rezepte in Datei exportieren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Drucken"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "Rezepte"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "B_earbeite mehrere Rezepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Neu"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "Datei _importieren"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Rezept importieren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Rezept aus Datei importieren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "_Webseite importieren"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s Rezept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Rezept von Webseite importieren"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "_Alle Rezepte exportieren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Alle Rezepte in eine Datei exportieren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Beenden"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Aktionen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "_Mülleimer öffnen"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Mülleimer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Optionen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Plugins"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Plugins verwalten, die Gourmet um Funktionen erweitern."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "_Einstellungen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Über"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Werkzeuge"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Stoppuhr"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Kurzzeitwecker anzeigen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Durchsuchbarer Index der Rezeptdatenbank."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "%s löschen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "Es existieren noch ungespeicherte Änderungen bei %s. Sind Sie sicher, dass "
 "Sie diese löschen wollen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Gelöscht"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Unbenannt"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Rezepte dauerhaft löschen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Rezept dauerhaft löschen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Sind Sie sicher, dass Sie das Rezept <i>%s</i> löschen wollen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Sind Sie sicher, dass Sie die folgenden Rezepte löschen wollen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Sind Sie sicher, dass Sie die %s ausgewählten Rezepte löschen wollen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Rezepte anzeigen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Rezepte löschen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Rezept-Index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Rezept %s gelöscht"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Fertig!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Import läuft …"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Zutatenschlüssel-Editor"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Massenbearbeitung der Zutatenschlüssel"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "Stichwort"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "Artikel"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Feld"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Wert"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Anzahl"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Alle Schlüssel von \"%s\" nach \"%s\" ändern"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2084,12 +2022,12 @@ msgstr ""
 "dem Schlüssel \"%s\" existieren, lassen sie sich nicht mehr von den bereits "
 "existierenden unterscheiden."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Ändere alle Einträge von \"%s\" zu \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2100,12 +2038,12 @@ msgstr ""
 "dem Schlüssel \"%s\" existieren, lassen sie sich nicht mehr von den bereits "
 "existierenden unterscheiden."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Ändere _alle Vorkommen von \"%(unit)s\" to \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2114,13 +2052,13 @@ msgstr ""
 "Ändere \"%(unit)s\" zu \"%(text)s\", nur für _Zutaten \"%(item)s\" mit "
 "Schlüssel \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Ändere _alle Vorkommen von \"%(amount)s\" %(unit)s zu %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2129,7 +2067,7 @@ msgstr ""
 "Ändere \"%(amount)s\" %(unit)s zu \"%(text)s\" %(unit)s nur _wo der "
 "ZutatenSchlüssel %(key)s ist."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2138,11 +2076,11 @@ msgstr ""
 "Ändere \"%(amount)s\" %(unit)s zu \"%(text)s\" %(unit)s, nur bei "
 "Zutatenschlüssel %(key)s _und Artikel %(item)s."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Alle ausgewählten Zeilen ändern?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2151,7 +2089,7 @@ msgstr ""
 "Diese Aktion kann nicht rückgängig gemacht werden. Sollen in allen %s "
 "ausgewählten Reihen die folgenden Werte gesetzt werden:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2160,7 +2098,7 @@ msgstr ""
 "\n"
 "Schlüssel zu %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2169,7 +2107,7 @@ msgstr ""
 "\n"
 "Eintrag zu %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2178,7 +2116,7 @@ msgstr ""
 "\n"
 "Einheit zu %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2187,8 +2125,8 @@ msgstr ""
 "\n"
 "Menge zu %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2197,23 +2135,23 @@ msgstr[1] "%s Zutaten"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Zeige Zutaten %(bottom)s bis %(top)s von %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Menge"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Zutatenschlüssel"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2221,66 +2159,66 @@ msgstr ""
 "Zutatenschlüssel sind normalisierte Namen von Zutaten, die für "
 "Einkaufslisten und Berechnungen herangezogen werden."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Schlüssel ermitteln"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr "Den besten Schlüssel auf Basis der Datenbankeinträge ermitteln"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Schlüsselverknüpfungen bearbeiten"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Verknüpfungen von Schlüsseln und anderen Attributen bearbeiten"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Schlüssel bearbeiten"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "Art_ikel:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Schlüssel:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>Gewählte Zutaten _ändern</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Einkaufskategorie"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Einheiten wie im Rezept angegeben anzeigen (Keine Umrechnung)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Immer U.S. Einheiten anzeigen"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Immer metrische Einheiten anzeigen"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Einheiten automatisch anpassen"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Einheiten Anzeigeeinstellungen"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2288,42 +2226,42 @@ msgstr ""
 "Einheiten, wenn möglich, automatisch in bevorzugtes System (metrisch, "
 "imperial, etc.) umrechnen."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Sterne"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "vor %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Rezepte automatisch zusammenführen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "_Immer das neueste Rezept verwenden"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "_Immer das älteste Rezept verwenden"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Keine"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2332,97 +2270,97 @@ msgstr ""
 "entweder hier zusammengeführt werden oder durch Schließen des Dialogs "
 "belassen werden."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "_Doppelte Rezepte finden"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Doppelte Rezepte finden und löschen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Rezepte mit ähnlichen Inhalten"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Rezepte mit ähnlichen Zutaten"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Rezepte mit ähnlichen Inhalten und benötigten Zutaten"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Doppelte Rezepte</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "Rezepte aus Papierkorb e_inbeziehen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Zeige:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "_Alle Duplikate zusammenführen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Rezepte zusammenfügen</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "_automatisch Zusammenführen"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Für jedes Feld"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "dessen %(field)s %(value)s ist"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Änderung betrifft %s Rezept"
 msgstr[1] "Änderung betreffen %s Rezepte"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "%s löschen wo es %s ist?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "%s von %s nach \"%s\" ändern?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Diese Änderung kann nicht widerrufen werden.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Feldeditor"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Felder von mehreren Rezepten gleichzeitig bearbeiten"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Rezepte per E-_Mail versenden"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Versende das ausgewählte Rezept (oder alle Rezepte wenn kein Rezept "
@@ -2431,164 +2369,152 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 "Sind Sie sicher, dass Sie die %s ausgewählten Rezepte per e-Mail versenden "
 "wollen?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Ja, als E-Mail schicken"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "%s kann nicht in %s umgewandelt werden"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Die Dichtedaten sind erforderlich."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Einheiten-Umrechner"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Einheitenumrechnung berechnen"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Einheitenrechner"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Von</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "_Element:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Dichte:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "_Dichteangaben"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Zu</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Ergebnis:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Archivieren (zip, tarball)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Lade Zip-Archiv"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Entpacke Zip-Archiv"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML-Webseite"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Webseite exportieren"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Exportiere Rezepte in HTML-Dateien in Verzeichnis %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Rezept wurde als HTML-Datei %(file)s gespeichert"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Originalseite von %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "optional"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Webseite exportieren"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Exportiere Rezepte in HTML-Dateien in Verzeichnis %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Rezept wurde als HTML-Datei %(file)s gespeichert"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Textdatei"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Textexport"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Rezepte werden in Textdatei %(file)s exportiert."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Rezept als Textdatei %(file)s gespeichert"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Große Datei"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Datei %s ist für den Import zu groß"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2599,81 +2525,54 @@ msgstr ""
 "ist die Datei nicht für den Import vorgesehen. Falls doch, sollte sie in "
 "einem Texteditor aufgeteilt und erneut zum Import geladen werden."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Webseite"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "%s wird heruntergeladen"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Einkaufsliste für %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Rufe %s ab"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML-Datei"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML-Export"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Rezepte werden in Gourmet XML-Datei %(file)s exportiert."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Rezept wurde in Gourmet XML-Datei %(file)s gespeichert"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML-Datei (veraltet)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "MasterCook XML-Datei"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "MasterCook Textdatei"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "MasterCook-Import beendet."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Aufräumen der XML-Daten"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML-Datei"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2682,274 +2581,295 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Seitenlayout"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Rezepte drucken"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF Export"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Exportiere Rezept als PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Rezept als PDF %(file)s gesichert"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Letter"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Hochformat"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Eben"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "Punkte"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Karteikarte (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Karteikarte (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Karteikarte (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Karteikarte (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Letter"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Karteikarte (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Karteikarte (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Karteikarte (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Querformat"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Eben"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Spalte"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Spalte"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Spalte"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Spalte"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s Spalte"
 msgstr[1] "%s Spalten"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Hochformat"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Querformat"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Papiergröße"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Ausrichtung"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Schriftgröße"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Seiten-Layout"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Schriftgröße"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Linker Rand"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Rechter Rand"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Oberer Rand"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Unterer Rand"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "PDF-Optionen"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster-Datei"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster-Export"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Exportiere Rezepte nach MealMaster(tm)-Datei %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Rezept gespeichert als MealMaster-Datei %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "Portion"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Große Datei"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "HTML Export"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Rezepte werden in Gourmet XML-Datei %(file)s exportiert."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Rezept wurde in Gourmet XML-Datei %(file)s gespeichert"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Einkaufslistenspeicher"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Liste als Rezept speichern"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Strg><Umschalt>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Eine Einkaufsliste als Rezept für den späteren Gebrauch speichern"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Menü für %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menü"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Nährwertangaben geben Werte pro %s an"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Nährwertangaben geben Werte für das gesamte Rezept an"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Nährwertangaben für %s Zutaten fehlen: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Irgendeine Speisengruppe"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "Auswahl"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Konvertiere Einheit für %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Um Ernährungsinformationen berechnen zu können, legen Sie Einheit, in die "
 "Sie \"%s\" konvertieren wollen, fest."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Zutatenschlüssel ändern"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2958,27 +2878,27 @@ msgstr ""
 "Möchten Sie den Zutatenschlüssel von %(old_key)s auf %(new_key)s überall "
 "oder nur in diesem Rezept %(title)s ändern?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Ändere üb_erall"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Nur in diesem Rezept %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Zutatenschlüssel überall von %(old_key)s auf %(new_key)s ändern?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Ändere Einheit"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2987,11 +2907,11 @@ msgstr ""
 "Möchten Sie die Einheit von %(old_unit)s zu %(new_unit)s für alle Zutaten "
 "%(ingkey)s oder nur im Rezept %(title)s ändern?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -3000,198 +2920,199 @@ msgstr ""
 "mehrere Beschreibungen der Nahrung mit verschiedenen Dichten. Bitte wählen "
 "sie unten die richtige aus."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Um Nährwertangaben hinzuzufügen, benötigt Gourmet eine gültige Menge und "
 "Einheit."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Ernährung"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Zutat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "USDA Datenbank Entsprechung"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 Gramm"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalorien"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Gesamtfettgehalt"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "gesättigtes Fett"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Cholesterin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Natrium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Kohlehydrate gesamt"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Ballaststoffe"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Zucker"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteine"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alpha-Carotin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Potasche"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-Carotin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Kalzium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Kupfer"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Folsäure gesamt"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Folsäure"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Folsäure"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "empfohlene Tagesdosis an Folsäure"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Eisen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Lycopin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Lutein+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Pantothensäure"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Phosphor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Kalium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamin A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Thiamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamin A (IE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamin A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamin C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zink"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamine und Mineralien"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3200,11 +3121,11 @@ msgstr ""
 "Nährwertangaben fehlen\n"
 "für %(missing)s von %(total)s Zutaten."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _täglicher Wert"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3213,367 +3134,367 @@ msgstr ""
 "Anteil der empfohlenen Tagesmenge, basierend auf %i Kalorien pro Tag. "
 "Klicken Sie, um die Kalorienmenge pro Tag zu ändern."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Menge pro %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Menge pro Rezept"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Lade Nährwerttabelle"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Nährwerttabelle vollständig importiert!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Hole Nährwerttabelle aus Zip-Archiv %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Entpacke %s aus Zip-Archiv."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Einlesen der Nährwerttabelle..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Lese Nährwerttabelle: %s von %s Datensätze gelesen."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Einlesen der Gewichtstabelle..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr "Lese Gewichtsdaten für Nährwertsätze: %s von %s Einträge gelesen."
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Wasser"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalorien"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g Protein"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g Lipid"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g Asche"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g Kohlenhydrate"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g Ballaststoffe"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g Zucker"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg Kalzium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg Eisen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg Magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg Phosphor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg Kalium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg Natrium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg Zink"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg Kupfer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg Mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mg Selen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg Vitamin C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg Thiamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg Riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg Niacin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg Pantothensäure"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg Vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "Mikrogramm Vitamin B9 gesamt"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "Mikrogramm Folsäure"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "Mikrogramm Vitamin B9 im Lebensmittel"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "Diätetische Vit.B9-Äquivalente in Mikrogramm"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Choline, total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "Mikrogramm Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamin A IE"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamin A (Retinal-Aktivitäts-Äquivalente in Mikrogramm)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "Mikrogramm Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "µg Alpha-Carotin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "Mikrogramm Beta-Carotin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "Mikrogramm Beta-Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "Mikrogramm Lycopen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "Mikrogramm Lutein+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g gesättigte Fettsäuren"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g einfach ungesättigte Fettsäuren"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g Ungesättigte Fettsäure"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Cholesterin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Prozent abgewiesen"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Milch- & Ei-Produkte"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Gewürze & Kräuter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Kindernahrung"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Fette und Öle"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Geflügel"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Suppen & Soßen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Würstchen & Frühstücksfleisch"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Müsli"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Früchte % Fruchtsäfte"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Schweinefleisch"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Gemüse"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Nüsse & Samen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Rindfleisch"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Getränke"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Fisch & Schalentiere"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Hülsenfrüchte"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Lamm, Kalb & Wild"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Gebackene Produkte"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Süßigkeiten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Getreide und Nudeln"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Fast Food"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Hauptgerichte, Vorspeisen und Beilagen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Snacks"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Nationale Gerichte"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "gesamte Datenbank"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Zutatenschlüssel"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "USDA ID Nummer"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA Artikelbeschreibung"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Entsprechung der volumenabhängige Masse"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3587,59 +3508,59 @@ msgstr "Werkzeuge"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Nährwertinformationen eingeben für"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Anzahl für Einkaufsliste"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "_Nährstoff-Informationen ändern"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "Sterne"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "%(number)s von %(total)s Rezepten wurden exportiert"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Export fertig."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Rezept in Hauptteil der E-Mail eintragen (Immer eine gute Idee)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Rezept als HTML-Anhang senden"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Rezept als PDF per E-Mail verschicken"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "E-Mail-Optionen"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Vor dem Versenden als E-Mail nicht nachfragen."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-Mail nicht gesendet"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3647,237 +3568,189 @@ msgstr ""
 "Sie haben das Rezept weder für den Hauptteil noch für den Anhang der E-Mail "
 "eingetragen."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Rezept speichern unter..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet kann keine Datei vom Typ \"%s\" exportieren."
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Rezepte exportieren"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "Rezepte"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Export fehlgeschlagen: Unbekannter Dateityp \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Es sollte sichergestellt werden, dass bei der Speicherung ein Dateityp aus "
 "dem Menü gewählt wird."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Exportieren"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Drucken fehlgeschlagen: Keine Druck-Plugins aktiv!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "%s Rezept drucken"
 msgstr[1] "%s Rezepte drucken"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Rufe Datei ab"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "ergibt"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-"Geben Sie die URL eines archivierten Rezeptes oder einer Webseite eines "
-"Rezeptes ein."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Weibseitenadresse eingeben"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "URL eingeben"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Bitte die Adresse einer Webseite oder eines Rezeptarchives eingeben."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Importieren der URL fehlgeschlagen"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet hat kein Plugin um URL zu importieren"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Import von URL %(url)s mit MIME-Typ %(type)s fehlgeschlagen. Importdatei in "
-"%(fn)s zwischengespeichert."
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Rezept öffnen..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Weibseitenadresse eingeben"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Änderungen"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Bitte die Adresse einer Webseite oder eines Rezeptarchives eingeben."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importieren"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Alle importierbaren Dateien"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "%s Rezepte importiert."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "Portion"
 msgstr[1] "Portionen"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "%s von %s Rezepten importiert."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "in Ordnung"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Webseite konnte nicht erkannt werden. Wähle allgemeinen Importer..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Import vollständig."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Rezept importieren"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Zutaten bearbeiten"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Zutaten bearbeiten."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Portionen"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Zutaten-Untergruppe"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Verbergen"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Text"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Aktionen"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Rezept importieren"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "_Tags löschen"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Rezept importieren"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "Überall"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "Titel"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "Zutat"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "Anweisungen"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "Notizen"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "Küche"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "Quelle"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Reguläre Ausdrücke zur Suche verwenden"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr "Reguläre Ausdrücke (Erweiterte Suche) in Volltextsuche verwenden"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 "Während der Eingabe suchen (deaktivieren, falls die Suche zu langsam ist)"
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Zeige Such_optionen"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Erweiterte Suchoptionen anzeigen"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3886,104 +3759,98 @@ msgstr[1] "%s Rezepte"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Zeige Rezepte %(bottom)s bis %(top)s von %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s in %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Angehalten"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "KRecipe Import"
 msgstr[1] "KRecipe Import"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pause"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Fertig"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Fehler: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Fehler"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Fehler %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Fehlerprotokoll"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "Sekunde"
 msgstr[1] "Sekunden"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "Minute"
 msgstr[1] "Minuten"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "Std."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "Stunde"
 msgstr[1] "Stunden"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "Tag"
 msgstr[1] "Tage"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "Woche"
 msgstr[1] "Wochen"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "Monat"
@@ -3992,7 +3859,7 @@ msgstr[1] "Monate"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "Jahr"
@@ -4004,73 +3871,30 @@ msgstr[1] "Jahre"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " und "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "und"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "bis"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML-Datei"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet Rezepteverwaltung"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Rezepte organisieren, Einkaufslisten erstellen, Nährwertangaben berechnen "
-"und mehr."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Rezepte durchsuchen"
@@ -4080,7 +3904,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Rezepte nach Kategorie,  Küche usw. auswählen"
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Hauptmenü"
@@ -4094,38 +3917,6 @@ msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 "Assistent um doppelte Rezepte zu finden und zu löschen oder zusammenführen"
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Verschicke als Email"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Rezepte aus Gourmet per E-Mail versenden"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Zip-, Gzip- und Tar-Support"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Importiere Rezepte aus zip- und tar-Archiven"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Import/Export"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4135,6 +3926,18 @@ msgstr "PDF Export"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Erstelle Webseiten aus Rezepten."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Import/Export"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4147,14 +3950,6 @@ msgid ""
 msgstr ""
 "Importiere und Exportiere Rezepte als Gourmet-XML-Dateien, geeignet als "
 "Backup oder zum Austausch mit anderen Gourmet-Benutzern."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "HTML Export"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Erstelle Webseiten aus Rezepten."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4216,22 +4011,6 @@ msgid ""
 msgstr ""
 "Hilft dem Benutzer Rezepte aus Textdateien zu importieren. Bietet auch "
 "Reintext-Export."
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Webseitenimport"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Importiere Rezept aus dem Internet"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Webseiten-Importer"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Importer für about.com, www.foodnetwork.com und andere"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4299,6 +4078,201 @@ msgstr ""
 "Dies sollte aktiviert werden, wenn UTF-16-Dateien nicht sauber importiert "
 "werden. Wenn man nie UTF-16 nutzt und nicht immer beim Import danach gefragt "
 "werden will sollte man dies deaktivieren."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Ausgewähltes Rezept per E-Mail versenden"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "Rezept per E-_Mail versenden"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Unterstützung Windows Portierung)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows Installation)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr ""
+#~ "Richard Ferguson (Verbesserungen der Schnittstelle des "
+#~ "Einheitenkonverters)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (Verbesserungen des Mealmaster-Exports)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo and splash screen)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr ""
+#~ "Yula Zubritsky (Ernährungsexperte und \"zur Einkaufsliste hinzufügen "
+#~ "Piktogramme)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (Verbesserungen an der "
+#~ "Internationalisierung des Programms, verschiedene Fehlerbereinigungen)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Betreuung der Windowsversion und "
+#~ "Überarbeitung der Webseite)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Aktualisiere Datenbank"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Je nach Größe der Datenbank kann dieser Prozess einige Zeit in Anspruch "
+#~ "nehmen. Zur Sicherheit wurde eine automatische Kopie der Datenbank "
+#~ "angelegt."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Zutat einfügen"
+
+#~ msgid "Import from file"
+#~ msgstr "Datei importieren"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Datei mit der Zutatenliste auswählen."
+
+#~ msgid "No file selected"
+#~ msgstr "Keine Datei ausgewählt"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr ""
+#~ "Es wurde keine Datei ausgewählt, daher wurde der Vorgang abgebrochen"
+
+#~ msgid "_Import file"
+#~ msgstr "Datei _importieren"
+
+#~ msgid "Import _webpage"
+#~ msgstr "_Webseite importieren"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Rezept von Webseite importieren"
+
+#~ msgid "Open _Trash"
+#~ msgstr "_Mülleimer öffnen"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Archivieren (zip, tarball)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Lade Zip-Archiv"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Entpacke Zip-Archiv"
+
+#~ msgid "Webpage"
+#~ msgstr "Webseite"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "%s wird heruntergeladen"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Einkaufsliste für %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Rufe %s ab"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Rufe Datei ab"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr ""
+#~ "Geben Sie die URL eines archivierten Rezeptes oder einer Webseite eines "
+#~ "Rezeptes ein."
+
+#~ msgid "Enter URL:"
+#~ msgstr "URL eingeben"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Importieren der URL fehlgeschlagen"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet hat kein Plugin um URL zu importieren"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Import von URL %(url)s mit MIME-Typ %(type)s fehlgeschlagen. Importdatei "
+#~ "in %(fn)s zwischengespeichert."
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Webseite konnte nicht erkannt werden. Wähle allgemeinen Importer..."
+
+#~ msgid "Import complete."
+#~ msgstr "Import vollständig."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Rezept importieren"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Zutaten bearbeiten"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Zutaten bearbeiten."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML-Datei"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet Rezepteverwaltung"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Rezepte organisieren, Einkaufslisten erstellen, Nährwertangaben berechnen "
+#~ "und mehr."
+
+#~ msgid "Send to Email"
+#~ msgstr "Verschicke als Email"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Rezepte aus Gourmet per E-Mail versenden"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Zip-, Gzip- und Tar-Support"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Importiere Rezepte aus zip- und tar-Archiven"
+
+#~ msgid "HTML Export"
+#~ msgstr "HTML Export"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Erstelle Webseiten aus Rezepten."
+
+#~ msgid "Webpage import"
+#~ msgstr "Webseitenimport"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Importiere Rezept aus dem Internet"
+
+#~ msgid "Website Importers"
+#~ msgstr "Webseiten-Importer"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Importer für about.com, www.foodnetwork.com und andere"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4431,9 +4405,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "_Portionen"
-
-#~ msgid "Select File_type"
-#~ msgstr "Datei_typ auswählen"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Es ist bereits eine Datei mit dem Namen %s vorhanden."

--- a/po/de_AT.po
+++ b/po/de_AT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2014-02-25 13:49+0100\n"
 "Last-Translator: Bernhard Reiter <ockham@raz.or.at>\n"
 "Language-Team: German (Austria) <de_AT@li.org>\n"
@@ -20,506 +20,509 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Neues Rezept"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Zur _Einkaufsliste hinzufügen"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Datei"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "Rezept"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Details"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gourmet Rezept Manager"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Einkaufsliste"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Titel"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "Kategorie"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Rezept"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Zutaten"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Rezept löschen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Rezept %s gelöscht"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Rezept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +530,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategorie"
 
@@ -560,285 +563,287 @@ msgstr "Kategorie"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Schlüssel"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet Rezept Manager"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,204 +858,164 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Assistent für Windows Portierung)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (Verbesserungen zum \"Einheiten Umrechner\")"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (Verbesserungen des Mealmaster Export)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Neues Rezept"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Einkaufsliste"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Kategorie eingeben"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Kategorie, zu der %s hinzugefügt werden soll"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Bearbeiten"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Kein Rezept ausgewählt. Wollen Sie die ganze Liste löschen?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Speichere Einkaufsliste als ..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1059,204 +1024,200 @@ msgstr ""
 "hinzufügen wollen."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Zur _Einkaufsliste hinzufügen"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Sie haben ihre Änderungen nicht gespeichert."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Sollen die Änderungen vor dem Drucken gespeichert werden?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Sollen die Änderungen vor dem Drucken gespeichert werden?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(wahlweise)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Wähle eine Datei die Ihre Zutatenliste enthält."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Anweisungen"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notizen"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Mng"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Einheit"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Artikel"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Wahlweise"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Das Rezept %s (ID %s) ist nicht in der Datenbank."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Umgerechnet: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Nicht Umgerechnet: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Geänderte Einheiten."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1265,231 +1226,229 @@ msgstr ""
 "Sie haben die Einheiten für %(item)s von %(old)s to %(new)s geändert. Wollen "
 "sie die Mengen umrechnen oder nicht?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "%(old_amt)s %(old_unit)s nach %(new_amt)s %(new_unit)s umgerechnet"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Kann von %(old_unit)s nach %(new_unit)s nicht umrechnen"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Zutatengruppe hinzufügen"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Name für eine neue Zutaten-untergruppe eingeben"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Rezept kann sich nicht selbst als Zutat aufrufen!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Unendliche Rekursion ist in Rezepten nicht erlaubt!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Sie haben kein Rezept ausgewählt!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Rezepte"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Küche"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Bewertung"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Quelle"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Zubereitungszeit"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Kochzeit"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Änderungen"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pause"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stop"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Nicht wieder fragen."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Sind sie sicher?"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Keine Datei ausgewählt"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Datei_typ auswählen"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Keine Datei ausgewählt, daher wurde die Aktion nicht ausgeführt"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1498,12 +1457,12 @@ msgstr ""
 "Entschuldigung, ich kann die\n"
 "Mengeangabe \"%s\" nicht verstehen."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1515,84 +1474,84 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "Mehl, Mehrzweck"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "Zucker"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "Salz"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "Schwarzer Pfeffer, gemahlen"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "Eis"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "Wasser"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "Pflanzenöl"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "Olivenöl"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Rezept ruft sich selbst als Zutat auf."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Zutat %s wird ignoriert."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Einkaufsliste für %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Für die folgenden Rezepte:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Für die folgenden Rezepte:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Umschlüsselung auswählen"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1600,29 +1559,28 @@ msgstr ""
 "Die korrekte Umschlüsselung kann nicht erkannt werden. Bitte wählen Sie die "
 "richtige Umschlüsselung aus der folgenden Liste."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "_Datei mit Umschlüsselung ansehen"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Import angehalten"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Import gestoppt"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Rezept _Index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Einkaufs_liste"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Übersetzer\n"
@@ -1630,335 +1588,319 @@ msgstr ""
 "Launchpad Contributions:\n"
 "  Erich Oswald https://launchpad.net/~e-oswald"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Gesichert!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Eingaben nach %s speichern"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Ein Import läuft gerade."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Ein Export läuft gerade."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Eine Löschung läuft gerade."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Das Programm dennoch verlassen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Nicht verlassen!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Ungelöschte Rezepte "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "Rezepte"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Rezepte exportieren"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "Rezepte anzeigen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Aktionen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Über"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Werkzeuge"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Rezepte dauerhaft löschen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Rezept dauerhaft löschen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Wollen Sie dieses Rezept <i>%s</i> wirklich löschen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Wollen Sie die die folgenden Rezepte löschen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Sind sie sicher, dass Sie das Rezept %s löschen wollen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Rezepte anzeigen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Rezept _Index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Rezept %s gelöscht"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Fertig!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importiere...."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "Schlüssel"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "Artikel"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Anzahl"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1966,12 +1908,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1979,78 +1921,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2059,387 +2001,375 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Menge"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Einkaufskategorie"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Kein"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Kann nicht von %s nach %s umrechnen"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Benötige Information über Physische Dichte"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Einheitenrechner"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML Webseite"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Webseite exportieren"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Exportiere Rezepte in HTML Dateien in das Verzeichniss %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Rezept als HTML Datei %(file)s gespeichert"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "wahlweise"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Webseite exportieren"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Exportiere Rezepte in HTML Dateien in das Verzeichniss %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Rezept als HTML Datei %(file)s gespeichert"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Text Export"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2447,81 +2377,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Einkaufsliste für %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML Datei"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML Export"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Exportiere Rezepte als Gourmet XML Datei %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Rezept als Gourmet XML Datei %(file)s gespeichert."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Mastercook Import fertig."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "XML aufräumen"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2530,882 +2433,899 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Rezepte drucken"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "Portionen"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Datei"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Text Export"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Exportiere Rezepte als Gourmet XML Datei %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Rezept als Gourmet XML Datei %(file)s gespeichert."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3419,59 +3339,59 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "%(number)s von %(total)s Rezepten exportiert"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Export fertig."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Rezept als Text in der E-Mail einfügen."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Rezept als HTML-Anhang mailen."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "E-Mail Optionen"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Vor dem Mail-Versand nicht fragen."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-mail nicht gesendet"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3479,230 +3399,185 @@ msgstr ""
 "Sie haben nicht ausgesucht ob Sie das Rezept als Text oder Anhang einfügen "
 "wollen."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Rezept speichern als..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet kann Datei vom Typ \"%s\" nicht exportieren"
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Rezepte exportieren"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "Rezepte"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "%s Rezept gedruckt"
 msgstr[1] "%s Rezepte gedruckt"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Änderungen"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Alle importierbaren Dateien"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "%s von %s Rezepten importiert."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Portionen"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "Titel"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "Zutat"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "Anweisungen"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "Küche"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "Quelle"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3711,103 +3586,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3816,7 +3685,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3828,71 +3697,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML Datei"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet Rezept Manager"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3902,7 +3730,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3915,38 +3742,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -3954,6 +3749,18 @@ msgstr "Text Export"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3964,14 +3771,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4025,22 +3824,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4100,6 +3883,36 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Assistent für Windows Portierung)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (Verbesserungen zum \"Einheiten Umrechner\")"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (Verbesserungen des Mealmaster Export)"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Wähle eine Datei die Ihre Zutatenliste enthält."
+
+#~ msgid "No file selected"
+#~ msgstr "Keine Datei ausgewählt"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Keine Datei ausgewählt, daher wurde die Aktion nicht ausgeführt"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Einkaufsliste für %s"
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML Datei"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet Rezept Manager"
+
 #~ msgid "Gourmet Recipe Manager starting up..."
 #~ msgstr "Gourmet Rezept Manager startet...."
 
@@ -4129,9 +3942,6 @@ msgstr ""
 
 #~ msgid "Exported %s to %s"
 #~ msgstr "%s wurden nach %s exportiert"
-
-#~ msgid "Select File_type"
-#~ msgstr "Datei_typ auswählen"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Eine Datei %s existiert bereits."

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-12-31 23:31+0000\n"
 "Last-Translator: Panagiotis Ligopsychakis <panligo@gmail.com>\n"
 "Language-Team: Greek, Modern (1453-) <el@li.org>\n"
@@ -21,64 +21,64 @@ msgstr ""
 "X-Rosetta-Version: 0.1\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Κατάλογος Συνταγών"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Νέα Συνταγή"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Προσθήκη στον _Κατάλογο Αγορών"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Προβολή _Συνταγής"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Αναζήτηση για:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Αναζήτηση συνταγών κατά την πληκτρολόγηση"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_Μέσα"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Αναζήτηση με διαφορετικά κριτήρια στα υπάρχοντα αποτελέσματα"
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "_Προσθέστε Κριτήρια Αναζήτησης"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Περιορισμός Αναζήτησης σε:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "_Αποτελέσματα Αναζήτισης"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Καθορισμός πεδίων στις Επιλεγμένες Συνταγές"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -86,130 +86,133 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Καθορίστε τα Πεδία Συνταγών για τις "
 "επιλεγμένες συνταγές</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "Προσθήκη _Είκονας"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Διαγραφή Εικόνας"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "_Πηγή:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "Α_ξιολόγηση"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "_Κουζίνα"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Κατηγορία:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "Χ_ρόνος Προετοιμασίας"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "_Χρόνος Μαγειρέματος"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Ιστοσελίδα"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Εικόνα:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Μερίδες"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Μονάδα Μέτρησης Μερίδας"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "Καθορισμός _τιμών μόνο σε κενά πεδία"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Καθορισμός όλων των τιμών για _όλες τις επιλεγμένες συνταγές"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (προεπιλεγμένο, αποθηκεύεται σε τοπικό αρχείο)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (αποθηκεύεται σε τοπικό αρχείο)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (απαιτείται σύνδεση σε βάση δεδομένων)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Επιλέξτε Βάση Δεδομένων"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 "<b>Επιλέξτε το Σύστημα Βάσης Δεδομένων που θα χρησιμοποιήσει το Gourmet</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "Σύστημα _Βάσης Δεδομένων"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Κεντρικός υπολογιστής:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "Όνο_μα Χρήστη:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Κωδικός:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Κωδικός πρόσβασης χρήστη στην βάση δεδομένων."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Όνομα _Βάσης Δεδομένων:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Αρχείο"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -218,11 +221,11 @@ msgstr ""
 "Εάν ο διακομιστής της βάσης δεδομένων σας λειτουργεί στο τοπικό σύστημα "
 "χρησιμοποιήστε το όνομα localhost."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -230,11 +233,11 @@ msgstr ""
 "Αποθήκευση κωδικού για την επόμενη φορά. Αυτό σημαίνει ότι ο κωδικός θα "
 "αποθηκευτεί χωρίς ασφάλεια στο αρχείο ρυθμίσεων σας."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "Απο_θήκευση Κωδικού"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -243,302 +246,303 @@ msgstr ""
 "πληροφορίες. Το Gourmet θα προσπαθήσει να δημιουργήσει αυτή τη βάση "
 "δεδομένων, εάν δεν υπάρχει ήδη."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "Συνταγή"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Το όνομα χρήστη στην βάση δεδομένων."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "Π_εριήγηση"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Λεπτομέρειες"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Προτιμήσεις  του Διαχειριστή Συνταγών Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Επιλογές Προβολής Λίστας</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Εμφάνιση _Επιλογών"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Συνταγές ανά σελίδα:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 "<i>Επιλογή στηλών που θα περιέχονται στην προβολή λίστας συνταγών .</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Προβολή Λίστας"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Επιλογές Προβολής Καρτέλας</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "Επιτ_ρέπεται η μετατροπή μονάδων κατά τον πολλαπλασιασμό"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Χρήση κλασμάτων"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Χρησιμοποίηση κλασμάτων, όταν είναι δυνατόν"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 "<i>Απομάκρυνση αντικειμένων που δεν χρησιμοποιούνται από το περιβάλλον Κάρτα "
 "Συνταγής.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Προβολή Κάρτας"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Επιλογές Λίστας Αγορών</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Τι πρέπει να κάνει το Gourmet με τα προαιρετικά συστατικά όταν προσθέτει "
 "συνταγές στην λίστα αγορών;</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "Ερώτηση εάν θα συμπεριληφθούν τα προαιρετικά συστατικά"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "_Απομνημόνευση των επιλογών χρήστη"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "_Καθαρισμός των αποθηκευμένων προαιρετικών συστατικών"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "Π_άντα να προστίθενται τα προαιρετικά συστατικά"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "Να μην προστίθενται τα προαιρετικά συστατικά"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Κατάλογος Αγορών"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "μερίδες"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Τίτλος"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Τίτλος:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Χρόνος _Προετοιμασίας:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "κατηγορία"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "αξιολόγηση"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Μερίδες"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Μονάδα Μέτρησης Μερίδας"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Αγορά"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Επεξεργασία _Περιγραφής"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Χρόνος Μαγειρέματος:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Χρόνος Προετοιμασίας:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Κουζίνα:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Κατηγορία:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Ιστοσελίδα:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Μερίδες:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Σύνδεσμος</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Πηγή:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b> Αξιολόγηση:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Πολλαπλασιασμός επί:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Οδηγίες</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Επεξεργασία _Οδηγιών Παρασκευής"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Σημειώσεις</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Επεξεργασία Σ_ημειώσεων"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Συνταγή"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Συστατικά:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Επεξεργασία _Συστατικών"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Προσθήκη _Συστατικού:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Συστατικά"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Προσθήκη συνταγής στην λίστα αγορών"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Προσθήκη στην _λίστα αγορών"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Εμφάνιση συνταγής στην Προβολή Κάρτας"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Διαγραφή επιλεγμένης συνταγής"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Διαγραφή Συνταγής"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Επεξεργασία ιδιοτήτων των επιλεγμένων συνταγών"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "_Ομαδική επεξεργασία συνταγών"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Αποστολή επιλεγμένης συνταγής με E-mail"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Άνοιγμα της επιλεγμένης συνταγής"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "Αποστολή Συνταγής με E-mail"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Επιλέξτε συνταγή"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "_Εκτύπωση επιλεγμένης συνταγής"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "Εκτύ_πωση συνταγής"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -550,31 +554,31 @@ msgstr ""
 "περιλαμβάνεται στην λίστα που αποθηκεύεται η εκτυπώνεται εκτός και αν "
 "ζητηθεί να αγοραστεί."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Προσθήκη στο _Ντουλάπι"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Εμφάνιση _Επιλογών"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Αναζήτηση _σε:"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "_Χρήση κανονικών εκφράσεων (προηγμένη αναζήτηση)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Αναζήτηση κατά την _πηκτρολόγιση"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Επιλογές Αναζήτησης</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Κατηγορία"
 
@@ -583,291 +587,293 @@ msgstr "Κατηγορία"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Κλειδί"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Επεξεργαστής Κατηγοριών"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Αναζήτηση με"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Αναζήτηση κατά την πληκτρολόγηση"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Χρήση κανονικών εκφράσεων"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Προηγμένη Αναζήτηση"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Προσθήκη Κατηγορίας: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Χρονόμετρο"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Χρονοδιακόπτης</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Τέλος Χρόνου!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Η υπενθύμιση θα χτυπά μέχρι να κλείσετε αυτό το παράθυρο ή μηδενίσετε το "
 "χρονόμετρο."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Ρύθμιση _ Χρονομέτρου: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Επαναφορά"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Έναρξη"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "_Ήχος"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Σημείωση"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Επανάληψη υπενθύμισης μέχρι να την απενεργοποιήσω"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Ρυθμίσεις"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Επεξεργασία πεδίων σε όλη την βάση δεδομένων</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Πεδίο για _επεξεργασία:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Για κάθε επιλεγμένη τιμή:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "Η τιμή αυτή να π_αραμείνει ως έχει"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>Η νέα τιμή θα προστεθεί στο τέλος  κάθε υπάρχοντος κειμένου</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Η νέα τιμή θα αντικαταστήσει την τυχόν υπάρχουσα τιμή</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Πεδίο:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Τιμή:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Α_λλαγή διαφορετικού πεδίου:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "_ Αλλαγή τιμής σε: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "_Διαγραφή τιμής"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Επιλογή ισοδύναμου του</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>Από την USDA βάση δεδομένων</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "_Άλλαγή συστατικού"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>ή</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "_Αναζήτηση στην Βάση Συστατικών USDA:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Αναζήτηση κατά την π_ληκτρολόγηση"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Εμφάνισε φαγητό μόνο στην _ομάδα:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>_Αποτελέσματα Αναζήτησης:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>Από:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "Π_οσότητα"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Μονάδα:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "μονάδα"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "_Αλλαγή μονάδας"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "_Αποθήκευση νέας μονάδας"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i> Προς:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Μονάδα:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Εισαγωγή διατροφικών πληροφοριών για </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Choose a Density</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Πλήκτρο Συστατικού: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>USDA ατνικείμενο: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "Επεξεργασία του _USDA Association"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Διατροφικές πληροφορίες</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "Επεξεργασία _Πληροφοριών"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "_Διατροφικές πληροφορίες"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Πυκνότητα:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "USDA ισοδύναμα:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Προσαρμοσμένα ισοδύναμα:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "_Πληροφορίες Πυκνότητας"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Γνωστές Διατροφικές Πληροφορίες</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "_Προηγμένη Αναζήτηση"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Διατροφικές Πληροφορίες"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "Α_γνόησε"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Διαχείριση συνταγών Gourmet"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Πνευματική Ιδιοκτησία (c) 2004,2005,2006,2007,2008,2009,2010,2011 Thomas M. "
 "Hinkle. GNU GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -892,221 +898,170 @@ msgstr ""
 "μπορεί να υπολογίσει διατροφικές πληροφορίες από τις συνταγές, βασιζόμενος "
 "στα συστατικά τους."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (βοήθεια στη μεταφορά του προγράμματος στα Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-"Daniel Folkinshteyn <nanotube@gmail.com> (πρόγραμμα εγκατάστασης για τα "
-"Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (βελτιώσεις στο περιβάλλον του Μετατροπέα Μονάδων)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (βελτιώσεις στην εξαγωγή σε τύπο αρχείου Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-"ixat <ixat.deviantart.com> (λογότυπος και οθόνη παφλασμών (splash screen) )"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-"Yula Zubritsky (εικονίδια \"Διατροφή\" και \"Προσθήκη στον Κατάλογο Αγορών\")"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (βελτιώσεις στην διεθνοποίηση, "
-"ανάμεικτες διορθώσεις λαθών κώδικα)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Επιμέλεια έκδοσης για Windows και "
-"επανασχεδίαση Ιστοτόπου)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Επιλογή Βάσης Δεδομένων"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Αναβάθμιση βάσης δεδομένων"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Νέα Συνταγή"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Όνομα _Βάσης Δεδομένων:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"Αναλόγως του μεγέθους της βάσης δεδομένων, αυτό μπορεί να διαρκέσει λίγο "
-"παραπάνω. Τα δεδομένα σας έχουν αυτόματα αποθηκευτεί σε εφεδρικό αρχείο σε "
-"περίπτωση που κάτι πάει στραβά."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Λεπτομέρειες"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Ένα αντίγραφο δημιουργήθηκε στο %s σε περίπτωση που κάτι συμβεί. Αν αποτύχει "
 "αυτή η αναβάθμιση, μπορείτε να μετονομάσετε χειροκίνητα το αντίγραφο αρχείο "
 "recipes.db για να το επαναφέρετε για χρήση με το παλαιότερο Gourmet."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Νέα Συνταγή"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Αλλαγή _Κατηγορίας"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Δημιουργία νέας κατηγορίας"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Αλλάζει την κατηγορία του επιλεγμένου αντικειμένου"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Κελάρι"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Μετακίνηση στον Κατάλογο Αγορών"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Μετακίνηση στο κελλά_ρι"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Απομάκρυνση από τη λίστα αγορών"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Μετακίνηση των επιλεγμένων αντικειμένων στο %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Κατάλογος Αγορών"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Υπάρχουν ήδη (Αντικείμενα Κελαριού)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Εισάγετε Κατηγορία"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Κατηγορία για Προσθήκη του %s"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Κατηγορία:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Συνατγές"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Προσθήκη στοιχείων"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Απομάκρυνση Συνταγών"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Απομάκρυνση Συνταγών από τον Κατάλογο Αγορών"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "Επεξεργασία"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "Βοήθεια"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Προσθήκη στοιχείων"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Προσθήκη τυχαίων στοιχείων στο λίστα αγορών"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "Χ"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 "Δέν έχει επιλεχθεί καμμία συνταγή. Θέλεις να γίνει καθαρισμός όλης της "
 "λίστας;"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Αποθήκευση Λίστας Αντικειμένων προς Αγορά ως..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Επιλογή προαιρετικών συστατικών"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1115,57 +1070,59 @@ msgstr ""
 "να συμπεριλάβετε στον Κατάλογο Αγορών."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "Συνταγή"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Πήγαινε"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Εξαγωγή συνταγής"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Εξαγωγή επιλεγμένης συνταγής (αποθήκευση σε αρχείο)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Διαγραφή συνταγής"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Διαγραφή αυτής της συνταγής"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Προσαρμογή μονάδων όταν πολλαπλασιάζονται"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Αλλάζει τις μονάδες μέτρησης για να γίνουν πιο ευανάγνωστες όπου είναι "
 "δυνατόν όταν πολλαπλασιάζονται."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Εκτύπωση Συνταγής"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Προσθήκη στον _Κατάλογο Αγορών"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Ξέχνα τα προαιρετικά συστατικά"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1173,150 +1130,144 @@ msgstr ""
 "Πριν γίνει προσθήκη στη λίστα αγορών, ρωτά για όλα τα προαιρετικά συστατικά, "
 "ακόμη και αν κάποιο προηγουμένως θέλατε να υπάρχει στη μνήμη."
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Εξαγωγή Συνταγής"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Έχετε μη αποθηκευμένες αλλαγές."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Εφαρμογή των αλλαγών πριν την εκτύπωση;"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Εφαρμογή των αλλαγών πριν την εκτύπωση;"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Προαιρετικό)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Αδύνατη η εύρεση της Συνταγής %s στην Βάση Δεδομένων"
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Αλλαγή Συνταγής:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Αποθήκευση αλλαγών στη βάση δεδομένων"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Προβολή Καρτέλας Συνταγής"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Επεξεργασία"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Αποθήκευση αλλαγών στο %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Προσθήκη συστατικού"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Προσθήκη ομάδας"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Επικόλληση συστατικών"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Εισαγωγή από αρχείο"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Προσ_θήκη συνταγής"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Προσθήκη μιας άλλης συνταγής ως ένα συστατικό αυτής της συνταγής"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Πάνω"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Κάτω"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Επιλέξτε ένα αρχείο που να περιλαμβάνει τον Κατάλογο Συστατικών σας."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Οδηγίες"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Σημειώσεις"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Ποσότητα"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Μονάδα"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Αντικείμενο"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Προαιρετικό"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Η Συνταγή %s (ID %s) δεν είναι στην Βάση Δεδομένων μας."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Μετατραπείσες: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Μη Μετατραπείσες: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Αλλαγμένη Μονάδα."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1325,249 +1276,248 @@ msgstr ""
 "Έχετε αλλάξει την Μονάδα για %(item)s από %(old)s σε %(new)s. Θα θέλετε να "
 "μετατραπεί και η ποσότητα ή όχι;"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Μετατραπείσες %(old_amt)s %(old_unit)s σε %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Αδύνατη η Μετατροπή από %(old_unit)s σε %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Προσθήκη Ομάδας Συστατικών"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Εισάγετε το όνομα για τη νέα υποομάδα συστατικών"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Όνομα Ομάδας:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Επιλέξτε συνταγή"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Μια συνταγή δεν μπορεί να αποκαλεί τον εαυτό της συστατικό!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Δεν επιτρέπεται άπειρη αναδρομή στις Συνταγές!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Δεν έχεις επιλέξει καμμία συνταγή!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Πόσους από %(title)s καλεί η συνταγή σας;"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Συνταγές"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Ήχος Κουδουνίσματος"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Προειδοποιητικός Ήχος"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Ήχος Σφάλματος"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Παύση Χρονόμετρου;"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Διακοπή _χρονόμετρου"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "Διατήρηση Χρονομέτρησης"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Πρόσθετα"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Τα πρόσθετα παρέχουν επιπλέον λειτουργικότητα στο Gourmet."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Το πρόσθετο χρειάζεται για τη λειτουργία άλλων προσθέτων. Να απενεργοποιηθεί "
 "οπωσδήποτε;"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Τα ακόλουθα πρόσθετα χρειάζονται %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Απενεργοποίηση οπωσδήποτε"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Κράτησε το πρόσθετο ενεργό"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "ή"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Παρουσιάστηκε σφάλμα κατά την ενεργοποίηση του προσθέτου."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Παρουσιάστηκε σφάλμα κατά την απενεργοποίηση του προσθέτου."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Κουζίνα"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Αξιολόγηση"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Πηγή"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Ιστοσελίδα"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Χρόνος Προετοιμασίας"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Χρόνος Ψησίματος"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Τροποποιήσεις"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Λανθασμένη εισαγωγή δεδομένων."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Μη αριθμητικό στοιχείο."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Παύση"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Σταμάτημα"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Μή με ρωτήσεις ξανά για αυτό."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Είσαι σίγουρος ότι θές να το κάνεις"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "άριστη"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "σπουδαία"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "καλό"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "καλό"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "φτωχή"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Μετατροπή Αξιολογήσεων σε Κλίμακα 5 Αστέρων."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Μετατροπή Αξιολογήσεων."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Παρακαλώ δώστε σε κάθε μία από τις Αξιολογήσεις το ισοδύναμό της σε Κλίμακα "
 "από 1 έως 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Τρέχουσα Αξιολόγηση"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Αξιολόγηση βάσει 5 Αστέρων"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Κανένα αρχείο δεν έχει επιλεχθεί"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Επιλογή Τύπου _Αρχείου"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Δεν επιλέχθηκε αρχείο, γι'αυτό η ενέργεια ακυρώθηκε"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr "Συγγνώμη, αλλά είναι αδύνατο να καταλάβω το ποσό \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Οι ποσότητες πρέπει να είναι αριθμοί (κλάσματα ή δεκαδικοί), διαστήματα "
 "αριθμών ή κενα"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1588,86 +1538,86 @@ msgstr ""
 "διαχωρίσετε.\n"
 "Για παράδειγμα, μπορείτε να εισάγετε \"2-4\" ή \"1 1/2 -3 1/2\".\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "Όνο_μα Χρήστη:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Κωδικός:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "αλεύρι, για όλες τις χρήσεις"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "ζάχαρη"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "αλάτι"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "μαύρο πιπέρι, του εδάφους"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "πάγος"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "νερό"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "λάδι, φυτικό"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "λάδι, ελαιόλαδο"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Αγνωστο"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Η Συνταγή αναφέρει τον εαυτό της ως Συστατικό."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Το συστατικό %s θα αγνοηθεί."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Λίστα αντικειμένων προς αγορά για %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Για τις ακόλουθες συνταγές:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " Χ%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Για τις ακόλουθες συνταγές:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Επιλογή κωδικοποίησης"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1675,29 +1625,28 @@ msgstr ""
 "Αδύνατος ο καθορισμός της κατάλληλης κωδικοποίησης. Παρακαλώ επιλέξτε τη "
 "σωστή κωδικοποίηση απο τη παρακάτω λίστα."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Δες το Αρχείο με Κωδικοποίηση"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Η εισαγωγή είναι σε παύση"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Διακοπή εισαγωγής"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Κατάλογος Συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Λίστα _Αντικειμένων προς Αγορά"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Kostas Koniaris <kostas291@yahoo.com>\n"
@@ -1718,337 +1667,324 @@ msgstr ""
 "  p2esp https://launchpad.net/~p2esp\n"
 "  tzem https://launchpad.net/~athmakrigiannis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Αποθηκεύτηκε!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Σώσιμο των αλλαγών σε %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Μια εισαγωγή είναι ήδη σε πρόοδο."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Μια εξαγωγή είναι ήδη σε πρόοδο."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Μια διαγραφή είναι ήδη σε πρόοδο."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Εξοδος από το πρόγραμμα έτσι κι αλλιώς;"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Οχι έξοδος!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Διαγράφηκαν οριστικά %s από %s συνταγές"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Απορίμματα"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Περιήγηση, μόνιμη διαγραφή ή επαναφορά των διαγραμένων συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Συνταγές που δεν έχουν διαγραφεί "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Αριθμός από  %(unit)s από %(title)s για αγορά"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Πολλαπλασιασμός %s επί:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Ορισμός %(attributes)s για την %(num)s επιλεγμένη συνταγή;"
 msgstr[1] "Ορισμός %(attributes)s για τις %(num)s επιλεγμένες συνταγές;"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Τυχόν προϋπάρχουσες τιμές δεν θα αλλάξουν."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Η νέα τιμή θα αντικαταστήσει τις προϋπάρχουσες τιμές."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Αυτή η αλλαγή δεν αναιρείται"
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Ορισμός τιμών για τις επιλεγμένες συνταγές"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Αναζήτηση συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Άνοιγμα συνταγής"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Άνοιγμα της επιλεγμένης συνταγής"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Διαγραφή συνταγής"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Διαγραφή επιλεγμένων Συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Επεξεργασία συνταγής"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Άνοιγμα επιλεγμένων συνταγών στον επεξεργαστή συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "Ε_ξαγωγή επιλεγμένων συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Εξαγωγή των επιλεγμένων συνταγών σε αρχείο"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "Εκτύπωση"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "συνταγές"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Ομα_δική επεξεργασία συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Νέο"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Εισαγωγή αρχείου"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Εισαγωγή Συνταγής"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Εισαγωγή συνταγής από αρχείο"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Εισα_γωγή Ιστοσελίδας"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s συνταγή"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Εισαγωγή συνταγής από Ιστοσελίδα"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Ε_ξαγωγή όλων των συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Εξαγωγή όλων των συνταγών σε αρχείο"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "Έ_ξοδος"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "Ενέργειες"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Άνοιγμα Α_πορριμάτων"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Απορίμματα"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "Π_ροτιμήσεις"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Πρόσθετα"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 "Διαχείριση προσθέτων που πρσθέτουν επιπλέον λειτουργικότητα στο Gourmet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Ρυ_θμίσεις"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "Περί"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "Εργαλεία"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "Χρονόμετρο"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Εμφάνιση χρονομέτρου"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Δείκτες συνταγών που μπορούν να αναζητηθούν στη βάση δεδομένων."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Να διαγραφεί %s;"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "Έχετε μη σωθείσες αλλαγές στο %s. Είστε σίγουρος ότι θέλετε να το διαγράψετε;"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Διαγράφηκε"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Χωρίς Τίτλο"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Διαγραφή των συνταγών για πάντα;"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Διαγραφή της συνταγής για πάντα;"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Είσαι σίγουρος ότι θές να διαγράψεις τη <i>%s</i> συνταγή"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Είσαι σίγουρος ότι θες να διαγράψεις τις ακόλουθες συνταγές;"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Είσαι σίγουρος ότι θες να διαγράψεις τις %s επιλεγμένες συνταγές;"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Προβολή Συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Διαγραφή Συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Κατάλογος Συνταγών"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Διαγραφή συνταγής %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Ολοκληρώθηκε!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Εισαγωγή..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Επεξεργαστής Κ_λειδιού Συστατικού"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Μαζική επεξεργασία κλειδιών συστατικού"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "κλειδί"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "αντικείμενο"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Πεδίο"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Τιμή"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Πλήθος"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Αλλαγή όλων των Κλειδιών \"%s\" σε \"%s\";"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2059,12 +1995,12 @@ msgstr ""
 "με το Κλειδί \"%s\", δεν θα μπορείτε να διακρίνετε ανάμεσα σε αυτά και σ' "
 "εκείνα που αλλάζετε τώρα."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Αλλαγή όλων των αντικειμένων από \"%s\" σε \"%s\";"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2075,12 +2011,12 @@ msgstr ""
 "με το Αντικείμενο \"%s\", δεν θα μπορείτε να διακρίνετε ανάμεσα σε αυτά και "
 "σ' εκείνα που αλλάζετε τώρα."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Αλλαγή όλων των περιπτώσεων του \"%(unit)s\" σε \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2089,13 +2025,13 @@ msgstr ""
 "Αλλαγή  του \"%(unit)s\" σε \"%(text)s\" μόνο για Συστατικά \"%(item)s\" με "
 "Κλειδί \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Αλλαγή όλων των περιπτώσεων του \"%(amount)s\" %(unit)s σε %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2104,7 +2040,7 @@ msgstr ""
 "Αλλαγή του \"%(amount)s\" %(unit)s σε \"%(text)s\" %(unit)s μόνο όπου το "
 "Κλειδί Συστατικού είναι %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2113,11 +2049,11 @@ msgstr ""
 "Αλλαγή του \"%(amount)s\" %(unit)s σε \"%(text)s\" %(unit)s μόνο όπου το "
 "Κλειδί Συστατικών είναι %(key)s και όπου το Αντικείμενο είναι %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Αλλαγή όλων των επιλεγμένων σειρών;"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2126,7 +2062,7 @@ msgstr ""
 "Αυτή η ενέργεια είναι μη αναστρέψιμη. Είστε σίγουρος ότι για όλες τις %s "
 "επιλεγμένες γραμμές, θέλετε να εισάγετε τις ακόλουθες τιμές:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2135,7 +2071,7 @@ msgstr ""
 "\n"
 "Κλειδί σε %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2144,7 +2080,7 @@ msgstr ""
 "\n"
 "Αντικείμενο σε %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2153,7 +2089,7 @@ msgstr ""
 "\n"
 "Μονάδα σε %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2162,8 +2098,8 @@ msgstr ""
 "\n"
 "Ποσότητες σε %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2172,23 +2108,23 @@ msgstr[1] "%s συστατικά"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Παρουσίαση συστατικών από %(bottom)s μέχρι %(top)s με σύνολο %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Ποσό"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Κλειδιά συστατικού"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2196,11 +2132,11 @@ msgstr ""
 "Τα κλειδιά συστατικού είναι βελτιστοποιημένα ονοματα συστατικών που "
 "χρησιμοποιούνται για τις λίστες αγορών και για τους υπολογισμούς."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Μάντεψε τα κλειδιά"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2208,60 +2144,60 @@ msgstr ""
 "Μάντεψε τις καλύτερες τιμές για όλα τα κλειδιά συστατικού βασισμένα σε τιμές "
 "που ήδη υπάρχουν"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Επεξεργασία Συσχετισμών Πλήκτρων"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 "Επεξεργάζεται τις συσχετίσεις του κλειδιού και άλλων ιδιοτήτων στη βάση "
 "δεδομένων."
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Επεξεργαστής Πλήκτων"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "_Αντικέιμενο"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Πλήκτρο:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>_Αλλαγή επιλεγμένων συστατικών</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Κατηγορία Αγορών"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 "Εμφανίζει τις μονάδες μέτρησης όπως είναι γραμμένες για κάθε συνταγή (καμμία "
 "αλλαγή)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Πάντοτε να εμφανίζονται μονάδες μετρήσεως Η.Π.Α"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Πάντοτε να εμφανίζονται μετρικές μονάδες μετρήσεως"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Αυτόματη ρύθμιση μονάδων"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Ορισμός προτιμήσεων εμφάνισης _μονάδων"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2269,42 +2205,42 @@ msgstr ""
 "Μετατρέπει αυτόματα τις μονάδες στο προτιμώμενο σύστημα (μετρικό, αγγλικό, κ."
 "τ.λ.) όπου είναι δυνατόν"
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Αστέρια"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "από %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Αυτόματση Συγχώνευση συνταγών"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Πάντοτε να χρησιμοποιείται η νεότερη συνταγή"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Πάντοτε να χρησιμοποιείται η παλαιότερη συνταγή"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Τίποτα"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2313,97 +2249,97 @@ msgstr ""
 "τις συγχνεύσετε εδώ, ή να κλείσετε αυτό το διάλογο και να τις αφήσετε όπως "
 "είναι."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Εύρεση _διπλών συνταγών"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Εύρεση και διαγραφή διπλών συνταγών"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Συνταγές με παρόμοιες πληροφορίες"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Συνταγές με παρόμοια συστατικά"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Συνταγές με παρόμοιες πληροφορίες και συστατικά"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Διπλότυπες συνταγές</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "_Συμπεριέλαβε συνταγές που βρίσκονται στον κάδο"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Εμφάνιση:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Συγχώνευση _όλων των διπλότυπων"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b> Συγχώνευση συνταγών</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "_Αυτόματη συγχώνευση"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Για κάθε επιλεγμένη τιμή"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Όπου το %(field)s είναι %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Η αλλαγή θα γίνει %s συνταγή"
 msgstr[1] "Η αλλαγή θα γίνει %s συνταγές"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Διαγραφή  %s όπου αυτό είναι  %s;"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Αλλαγή του  %s από  %s σε \" %s\""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Αυτή η αλλαγή δεν είναι αντιστρέψιμη.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Επεξεργαστής Πεδίου"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Επεξεργασία πεδίων μεταξύ πολλαπλών συνταγών μονομιάς."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Αποστολή συνταγών με Email"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Αποστολή όλων των επιλεγμένων συνταγών με Email (ή όλες οι συνταγές αν δεν "
@@ -2412,163 +2348,151 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 "Θέλετε πραγματικά να στείλετε με email όλες τις %s επιλεγμένες συνταγές;"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Ναι, στείλε τις με e_mail"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Αδύνατη η μετατροπή από %s σε %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Απαιτούνται πληροφορίες για την πυκνότητα."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Μετατροπέας Μονάδων"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Υπολογίζει τις μετατροπές μονάδων"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Μετατροπέας Μονάδων"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Από</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "Α_ντικείμενο"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "Πυκνό_τητα"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Πληροφορία Π_υκνότητας"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Σε</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "Αποτέ_λεσμα"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ";"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Αρχείο (zip, tarball)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Φόρτωση Αρχείου zip"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Αποσυμπίεση Αρχείου zip"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "Ιστοσελίδα τύπου HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Εξαγωγή Ιστοσελίδας"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Εξαγωγή συνταγών σε αρχεία τύπου HTML στον κατάλογο %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Η συνταγή αποθηκεύτηκε στο αρχείο τύπου HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Πρωτότυπη Σελίδα από %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "προαιρετικό"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Εξαγωγή Ιστοσελίδας"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Εξαγωγή συνταγών σε αρχεία τύπου HTML στον κατάλογο %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Η συνταγή αποθηκεύτηκε στο αρχείο τύπου HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Αρχείο Απλού Κειμένου"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Εξαγωγή σε Αρχείο Κειμένου"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Εξαγωγή συνταγών στο αρχείο κειμένου %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Η συνταγή αποθηκεύτηκε ως αρχείο απλού κειμένου %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Μεγάλο Αρχείο"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Το αρχείο %s είναι πολύ μεγάλο για να εισαχθεί"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2580,81 +2504,54 @@ msgstr ""
 "εισαγάγετε, χρησιμοποιείστε έναν επεξεργαστή κειμένου για να χωρίσετε το "
 "αρχείο σε μικρότερα αρχεία και δοκιμάστε να το εισαγάγετε ξανά."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Ιστοσελίδα"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Κατέβασμα %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Λίστα αντικειμένων προς αγορά για %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Ανάκτηση %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Αρχείο τύπου Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Εξαγωγή σε αρχείο τύπου Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Εξαγωγή Συνταγών στο Αρχείο Gourmet XML %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Η Συνταγή αποθηκεύθηκε ως Αρχείο Gourmet XML %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Αρχείο Gourmet XML (Απαρχαιομένο)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Αρχείο Mastercook XML"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Αρχείο Κειμένου Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Η εισαγωγή του αρχείου τύπου Mastercook ολοκληρώθηκε."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Συγύρισμα της XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "Αρχείο KRecipe XML"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2663,275 +2560,296 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Διαμόρφωση Σελίδας"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Εκτύπωση των Συνταγών"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Τύπος Φορητού Εγγράφου)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Εξαγωγή σε PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Εξαγωγή Συνταγών σε PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Η Συνταγή αποθηκεύθηκε ως PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Γράμμα"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Κατακόρυφος"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Απλό"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "points"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Κατάλογος Καρτών (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Κατάλογος Καρτών (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Κατάλογος Καρτών (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Κατάλογος Καρτών (Α7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Γράμμα"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Νομικά Θέματα"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Κατάλογος Καρτών (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Κατάλογος Καρτών (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Κατάλογος Καρτών (Α7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Οριζόντιος"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Απλό"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Στήλη"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Στήλη"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Στήλη"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Στήλη"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s Στήλη"
 msgstr[1] "%s Στήλες"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Κατακόρυφος"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Οριζόντιος"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Μέγεθος _Σελίδας"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "Προσανατολισμός"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Μέγεθος Γραμματοσειράς"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Σχεδιάγραμμα Σελίδας"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Μέγεθος Γραμματοσειράς"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Αριστερό Περιθώριο"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Δεξιό Περιθώριο"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Άνω Περιθώριο"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Κάτω Περιθώριο"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "Επιλογές PDF"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "Αρχείο MealΜaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Εξαγωγή σε αρχείο MealΜaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Εξαγωγή Συνταγών σε αρχεία τύπου MealMaster %(file)s"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Η Συνταγή αποθηκεύτηκε ως Αρχείο Τύπου MealMaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "σερβίρισμα"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Μεγάλο Αρχείο"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Εξαγωγή HTML"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Εξαγωγή Συνταγών στο Αρχείο Gourmet XML %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Η Συνταγή αποθηκεύθηκε ως Αρχείο Gourmet XML %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Αποθήκευση Λίστας Αγορών"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Αποθήκευση Λίστας ως Συνταγή"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Αποθήκευση της τρέχουσας λίστας αγορών ως συνταγή για μελλοντική χρήση"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Μενού για %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Μενού"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Διατροφικές Πληροφορίες αντικατοπτρίζουν το ποσό για %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 "Διατροφικές Πληροφορίες αντικατοπτρίζουν το ποσό για ολόκληρη τη συνταγή."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Λείπουν οι διατροφικές πληροφορίες για %s συστατικά: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Οποιαδήποτε Ομάδα Τροφών"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "επιλογή"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Μετατροπή Μονάδας για %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Προκειμένου να υπολογίσει τις Διατροφικές Πληροφορίες ο Gourmet, χρειάζεται "
 "να μετατρέψετε την \"%s\" σε μια Μονάδα που να αντιλαμβάνεται."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Αλλαγή κλειδιού συστατικού"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2940,29 +2858,29 @@ msgstr ""
 "Αλλαγή του Κλειδιού Συστατικών από %(old_key)s σε %(new_key)s παντού ή μόνο "
 "στην Συνταγή %(title)s;"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Αλλαγή _παντού"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Μόνο στην συνταγή %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 "Αλλαγή του κλειδιού συστατικού έτσι και αλλιώς από %(old_key)s σε "
 "%(new_key)s;"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Αλλαγή μονάδας"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2971,11 +2889,11 @@ msgstr ""
 "Αλλαγή μονάδας από %(old_unit)s σε %(new_unit)s για όλα τα συστατικά "
 "%(ingkey)s ή μόνο για την συνταγή %(title)s;"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2984,198 +2902,199 @@ msgstr ""
 "Διατροφική Βάση Δεδομένων μας έχει διάφορες περιγραφές αυτού του Φαγητού με "
 "διαφορετικές Πυκνότητες. Παρακαλώ επιλέξτε την σωστή από τις παρακάτω."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Για να εφαρμόσει τις Διατροφικές Πληροφορίες, το Gourmet χρειάζεται έγκυρα "
 "ποσό και μονάδα."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Διατροφή"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Συστατικό"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Ισοδύναμο στην Βάση Δεδομένων USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 γραμμάρια"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Θερμίδες"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Ολικό Λίπος"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Κορεσμένα Λιπαρά"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Χοληστερόλη"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Νάτριο"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Συνολικοί Υδρογονάνθρακες"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Διαιτητικές Ίνες"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Σάκχαρα"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Πρωτεΐνες"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "α-Καροτένιο"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Τέφρα"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "β-Κατοτένιο"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "β-Κρυπτοξανθίνη"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Ασβέστιο"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Χαλκός"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Ολικό Φολικό"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Φολικό Οξύ"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Φολικό Τροφής"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Ισοδύναμα Διαιτητικού Φολικού"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Σίδηρος"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Λυκοπένη"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Λουτεΐνη+Ζεαζανθίνη"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Μαγνήσιο"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Μαγγάνιο"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Νιασίνη"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Παντοθενικό Οξύ"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Φώσφορος"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Κάλλιο"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Βιταμίνη Α"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Ρετινόλη"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Ριβοφλαβίνη"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Σελήνιο"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Θειαμίνη"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Βιταμίνη A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Βιταμίνη Α (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Βιταμίνη B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Βιταμίνη B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Βιταμίνη C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Βιταμίνη Ε"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Βιταμίνη Κ"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Ψευδάργυρος"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Βιταμίνες και μεταλλικά στοιχεία"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3184,11 +3103,11 @@ msgstr ""
 "Απούσες Διατροφικές Πληροφορίες\n"
 "για %(missing)s των %(total)s Συστατικών."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Καθημερινή Ποσότητα"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3197,369 +3116,369 @@ msgstr ""
 "Ποσοστό  Συνιστωμένης Ημερήσιας Παροχής βαρισμένο στο %i Θερμίδων ανά Ημέρα. "
 "Κάντε κλικ για να επεξεργαστείτε τον αριθμό Θερμίδων ανά Ημέρα."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Ποσό για  %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Ποσό ανά Συνταγή"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Φόρτωση Διατροφικών Δεδομένων"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Ολοκληρώθηκε η Εισαγωφή της Διατροφικής Βάσης Δεδομένων!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Προσκόμιση Διατροφικής Βάσης Δεδομένων από το αρχείο zip %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Εξαγωγή %s από αρχείο zip."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Ανάλυση Διατροφικών Δεδομένων..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Ανάγνωση Διατροφικών Δεδομένων: Εισήχθησαν %s από %s εγγραφές."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Ανάλυση Δεδομένων Βάρους..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Ανάγνωση Δεδομένων Βάρους φια Διατροφικά Αντικείμενα: Εισήχθησαν %s από %s "
 "εγγραφές."
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Νερό"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Χιλιοθερμίδες"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g Πρωτεΐνη"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g Λιπίδια"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g Τέφρα"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g Yδρογονάνθρακες"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g Ίνες"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g Σακχάρων"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg Ασβεστίου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg Σιδήρου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg μαγνήσιου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg φωσφόρου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg Καλίου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg Νατρίου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg Ψευδαργύρου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg Χαλκού"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg Μαγγανίου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "μg Σεληνίου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg βταμίνη c"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg Θειαμίνη"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg Ριβοφλαβίνης"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg Νιασίνης"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg Παντοθενικού Οξέος"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg βιταμίνη B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "μg Ολικού Φολικού"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "μg Φολικού Οξέος"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "μg Φολικού Τροφής"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "μg Ισοδύναμα Διαιτητικού Φολικού"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Συνολική Χολίνη"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "μg Βιταμίνης B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "IU Βιταμίνης A"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Βιταμίνη Α (Ισοδύναμο σε μg Ρετιναλικής Δραστηριότητας)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "μg Ρετινόλης"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "μg α-Καροτένιου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "μg β-Καροτένιου"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "μg β-Κρυπτοξαθίνης"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "μg Λυκοπένης"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "μg Λουτεΐνης+Ζεαζανθίνης"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Βιταμίνη Ε"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Βιταμίνη Κ"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g Κεκορεσμένων Λιπαρών Οξέων"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g Μονοακόρεστων Λιπαρών Οξέων"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g Πολυακόρεστων Λιπαρών Οξέων"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Χοληστερόλης"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Ποσοστό Άρνησης"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Γαλακτοκομικά Προϊόντα & Αυγά"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Μπαχαρικά & Βότανα"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Βρεφικές Τροφές"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Λιπαρά και Έλαια"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Πουλερικά"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Σούπες & Σάλτσες"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Λουκάνικα & Κρέας"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Δημητριακά Πρωινού"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Φρούτα & Χυμοί Φρούτων"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Χοιρινό"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Λαχανικά"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Ξηροί Καρποί & Σπόροι"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Μπιφτέκι"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Ποτά"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Ψαρια & Όστρακα"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Όσπρια"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Αρνί, Μοσχάρι & Game"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Ψημένα Προϊόντα"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Γλυκά"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Δημητριακά και Ζυμαρικά"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Φαστ Φουντ"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Γεύματα, Ορεκτικά και Συνοδευτικά"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Σνακς"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Έθνικ Φαγητά"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "ολόκληρη η βάση"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Κλειδί Συστατικού"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "Αριθμός USDA ID"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "Περιγραφή Στοιχεόυ USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Ισοδύναμο Πυκνότητας"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3573,59 +3492,59 @@ msgstr "Εργαλεία"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Ανάκτηση διατροφικών πληροφοριών για την τρέχουσα λίστα"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Σύνολο για την Λίστα Αγορών"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "Επεξεργασία _διατροφικών πλαροφοριών"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "Αστέρια"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Εξαχθείσες %(number)s από %(total)s Συνταγές"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Η εξαγωγή ολοκληρώθηκε."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Συμπερίληψη Συνταγής στο Σώμα του e-Mηνύματος"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "e-Ταχυδρόμηση Συνταγής ως Συνvημένο HTML"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Αποστολή Συνταγής με E-mail ως PDF Συννημένο"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Επιλογές e-Ταχυδρομείου"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Χωρίς ερώτηση πριν την αποστολή e-Μηνύματος."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Το e-Μήνυμα Ηλεκτρονικού δεν στάλθηκε"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3633,238 +3552,192 @@ msgstr ""
 "Δεν έχετε επιλέξει να συμπεριληφθεί η Συνταγή στο Σώμα του Μηνύματος ή ως "
 "Συννημμένο."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Αποθήκευση συνταγής ως..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Το Gourmet δεν μπορεί να εξάγει σε αρχείο τύπου \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Εξαγωγή συνταγών"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "συνταγές"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Αδύνατον να εξαχθεί: άγνωστος τύπος αρχείου \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Παρακαλώ σιγουρευτείτε ότι θα επιλέξετε ένα τύπο αρχείου από το πτυσσόμενο "
 "μενού όταν το αποθηκεύετε."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Εξαγωγή"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Αδυναμία εκτύπωσης: δεν υπάρχουν ενεργοποιημένα πρόσθετα εκτύπωσης!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Εκτύπωση %s συνταγής"
 msgstr[1] "Εκτύπωση %s συνταγών"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Ανάκτηση αρχείου"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "απόδοση"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Εισάγετε το URL ενός Αρχείου ή Ιστοχώρου Συνταγών."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Εισάγετε διεύθυνση ιστοσελίδας"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Εισαγωγή URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Εισάγετε την διεύθυνση μιας ιστοσελίδας ή ενός αρχείου συνταγής."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Αδύνατον να εισάγω το URL"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Η εφαρμογή Gourmet δεν έχει πρόσθετο ικανό για την ισαγωγή URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Αδύνατον να εισαχθεί το URL %(url)s του τύπου %(type)s. Το αρχείο "
-"αποθηκεύτηκε προσωρινά στην τοποθεσία %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Άνοιγμα συνταγής..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Εισάγετε διεύθυνση ιστοσελίδας"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Τροποποιήσεις"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Εισάγετε την διεύθυνση μιας ιστοσελίδας ή ενός αρχείου συνταγής."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Εισαγωγή"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Όλα τα Εισαγώγιμα Αρχεία"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Εισαχθείσες %s συνταγές."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "σερβίρισμα"
 msgstr[1] "σερβιρίσματα"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Εισήχθησαν %s από %s συνταγές."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "Εντάξει"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Δεν είναι δυνατή η αναγνώριση του wesite. Χρήση γενικού εισαγωγέα..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Η εισαγωγή δεδομένων ολοκληρώθηκε."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Εισαγωγή Συνταγής"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Επεξεργασία υλικών"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Επεξεργασία υλικών."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Σερβιρίσματα"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Υποομάδα συστατικού"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Απόκρυψη"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Κείμενο"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Ενέργειες"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Εισαγωγή συνταγής"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Καθαρισμός Ε_τικετών"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Εισαγωγή Συνταγής"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "οπουδήποτε"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "Τίτλος"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "Συστατικό"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "Οδηγίες"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "σημειώσεις"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "Κουζίνα"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "πηγή"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Χρήση κανονικών παραστάσεων κατά την αναζήτηση"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Χρήση κανονικών παραστάσεων (μια προχωρημένη γλώσσα αναζήτησης) για "
 "αναζήτηση κειμένου"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 "Αναζήτηση κατά την πληκτρολόγηση (απενεργοποιείστε αν η αναζήτηση είναι πολύ "
 "αργή)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Εμφάνιση _Επιλογών Αναζήτησης"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Εμφανίζει προχωρημένες επιλογές αναζήτησης"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3873,104 +3746,98 @@ msgstr[1] "%s συναταγές"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Παρουσίαση Συνταγών %(bottom)s έως %(top)s από %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s σε %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Παύση"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "Εισαγωγή από KRecipe"
 msgstr[1] "Εισαγωγή από KRecipe"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Παύση"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Ολοκληρώθηκε"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Σφάλμα: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Σφάλμα"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Σφάλμα %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "ανατρέξτε"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "δευτερόλεπτο"
 msgstr[1] "δευτερόλεπτα"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "λεπτά"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "λεπτό"
 msgstr[1] "λεπτά"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "ώρες."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ώρα"
 msgstr[1] "ώρες"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "ημέρα"
 msgstr[1] "ημέρες"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "εβδομάδα"
 msgstr[1] "εβδομάδες"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "μήνας"
@@ -3979,7 +3846,7 @@ msgstr[1] "μήνες"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "έτος"
@@ -3991,73 +3858,30 @@ msgstr[1] "έτη"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " και "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "και"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "προς"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Αρχείο τύπου Gourmet XML"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Διαχείριση συνταγών Gourmet"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Οργανώστε συνταγές, δημιουργήστε καταστάσεις αγορών, υπολογίστε τις "
-"διατροφικές πληροφορίες και άλλα"
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Προσπέλαση Συνταγών"
@@ -4067,7 +3891,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Επιλογή συνταγών με προσπέλαση ανά κατηγορία, κουζίνα, κλπ."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Κύριο"
@@ -4080,38 +3903,6 @@ msgstr "Εύρεση διπλότυπων συνταγών"
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr "Ένας οδηγός εύρεσης και αφαίρεσης ή συγχώνευσης  διπλότυπων συνταγών."
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Αποστολή στο E-mail"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Αποστολή συνταγών από το Gourmet με E-mail"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Υποστήριξη για Zip, Gzip και Tarball αρχεία"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Εισαγωγή συνταγών από zip ή tar αρχεία"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Εισαγωγέας/Εξαγωγέας"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4121,6 +3912,18 @@ msgstr "Εξαγωγή σε PDF"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Δημιουργία ιστοσελίδων συνταγών από συνταγές."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Εισαγωγέας/Εξαγωγέας"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4133,14 +3936,6 @@ msgid ""
 msgstr ""
 "Εισαγωγή και Εξαγωγή συνταγών ως XML αρχείων του Gourmet, κατάλληλα για "
 "αντίγραφα ασφαλείας ή ανταλλαγή με άλλους χρήστες του Gourmet."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "Εξαγωγή HTML"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Δημιουργία ιστοσελίδων συνταγών από συνταγές."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4202,22 +3997,6 @@ msgid ""
 msgstr ""
 "Βοήθεια χρήστη να επιλέξει και να εισάγει απλό κείμενο. Επιπλέον παρέχει "
 "εξαγωγή απλού κειμένου."
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Εισαγωγή Ιστοσελίδας"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Εισαγωγή συνταγών από το διαδίκτυο."
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Εισαγωγείς Ιστοσελίδων"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Εισαγωγείς για about.com, www.foodnetwork.com, και άλλων"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4287,6 +4066,202 @@ msgstr ""
 "Gourmet. Απενεργοποιήστε το αν ποτέ δεν χρησιμοποιείτε το UTF16 και "
 "ενοχλείστε από την συνεχή εμφάνιση του διαλόγου \"Κωδικοποίηση\" όταν "
 "εισάγετε αρχεία."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Αποστολή επιλεγμένης συνταγής με E-mail"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "Αποστολή Συνταγής με E-mail"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (βοήθεια στη μεταφορά του προγράμματος στα Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr ""
+#~ "Daniel Folkinshteyn <nanotube@gmail.com> (πρόγραμμα εγκατάστασης για τα "
+#~ "Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (βελτιώσεις στο περιβάλλον του Μετατροπέα Μονάδων)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (βελτιώσεις στην εξαγωγή σε τύπο αρχείου Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr ""
+#~ "ixat <ixat.deviantart.com> (λογότυπος και οθόνη παφλασμών (splash "
+#~ "screen) )"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr ""
+#~ "Yula Zubritsky (εικονίδια \"Διατροφή\" και \"Προσθήκη στον Κατάλογο "
+#~ "Αγορών\")"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (βελτιώσεις στην "
+#~ "διεθνοποίηση, ανάμεικτες διορθώσεις λαθών κώδικα)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Επιμέλεια έκδοσης για Windows και "
+#~ "επανασχεδίαση Ιστοτόπου)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Αναβάθμιση βάσης δεδομένων"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Αναλόγως του μεγέθους της βάσης δεδομένων, αυτό μπορεί να διαρκέσει λίγο "
+#~ "παραπάνω. Τα δεδομένα σας έχουν αυτόματα αποθηκευτεί σε εφεδρικό αρχείο "
+#~ "σε περίπτωση που κάτι πάει στραβά."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Επικόλληση συστατικών"
+
+#~ msgid "Import from file"
+#~ msgstr "Εισαγωγή από αρχείο"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr ""
+#~ "Επιλέξτε ένα αρχείο που να περιλαμβάνει τον Κατάλογο Συστατικών σας."
+
+#~ msgid "No file selected"
+#~ msgstr "Κανένα αρχείο δεν έχει επιλεχθεί"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Δεν επιλέχθηκε αρχείο, γι'αυτό η ενέργεια ακυρώθηκε"
+
+#~ msgid "_Import file"
+#~ msgstr "_Εισαγωγή αρχείου"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Εισα_γωγή Ιστοσελίδας"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Εισαγωγή συνταγής από Ιστοσελίδα"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Άνοιγμα Α_πορριμάτων"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Αρχείο (zip, tarball)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Φόρτωση Αρχείου zip"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Αποσυμπίεση Αρχείου zip"
+
+#~ msgid "Webpage"
+#~ msgstr "Ιστοσελίδα"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Κατέβασμα %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Λίστα αντικειμένων προς αγορά για %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Ανάκτηση %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Ανάκτηση αρχείου"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Εισάγετε το URL ενός Αρχείου ή Ιστοχώρου Συνταγών."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Εισαγωγή URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Αδύνατον να εισάγω το URL"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Η εφαρμογή Gourmet δεν έχει πρόσθετο ικανό για την ισαγωγή URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Αδύνατον να εισαχθεί το URL %(url)s του τύπου %(type)s. Το αρχείο "
+#~ "αποθηκεύτηκε προσωρινά στην τοποθεσία %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η αναγνώριση του wesite. Χρήση γενικού εισαγωγέα..."
+
+#~ msgid "Import complete."
+#~ msgstr "Η εισαγωγή δεδομένων ολοκληρώθηκε."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Εισαγωγή Συνταγής"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Επεξεργασία υλικών"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Επεξεργασία υλικών."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Αρχείο τύπου Gourmet XML"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Διαχείριση συνταγών Gourmet"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Οργανώστε συνταγές, δημιουργήστε καταστάσεις αγορών, υπολογίστε τις "
+#~ "διατροφικές πληροφορίες και άλλα"
+
+#~ msgid "Send to Email"
+#~ msgstr "Αποστολή στο E-mail"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Αποστολή συνταγών από το Gourmet με E-mail"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Υποστήριξη για Zip, Gzip και Tarball αρχεία"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Εισαγωγή συνταγών από zip ή tar αρχεία"
+
+#~ msgid "HTML Export"
+#~ msgstr "Εξαγωγή HTML"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Δημιουργία ιστοσελίδων συνταγών από συνταγές."
+
+#~ msgid "Webpage import"
+#~ msgstr "Εισαγωγή Ιστοσελίδας"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Εισαγωγή συνταγών από το διαδίκτυο."
+
+#~ msgid "Website Importers"
+#~ msgstr "Εισαγωγείς Ιστοσελίδων"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Εισαγωγείς για about.com, www.foodnetwork.com, και άλλων"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4424,9 +4399,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "_Μερίδες"
-
-#~ msgid "Select File_type"
-#~ msgstr "Επιλογή Τύπου _Αρχείου"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Το αρχείο με το όνομα %s υπάρχει ήδη."

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-06-20 00:25+0000\n"
 "Last-Translator: Vincent Lhote <Unknown>\n"
 "Language-Team: English (Australia) <en_AU@li.org>\n"
@@ -20,506 +20,506 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Add to Shopping List"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+msgid "Copy selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +527,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +560,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,651 +854,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Add to Shopping List"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1509,445 +1461,425 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Vincent Lhote https://launchpad.net/~vincent.lhote\n"
 "  jamie edgar https://launchpad.net/~jolt76"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+msgid "_Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1955,12 +1887,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1968,78 +1900,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2048,386 +1980,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2435,81 +2355,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2518,880 +2411,897 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3405,288 +3315,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3695,103 +3559,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3800,7 +3658,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3812,69 +3670,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3884,7 +3703,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3897,44 +3715,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3945,14 +3743,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4006,22 +3796,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2013-10-02 23:45+0000\n"
 "Last-Translator: cne007 <Unknown>\n"
 "Language-Team: English (Canada) <en_CA@li.org>\n"
@@ -20,506 +20,506 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Recipe Index"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Add to _Shopping List"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "View Re_cipe"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Search for:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_in"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "A_dd Search Criteria"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Limiting Search to:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Search _Results"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Rating:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Image:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Host:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Username"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Password:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_File"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Browse"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Details"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Card View"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+msgid "Copy selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +527,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +560,287 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Amount:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "Unit"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
-msgstr ""
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
+msgstr "Recipe Index"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,651 +855,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Add to _Shopping List"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1509,113 +1462,112 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Username"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Password:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1623,335 +1575,316 @@ msgstr ""
 "  Vincent Lhote https://launchpad.net/~vincent.lhote\n"
 "  cne007 https://launchpad.net/~lepelerin2002"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+msgid "_Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Recipe Index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1959,12 +1892,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1972,78 +1905,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2052,386 +1985,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "None"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2439,81 +2360,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2522,881 +2416,898 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_File"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3410,288 +3321,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3700,103 +3565,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3805,7 +3664,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3817,70 +3676,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Recipe Index"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3890,7 +3709,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3903,44 +3721,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3951,14 +3749,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4012,22 +3802,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-06-20 00:24+0000\n"
 "Last-Translator: Vincent Lhote <Unknown>\n"
 "Language-Team: British English <en@li.org>\n"
@@ -18,508 +18,511 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_New Recipe"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Add to _Shopping List"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Yield Unit"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_File"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recipe"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Details"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gourmet Recipe Manager"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Show timer"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Shopping List"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Title"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "category"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Yield"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Yield Unit"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recipe"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredients"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Delete Recipe"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Open selected recipe"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Choose recipe"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +530,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Category"
 
@@ -560,286 +563,288 @@ msgstr "Category"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Key"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Search as you type"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Timer"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "unit"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Nutritional Information"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet Recipe Manager"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -862,215 +867,167 @@ msgstr ""
 "recipes. Gourmet can also calculate nutritional information for recipes "
 "based on the ingredients."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Windows porting assistance)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (improvements to Unit Converter interface)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (improvements to Mealmaster export)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo and splash screen)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Windows version maintenance and website "
-"re-design)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Choose Database File"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Upgrading database"
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr "Details"
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "New Recipe"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr "Details"
+
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+"A backup has been made in %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename your backup file recipes.db to recover it for "
+"use with older Gourmet."
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Change _Category"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Create new category"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Change the category of the currently selected item"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Pantry"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Move to _Shopping List"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Move to _pantry"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Remove from shopping list"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Move selected items into %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Shopping List"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Already Have (_Pantry Items)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Enter Category"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Category to add %s to"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Category:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recipes"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Add items:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Remove Recipes"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Remove recipes from shopping list"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Edit"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Help"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Add items"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Add arbitrary items to shopping list"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "No recipes selected. Do you want to clear the entire list?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Save Shopping List As..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Select optional ingredients"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1079,56 +1036,58 @@ msgstr ""
 "include on your shopping list."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recipe"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Go"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Export recipe"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Export selected recipe (save to file)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Delete recipe"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Delete this recipe"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Adjust units when multiplying"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Change units to make them more readable where possible when multiplying."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Print recipe"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Add to _Shopping List"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Forget remembered optional ingredients"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1136,150 +1095,144 @@ msgstr ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Export Recipe"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "You have unsaved changes."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Apply changes before printing?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Apply changes before printing?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Optional)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Unable to find recipe %s in database."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Edit Recipe:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Save edits to database"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "View Recipe Card"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Edit"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Save changes to %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Add ingredient"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Add group"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Paste ingredients"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Import from file"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Add _recipe"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Add another recipe as an ingredient in this recipe"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Delete"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Up"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Down"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Choose a file containing your ingredient list."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Description"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instructions"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notes"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Amt"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Unit"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Item"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Optional"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "The recipe %s (ID %s) is not in our database."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Converted: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Not Converted: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Changed unit."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1288,231 +1241,230 @@ msgstr ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Unable to convert from %(old_unit)s to %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Adding Ingredient Group"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Enter a name for new subgroup of ingredients"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Name of group:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Choose recipe"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Recipe cannot call itself as an ingredient!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Infinite recursion is not allowed in recipes!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "You haven't selected any recipes!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "How much of %(title)s does your recipe call for?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recipes"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Ringing Sound"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Warning Sound"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Error Sound"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Stop timer?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Stop _timer"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Keep timing"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
-msgstr ""
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
+msgstr "Manage plugins which add extra functionality to Gourmet."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr "Plugin is needed for other plugins. Deactivate plugin anyway?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "The following plugins require %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Deactivate anyway"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Keep plugin active"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "or"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "An error occurred activating plugin."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "An error occurred deactivating plugin."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Cuisine"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Rating"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Source"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Website"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Preparation Time"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Cooking Time"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Modifications"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Invalid input."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Not a number."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pause"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stop"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Don't ask me this again."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Do you really want to do this"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "excellent"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "great"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "good"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "fair"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "poor"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Convert ratings to 5 star scale."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Convert ratings."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Please give each of the ratings an equivalent on a scale of 1 to 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Current Rating"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Rating out of 5 Stars"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Select File_type"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "No file was selected, so the action has been cancelled"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1521,13 +1473,13 @@ msgstr ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1547,84 +1499,84 @@ msgstr ""
 "To enter a range of numbers, use a \"-\" to separate them.\n"
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "flour, all purpose"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "sugar"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "salt"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "black pepper, ground"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "ice"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "water"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "oil, vegetable"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "oil, olive"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Unknown"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Recipe calls for itself as an ingredient."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Ingredient %s will be ignored."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Shopping list for %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "For the following recipes:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "For the following recipes:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Select encoding"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1632,29 +1584,28 @@ msgstr ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "See _file with encoding"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Import paused"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Stop import"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Recipe _Index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Shopping _List"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1671,335 +1622,322 @@ msgstr ""
 "  Vincent Lhote https://launchpad.net/~vincent.lhote\n"
 "  eadmund https://launchpad.net/~eadmund"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Saved!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Save your edits to %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "An import is in progress."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "An export is in progress."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "A delete is in progress."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Exit program anyway?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Don't exit!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Permanently deleted %s of %s recipes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Trash"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Browse, permanently delete or undelete deleted recipes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Undeleted recipes "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Number of %(unit)s of %(title)s to shop for"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multiply %s by:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Set %(attributes)s for %(num)s selected recipe?"
 msgstr[1] "Set %(attributes)s for %(num)s selected recipes?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Any previously existing values will not be changed."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "The new values will overwrite any previously existing values."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "This change cannot be undone."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Set values for selected recipes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Search recipes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Open recipe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Open selected recipe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Delete recipe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Delete selected recipes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Edit recipe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Open selected recipes in recipe editor view"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_xport selected recipes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Export selected recipes to file"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Print"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "recipes"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Batch _edit recipes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_New"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Import Recipe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Import recipe from file"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Import _webpage"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s recipe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Import recipe from webpage"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Export _all recipes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Export all recipes to file"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "Quit"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Actions"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Open _Trash"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Trash"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Preferences"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Plugins"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Manage plugins which add extra functionality to Gourmet."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Setti_ngs"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_About"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Tools"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Timer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Show timer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Searchable index of recipes in the database."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Delete %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "You have unsaved changes to %s. Are you sure you want to delete?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Deleted"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Untitled"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Permanently delete recipes?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Permanently delete recipe?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Are you sure you want to delete the recipe <i>%s</i>?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Are you sure you want to delete the following recipes?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Are you sure you want to delete the %s selected recipes?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "See recipes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Delete Recipes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Recipe _Index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Deleted recipe %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Done!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importing..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Ingredient _Key Editor"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Edit ingredient keys en masse"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "key"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "item"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Field"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Value"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Count"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Change all keys \"%s\" to \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2010,12 +1948,12 @@ msgstr ""
 "the key \"%s\", you won't be able to distinguish between those items and the "
 "items you are changing now."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Change all items \"%s\" to \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2026,12 +1964,12 @@ msgstr ""
 "the item \"%s\", you won't be able to distinguish between those items and "
 "the items you are changing now."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2040,12 +1978,12 @@ msgstr ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2054,7 +1992,7 @@ msgstr ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2063,11 +2001,11 @@ msgstr ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Change all selected rows?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2076,7 +2014,7 @@ msgstr ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2085,7 +2023,7 @@ msgstr ""
 "\n"
 "Key to %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2094,7 +2032,7 @@ msgstr ""
 "\n"
 "Item to %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2103,7 +2041,7 @@ msgstr ""
 "\n"
 "Unit to %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2112,8 +2050,8 @@ msgstr ""
 "\n"
 "Amount to %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2122,23 +2060,23 @@ msgstr[1] "%s ingredients"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Amount"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Ingredient Keys"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2146,11 +2084,11 @@ msgstr ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Guess keys"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2158,56 +2096,56 @@ msgstr ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Edit Key Associations"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Edit associations with key and other attributes in database"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Shopping Category"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Display units as written for each recipe (no change)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Always display U.S. units"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Always display metric units"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Automatically adjust units"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Set _unit display preferences"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2215,42 +2153,42 @@ msgstr ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Stars"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s ago"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Auto-Merge recipes"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Always use newest recipe"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Always use oldest recipe"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "None"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2258,259 +2196,247 @@ msgstr ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Find _duplicate recipes"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Find and remove duplicate recipes"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "For each selected value"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Where %(field)s is %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Change will affect %s recipe"
 msgstr[1] "Change will affect %s recipes"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Delete %s where it is %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Change %s from %s to \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>This change is not reversable.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Field Editor"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Edit fields across multiple recipes at a time."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Email recipes"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr "Email all selected recipes (or all recipes if no recipes are selected"
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Do you really want to email all %s selected recipes?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Yes, e_mail them"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Cannot convert %s to %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Need density information."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Unit Converter"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Calculate unit conversions"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Loading zip archive"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Unzipping zip archive"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML Web Page"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Exporting Webpage"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Exporting recipes to HTML files in directory %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Recipe saved as HTML file %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Original Page from %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "optional"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Exporting Webpage"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Exporting recipes to HTML files in directory %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Recipe saved as HTML file %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Plain Text file"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Text Export"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Exporting recipes to text file %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Recipe saved as plain text file %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Big File"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "File %s is too big to import"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2521,81 +2447,54 @@ msgstr ""
 "mean to import it anyway. If you really do want to import this file, use a "
 "text editor to split it into smaller files and try importing again."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Webpage"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Downloading %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Shopping list for %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Retrieving %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML File"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML Export"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Exporting recipes to Gourmet XML file %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Recipe saved in Gourmet XML file %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML File (Obsolete)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML File"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook Text File"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Mastercook import finished."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Tidying up XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML File"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2604,274 +2503,295 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Page Layout"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Print Recipes"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF Export"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Exporting recipes to PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Recipe saved as PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Letter"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Portrait"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Plain"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "points"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Index Card (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Index Card (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Index Card (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Index Card (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Letter"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Index Cards (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Index Cards (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Index Cards (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Plain"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Column"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Column"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Column"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Column"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s Column"
 msgstr[1] "%s Columns"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Portrait"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Landscape"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Paper _Size"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientation"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Font Size"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Page _Layout"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Font Size"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Left Margin"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Right Margin"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Top Margin"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Bottom Margin"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster file"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster Export"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Exporting recipes to MealMaster file %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Recipe saved as MealMaster file %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "serving"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Big File"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Export"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Exporting recipes to Gourmet XML file %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Recipe saved in Gourmet XML file %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Shopping List Saver"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Save List as Recipe"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Save current shopping list as a recipe for future use"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Menu for %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Nutritional information reflects amount per %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Nutritional information reflects amounts for entire recipe"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Nutritional information is missing for %s ingredients: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Any food group"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "selection"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Convert unit for %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "In order to calculate nutritional information, Gourmet needs you to help it "
 "convert \"%s\" into a unit it understands."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Change ingredient key"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2880,27 +2800,27 @@ msgstr ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Change _everywhere"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Just in recipe %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Change unit"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2909,11 +2829,11 @@ msgstr ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2922,197 +2842,198 @@ msgstr ""
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "To apply nutritional information, Gourmet needs a valid amount and unit."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Nutrition"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingredient"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "USDA Database Equivalent"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 grams"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Calories"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Total Fat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Saturated Fat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Cholesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sodium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Total Carbohydrate"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Dietary Fibre"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Sugars"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Protein"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alpha-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Ash"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Calcium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Copper"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Folate Total"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Folic acid"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Food Folate"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Dietary folate equivalents"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Iron"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Lycopene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Lutein+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Manganese"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Pantothenic Acid"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Phosphorus"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potassium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamin A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selenium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Thiamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamin A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamin A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamin C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zinc"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamins and minerals"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3121,11 +3042,11 @@ msgstr ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Daily Value"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3134,367 +3055,367 @@ msgstr ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Amount per %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Amount per recipe"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Loading Nutritional Data"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Nutritonal database import complete!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Fetching nutritional database from zip archive %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Extracting %s from zip archive."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Parsing nutritional data..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Reading nutritional data: imported %s of %s entries."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Parsing weight data..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr "Reading weight data for nutritional items: imported %s of %s entries"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Water"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilocalories"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g protein"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipid"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g ash"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g carbohydrates"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g fibre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g sugar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg calcium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg iron"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg phosphorus"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg potassium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg sodium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg zinc"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg copper"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg manganese"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "microgram selenium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamin c"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg thiamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niacin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg pantothenic acid"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "microgram Folate Total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "microgram Folic acid"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "microgram Food Folate"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "microgram dietary folate equivalents"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Choline, total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "microgram Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamin A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamin A (microgram Retinal Activity Equivalents"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "microgram Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "microgram Alpha-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "microgram Beta-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "microgram Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "microgram Lycopene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "microgram Lutein+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g Saturated Fatty Acid"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g Monounsaturated Fatty Acids"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g Polyunsaturated Fatty Acids"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Cholesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Percent refuse"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Dairy & Egg Products"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Spices & Herbs"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Baby Foods"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Fats and Oils"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Poultry"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Soups & Sauces"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Sausages & Lunch Meats"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Breakfast Cereals"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Fruits & Fruit Juices"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Pork"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Vegetables"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Nuts & Seeds"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Beef"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Beverages"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Fish & Shellfish"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Legumes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Lamb, Veal & Game"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Baked Products"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Sweets"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Grains and Pasta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Fast Foods"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Meals, Entrees, and Sidedishes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Snacks"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Ethnic Foods"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "entire database"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Ingredient Key"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "USDA ID Number"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA Item Description"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Density Equivalent"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3508,59 +3429,59 @@ msgstr "Tools"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Get nutritional information for current list"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Amount for Shopping List"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "stars"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Exported %(number)s of %(total)s recipes"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Export complete."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Include Recipe in Body of E-mail (A good idea no matter what)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "E-mail Recipe as HTML Attachment"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "E-mail Recipe as PDF Attachment"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "E-mail Options"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Don't ask before sending e-mail."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-mail not sent"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3568,233 +3489,187 @@ msgstr ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Save recipe as..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet cannot export file of type \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Export recipes"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recipes"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Unable to export: unknown filetype \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Export"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Unable to print: no print plugins are active!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Print %s recipe"
 msgstr[1] "Print %s recipes"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Retrieving file"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "yield"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Enter the URL of a recipe archive or recipe website."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Enter website address"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Enter URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Enter the address of a website or recipe archive."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Unable to import URL"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet does not have a plugin capable of importing URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Open recipe..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Enter website address"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Modifications"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Enter the address of a website or recipe archive."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Import"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "All importable files"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Imported %s recipes."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "serving"
 msgstr[1] "servings"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Imported %s of %s recipes."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "okay"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Don't recognise this webpage. Using generic importer..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Import complete."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Importing recipe"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Processing ingredients"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Processing ingredients."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Servings"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Ingredient Subgroup"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Hide"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Text"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Actions"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Import recipe"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Clear _Tags"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Import Recipe"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "anywhere"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "title"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingredient"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instructions"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "notes"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "cuisine"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "source"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Use regular expressions in search"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr "Use regular expressions (an advanced search language) in text search"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Search as you type (turn off if search is too slow)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Show Search _Options"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Show advanced searching options"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3803,103 +3678,97 @@ msgstr[1] "%s recipes"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Showing recipes %(bottom)s to %(top)s of %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s in %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Paused"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pause"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Done"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Error"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Error %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Traceback"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "second"
 msgstr[1] "seconds"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minute"
 msgstr[1] "minutes"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "hrs."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "hour"
 msgstr[1] "hours"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "day"
 msgstr[1] "days"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
 msgstr[1] "weeks"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "month"
@@ -3908,7 +3777,7 @@ msgstr[1] "months"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "year"
@@ -3920,73 +3789,30 @@ msgstr[1] "years"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " and "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "and"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "to"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML File"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet Recipe Manager"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organise recipes, create shopping lists, calculate nutritional information, "
-"and more."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3996,7 +3822,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -4009,38 +3834,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4048,6 +3841,18 @@ msgstr "PDF Export"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -4058,14 +3863,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4119,22 +3916,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4193,6 +3974,155 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Windows porting assistance)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (improvements to Unit Converter interface)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (improvements to Mealmaster export)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo and splash screen)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Windows version maintenance and "
+#~ "website re-design)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Upgrading database"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Paste ingredients"
+
+#~ msgid "Import from file"
+#~ msgstr "Import from file"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Choose a file containing your ingredient list."
+
+#~ msgid "No file selected"
+#~ msgstr "No file selected"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "No file was selected, so the action has been cancelled"
+
+#~ msgid "_Import file"
+#~ msgstr "_Import file"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Import _webpage"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Import recipe from webpage"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Open _Trash"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Loading zip archive"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Unzipping zip archive"
+
+#~ msgid "Webpage"
+#~ msgstr "Webpage"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Downloading %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Shopping list for %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Retrieving %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Retrieving file"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Enter the URL of a recipe archive or recipe website."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Enter URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Unable to import URL"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet does not have a plugin capable of importing URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Don't recognise this webpage. Using generic importer..."
+
+#~ msgid "Import complete."
+#~ msgstr "Import complete."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Importing recipe"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Processing ingredients"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Processing ingredients."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML File"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet Recipe Manager"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organise recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
 
 #~ msgid "Select recipe image"
 #~ msgstr "Select recipe image"
@@ -4288,9 +4218,6 @@ msgstr ""
 #~ "You've requested to close a window with an active timer. You can stop the "
 #~ "timer, or you can just close the window. If you close the window, it will "
 #~ "reappear when your timer goes off."
-
-#~ msgid "Select File_type"
-#~ msgstr "Select File_type"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "A file named %s already exists."

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gourmet Recipe Manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2013-06-05 03:44+0000\n"
 "Last-Translator: Leo Arias <leo.arias@canonical.com>\n"
 "Language-Team: Esperanto <eo@li.org>\n"
@@ -20,506 +20,508 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Indekso de receptoj"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nova recepto"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Aldoni al aĉetli_sto"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Vidi re_cepton"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Serĉi:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Serĉi receptojn dume vi tajpas"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Al_doni serĉkriterojn"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Limigi serĉon al:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Serĉ_rezultoj"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Bildo:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Forviŝu recepton"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Forviŝu elektatajn receptojn"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "_Nova recepto"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +529,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +562,287 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
-msgstr ""
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
+msgstr "Indekso de receptoj"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,651 +857,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Aldoni al aĉetli_sto"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1509,111 +1464,110 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1623,335 +1577,318 @@ msgstr ""
 "  Registry Administrators https://launchpad.net/~registry\n"
 "  صقر بن عبدالله https://launchpad.net/~agari"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Forviŝu elektatajn receptojn"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "_Forviŝu recepton"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "_Forviŝu recepton"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Agoj"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Pri"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Indekso de receptoj"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1959,12 +1896,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1972,78 +1909,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2052,386 +1989,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2439,81 +2364,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2522,880 +2420,897 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3409,288 +3324,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3699,103 +3568,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3804,7 +3667,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3816,70 +3679,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Indekso de receptoj"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3889,7 +3712,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3902,44 +3724,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3950,14 +3752,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4011,22 +3805,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2015-09-30 12:03+0200\n"
 "Last-Translator: Rafa Soler <Unknown>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -19,64 +19,64 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Poedit 1.8.4\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Índice de recetas"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nueva Receta"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Añadir a li_sta de la compra"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Ver Re_ceta"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Buscar por:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Buscar recetas según se escribe"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_en"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Buscar por otros criterios en los resultados de la búsqueda actual"
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "A_ñadir criterio de búsqueda"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Limitar búsqueda a:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "_Resultados de la búsqueda"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Establecer campos para las Recetas Seleccionadas"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -84,128 +84,131 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Establecer campos para las Recetas "
 "Seleccionadas</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Añadir imagen"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Eliminar imagen"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "_Fuente:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Puntuación:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "Coc_ina:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Categoría:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "Tiempo de _Preparación:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Tie_mpo de cocción :"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "Página _web:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Imagen:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Porciones:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr "Unidad de porció_n"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "Sól_o establecer valores para campos actualmente vacíos"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Establecer todos los valores para tod_as las recetas seleccionadas"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (por defecto, almacenado en un archivo local)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (almacenado en un archivo local)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (requiere conexión a base de datos)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Seleccione la base de datos"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Elegir sistema de base de datos para ser utilizado por Gourmet</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "Sistema de base de _datos"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "Anfi_trión:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "Nombre de _usuario:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "Contraseña:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Contraseña de usuario de la base de datos."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "_Nombre de la base de datos:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "Archivo"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -213,11 +216,11 @@ msgstr ""
 "Nombre del equipo donde corre el servidor de base de datos. Si el servidor "
 "se ejecuta en la maquina local, use localhost."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -225,11 +228,11 @@ msgstr ""
 "Guardar la contraseña para la próxima vez. Esto implica que la contraseña se "
 "almacenará de forma no segura en su archivo de configuración."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "Guardar contra_seña"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -237,301 +240,302 @@ msgstr ""
 "Nombre de la base de datos en la que Gourmet guardará la información. "
 "Gourmet intentará crear esta base de datos si no existe ya."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "receta"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Su nombre de usuario en la base de datos."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Examinar"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detalles"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Preferencias del gestor de recetas Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Preferencias de la Vista de índice</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Mostrar _Opciones"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Recetas por página:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 "<i>Configurar qué columnas se incluyen en la vista de índice de recetas.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Vísta de índice"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Preferencias de la Vista de tarjeta</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "_Permitir cambiar las unidades al multiplicar"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Usar fracciones"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Usar fracciones cuando sea posible para la visualización"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 "<i>Eliminar elementos que no usa del interfaz de Tarjetas de recetas.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Vista de tarjeta"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Preferencias de la Lista de la compra</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>¿Qué debe hacer Gourmet con los ingredientes opcionales cuando añada "
 "recetas a la lista de la compra?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "_Preguntar si incluir los ingredientes adicionales"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "_Recordar las selecciones del usuario por defecto"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "_Limpiar los ingredientes opcionales recordados"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "_Añadir siempre los ingredientes opcionales"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Nunca añadir los ingredientes opcionales"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Listas de compra"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "raciones"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Título"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Título:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Tiempo de _preparación:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "categoría"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "valoración"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Porciones"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Unidad de porción"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Tienda"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Editar _descripción"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Tiempo de cocina:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Tiempo de preparación:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Cocina:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Categoría:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Página web:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Porciones:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Enlace</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Fuente:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Valoración:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Multiplicar por:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Instrucciones</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Editar _instrucciones"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Notas</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Editar _notas"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Receta"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Ingredientes</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Editar _ingredientes"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Añadir _ingrediente:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredientes"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Añadir receta a la lista de compra"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Añadir a la lista de la _compra"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Saltar a la receta en la vista Tarjeta de receta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Borrar la receta seleccionada"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Borrar Receta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Editar los atributos de las recetas seleccionadas"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "Editar recetas en _lotes"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Enviar por correo electrónico la receta seleccionada"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Abrir receta seleccionada"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "_Enviar la receta por correo electrónico"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Seleccione receta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Imprimir la receta seleccionada"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "_Imprimir la receta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -543,31 +547,31 @@ msgstr ""
 "se necesita, pero no será incluido cuando se guarde o imprima la lista, a "
 "menos que se indique que hace falta comprarlo."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Añadir a _Despensa"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Mostrar _Opciones"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Bus_car"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "_Usar expresiones regulares (búsqueda avanzada)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Buscar mientras _teclea"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Opciones de búsqueda</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Categoría"
 
@@ -576,288 +580,290 @@ msgstr "Categoría"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Clave"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Editor de categorías"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Buscar por"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Buscar mientras teclea"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Usar expresiones regulares"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Búsqueda avanzada"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Añadir categoría: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Temporizador"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Temporizador</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>¡Temporizador finalizado!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "El temporizador continuará hasta que se cierre este diálogo o se reinicie el "
 "temporizador."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Establecer _temporizador "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Reiniciar"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Iniciar"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "S_onido"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Nota"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Re_petir la alarma hasta que sea desactivada"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Configuración"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Editar los campos a través de la base de datos</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Campo a _Editar:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Para cada valor seleccionado:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "_Dejar valor como está"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>El nuevo valor se añadirá al final de cualquier texto existente</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>El nuevo valor reemplazará cualquier valor existente</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Campo:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Valor:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Cambiar _otro campo:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "Ca_mbiar valor a: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "_Borrar valor"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Seleccionar equivalente de</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>desde la base de datos USDA </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "_Cambiar ingrediente"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>o</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "_Buscar ingrediente en la base de datos USDA"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Buscar mientras t_eclea"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Mostrar comida únicamente del _grupo:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Buscar en _resultados:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>Desde:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Cantidad:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Unidad:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "unidad"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "_Cambiar unidad"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "_Guardar nueva unidad"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>A:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Unidad:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Introducir información nutricional para </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Elegir una densidad</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Ingrediente clave: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>Elemento USDA: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "Editar asociación _USDA"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Información nutricional</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "Editar _información"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "Información _nutricional"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Densidad:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "Equivalentes USDA:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Equivalencias personalizadas:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "Información de _densidad"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Información nutricional conocida</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "Búsqueda _Avanzada"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Información nutricional"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "I_gnorar"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gestor de recetas Gourmet"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr "Copyright (c) 2004-2014 Thomas M. Hinkle. GNU GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -872,218 +878,171 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (ayuda con la versión Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (instalador para Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (mejoras del convertidor de unidades)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (mejoras de exportación de Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.devianart.com> (logo e imagen de inicio)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (Iconos nutricional y agregar-a-lista de compras)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (Mejoras a la "
-"internacionalizacion, diversos bugfixes)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Versión de Windows en mantenimiento y "
-"rediseño de la web)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Seleccionar Archivo de Base de Datos"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Actualizar base de datos"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Nueva receta"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "_Nombre de la base de datos:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"Dependiendo del tamaño de su base de datos, este puede ser un proceso "
-"intenso y puede tardar un tiempo. Sus datos han sido automáticamente "
-"respaldados en caso de que algo salga mal."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Detalles"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Una copia de resguardo ha sido creada en %s en caso de que algo salga mal. "
 "Si esta actualización falla, puede renombrar manualmente el archivo de su "
 "copia de respaldo recipes.db para recuperarla para usar con una versión más "
 "antigüa de Gourmet."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Nueva receta"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Cambiar _Categoría"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Crear una nueva categoría"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Cambiar la categoría del artículo seleccionado"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Despensa"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Mover a la li_sta de la Compra"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Mover a la des_pensa"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Quitar de la lista de compras"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Mover los artículos seleccionados dentro de %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Li_sta de la Compra"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Ya Hay (Artículos en la _Despensa)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Introduzca Categoría"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Categoría a la cual agregar %s"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Categoría:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recetas"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Añadir artículos:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Borrar Recetas"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Borrar recetas de la lista de la compra"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Editar"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "A_yuda"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Añadir artículos"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Agregar artículos arbitrariamente a la lista de compras"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 "No ha seleccionado ninguna receta. ¿Quiere limpiar todos los contenidos de "
 "la lista?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Guardar la Lista de la Compra Como..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Seleccionar ingredientes opcionales"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1092,57 +1051,59 @@ msgstr ""
 "incluir en su lista de Compras."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Receta"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Ir"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Exportar receta"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Exportar la receta seleccionada (guardar a un archivo)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "Borrar receta"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Borrar esta receta"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Ajustar unidades cuando se multiplican"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Cambia las unidades para hacerlas más legibles al multiplicar cuando que sea "
 "posible."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Imprimir la receta"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Añadir a li_sta de la compra"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Olvidar los ingredientes opcionales"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1150,150 +1111,144 @@ msgstr ""
 "Antes de añadir a la lista de la compra, pregunte acerca de todos los "
 "ingredientes opcionales, incluso los que ya ha querido recordar"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Exportar receta"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr "Receta satisfactoriamente exportada a <a href=\"file:///%s\">%s</a>"
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Tiene cambios que no se han guardado."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "¿Aplicar cambios antes de imprimir?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "¿Aplicar cambios antes de imprimir?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Opcional)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Imposible encontrar la receta %s en la base de datos."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Editar receta:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Guardar ediciones en la base de datos"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Vista de la Tarjeta de Receta"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Editar"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Guardar cambios a %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Añadir ingrediente"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Añadir grupo"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Pegar ingredientes"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importar desde un archivo"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Añadir _receta"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Agregar otra receta como ingrediente en esta receta"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Suprimir"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Arriba"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Abajo"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Escoja un fichero con su lista de ingredientes."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Descripción"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instrucciones"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notas"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Cant."
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Unidad"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Artículo"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Opcional"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "La receta %s (ID %s) no está en el base de datos."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Convertido: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "No Convertido: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Unidad cambiada."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1302,236 +1257,234 @@ msgstr ""
 "Ha cambiado la unidad para %(item)s de %(old)s a %(new)s. ¿Desea convertir "
 "la cantidad o no?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "%(old_amt)s %(old_unit)s convertido a %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "No fue posible convertir de %(old_unit)s a %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Agregando el Grupo de ingredientes"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Introduzca un nombre para el nuevo subgrupo de ingredientes"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Nombre del grupo:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Seleccione receta"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "¡La Receta no puede requerirse a si misma como ingrediente!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "¡No se permite recursión infinita en recetas!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "¡No ha seleccionado ninguna receta!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "¿Cuánto de %(title)s tu receta necesita?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recetas"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Timbre"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Sonido de Alarma"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Sonido de Error"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Detener el temporizador?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "De_tener alarma"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "Sigue cronometrando"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Complementos"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Los complementos añaden funciones adicionales a Gourmet."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "El complemento es necesitado por otros complementos. Desactivar el "
 "complemento de todos modos?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Los siguientes complementos requieren %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Desactivar de todas formas."
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Mantener el plugin activado"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "o"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Un error ocurrio al activar el plugin"
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Un error ocurrio al desactivar el plugin"
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Cocina"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Valoración"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Fuente"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Sitio web"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Tiempo de preparación"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Tiempo de cocción"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Modificaciones"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Entrada inválida"
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "No es un número"
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pausar"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Parar"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "No preguntar otra vez."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "¿Realmente desea hacer esto?"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "excelente"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "genial"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "buena"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "justo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "pobre"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Convertir puntuaciones a una escala de 5 estrellas."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Convertir puntuaciones."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Por favor dé a cada una de estas valoraciones un equivalente en una escala "
 "de 1 a 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Valoración actual"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Valoración sobre 5 estrellas"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "No hay ningún archivo seleccionado"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Selecciona tipo de archivo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-"No se seleccionó ningún archivo, por lo que la acción ha sido cancelada"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1540,14 +1493,14 @@ msgstr ""
 "Lo siento. No puedo entender\n"
 "la cantidad \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Las cantidades deben ser numeros (fracciones o decimales), rangos de "
 "números, o dejar en blanco."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1567,85 +1520,85 @@ msgstr ""
 "Para ingresar un rango de numeros, use un \"-\" como separador.\n"
 "Por ejemplo, uted podria ingresar \"2-4\" o \"1 1/2 - 3 1/2\".\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "Nombre de _usuario:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "Contraseña:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "harina, para todos los propósitos"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "azucar"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sal"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "pimienta negra, molida"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "hielo"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "agua"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "aceite, vegetal"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "aceite, de oliva"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "La receta se requiere a si misma como un ingrediente."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Los Ingredientes %s serán ignorados."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Lista de compras para %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr "Para las siguientes recetas:\n"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Para las siguientes recetas:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Seleccionar codificación"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1653,29 +1606,28 @@ msgstr ""
 "No se puede determinar la codificación correcta. Seleccionar la codificación "
 "correcta de la lista."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Ver _archivo con la codificación."
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importación pausada"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Parar importación"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Índice de recetas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Lista de la compra"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Alvaro MuñozCarlos Perelló MarínPablo QuirósRicardo Barrios from Organica "
@@ -1731,335 +1683,322 @@ msgstr ""
 "  llanter https://launchpad.net/~eresunmelo\n"
 "  remialdo https://launchpad.net/~remialdo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "¡Guardado!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Guardar sus cambios a %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Una importación está en proceso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Una exportación está en proceso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Un borrado está en proceso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "¿Salir del programa de todas formas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "¡No Salir!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Borrados permanentemente %s de %s recetas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Papelera"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Navegar, borrar permanentemente o recuperar recetas borradas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Recetas no borradas "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Número de %(unit)s de %(title)s a comprar"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multiplica %s por:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "¿Establecer %(attributes)s para %(num)s receta seleccionada?"
 msgstr[1] "¿Establecer %(attributes)s para %(num)s recetas seleccionadas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Cualquier valor previo no será cambiado"
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Los nuevos valores sobreescribirán los valores existentes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Este cambio no se puede deshacer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Fijar valores para las recetas seleccionadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Buscar recetas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Abrir receta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Abrir receta seleccionada"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Eliminar receta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Eliminar las recetas seleccionadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Editar receta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Abrir recetas seleccionados en el editor"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_xportar las recetas seleccionadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Exportar las recetas seleccionadas a un archivo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Imprimir"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "recetas"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "_Editar las recetas en grupo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nuevo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Importar Archivo"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Importar receta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Importar receta desde un archivo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Importar página _web"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s receta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Importar recetas desde una página web"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Export_ar todas las recetas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Exportar todas las receta a un archivo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Salir"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Acciones"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Abrir papelera"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Papelera"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Preferencias"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "Com_plementos"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Manejar complementos que agregan funcionalidad extra a Gourmet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Configuracio_nes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Acerca de ..."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Herramientas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Temporizador"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Mostrar temporizador"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Índice de búsqueda de recetas en la base de datos."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "¿Borrar %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "No has guardado los cambios en %s. ¿estás seguro que lo quieres borrar?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Eliminado"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Sin título"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "¿Borrar las recetas definitivamente?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "¿Borrar la receta definitivamente?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "¿Esta seguro que desea borrar la receta <i>%s</i>?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "¿Esta seguro que desea borrar las siguientes recetas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "¿Esta seguro que desea borrar las %s recetas seleccionadas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Ver recetas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Eliminar Recetas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr "Recetas eliminadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Se borró la receta %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr "Ver la papelera"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "¡Hecho!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importando..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Editor de ingrediente clave"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Editar ingredientes clave en masa"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "clave"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "artículo"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Campo"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Cantidad"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Cambiar todas las claves \"%s\" a \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2070,12 +2009,12 @@ msgstr ""
 "\"%s\", no serás capaz de distinguir entre esos elementos y los elementos "
 "que estás cambiando ahora."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Cambiar todos los elementos \"%s\" a \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2086,27 +2025,27 @@ msgstr ""
 "elemento \"%s\", no serás capaz de distinguir entre esos elementos y los "
 "elementos que estás cambiando ahora."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Cambiar _todas las apariciones de \"%(unit)s\" a \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
-"Cambiar \"%(unit)s\" a \"%(text)s\" solamente para _ingredientes \"%(item)s"
-"\" con la clave \"%(key)s\""
+"Cambiar \"%(unit)s\" a \"%(text)s\" solamente para _ingredientes "
+"\"%(item)s\" con la clave \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Cambiar todas las apariciones de \"%(amount)s\" %(unit)s a %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2115,7 +2054,7 @@ msgstr ""
 "Cambiar %(amount)s\" %(unit)s a \"%(text)s\" %(unit)s solamente _donde la "
 "clave es %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2124,11 +2063,11 @@ msgstr ""
 "Cambiar \"%(amount)s\" %(unit)s a \"%(text)s\" %(unit)s solamente donde la "
 "clave es %(key)s _y el ingrediente es %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Cambiar todas las filas seleccionadas?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2137,7 +2076,7 @@ msgstr ""
 "Esta acción no se podrá deshacer. ¿Está seguro de que, para las %s filas "
 "seleccionadas, quiere cambiar los siguientes valores?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2146,7 +2085,7 @@ msgstr ""
 "\n"
 "Clave para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2155,7 +2094,7 @@ msgstr ""
 "\n"
 "Elemento para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2164,7 +2103,7 @@ msgstr ""
 "\n"
 "Unidad para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2173,8 +2112,8 @@ msgstr ""
 "\n"
 "Monto para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2183,23 +2122,23 @@ msgstr[1] "ingredientes %s"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Mostrar ingredientes %(bottom)s hacia %(top)s del %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Cantidad"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Ingredientes clave"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2207,11 +2146,11 @@ msgstr ""
 "Las entradas de ingredientes son estándar para su uso en la lista de compras "
 "y cálculos."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Suposiciones clave"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2219,58 +2158,58 @@ msgstr ""
 "Adivina el mejor valor para las entradas de ingredientes basado en los "
 "valores actuales de su base de datos"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Editar asociación de clave"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Editar asociaciones con clave y otros"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Editor de claves"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "_Elemento:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Clave:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>_Cambiar ingredientes seleccionados</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Categoría de Compras"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 "Muestra la unidades de los ingredientes para cada receta tal cual aparecen "
 "(sin cambio)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Siempre despliega unidades anglosajonas"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Siempre despliega unidades métricas"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Ajustar las unidades automáticamente"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Establezca preferencias de despliegue de _unidades"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2278,42 +2217,42 @@ msgstr ""
 "Convertir unidades al sistema de preferencia (metrico, anglosajón, etc.) "
 "automáticamente cuando sea posible."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Estrellas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "hace %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Auto-Mezclar recetas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Siempre usar la receta mas reciente"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Siempre usar la receta mas antigua"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Ninguno"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2321,97 +2260,97 @@ msgstr ""
 "Algunas de las recetas importadas parecen estar duplicadas. Puede mezclarlas "
 "aquí, o cerrar esta ventana de diálogo para dejarlas como están."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Buscar recetas _duplicadas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Buscar y eliminar recetas duplicadas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Recetas con información de receta similar"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Recetas con ingredientes similares"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Recetas con información de receta similar e ingredientes"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Recetas duplicadas</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "_Incluir recetas en la papelera"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Mostrando:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Fusionar _todas las duplicadas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Fusionar recetas</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "Fusión _automática"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Para cada valor seleccionado"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Donde %(field)s es %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "El cambio afectará %s receta"
 msgstr[1] "El cambio afectará %s recetas"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Borrar %s donde eso es %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "¿Cambiar %s de %s a \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Este cambio no es reversible.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Editor de campos"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Editar campos a través de multiples recetas a la vez"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Enviar por correo las recetas"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Mandar por correo todas las recetas seleccionadas (o todas las recetas si no "
@@ -2420,162 +2359,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Realmente quiere enviar por email las %s recetas seleccionadas?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Si, envíalas por _correo"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "No se puede convertir %s a %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Necesita información de densidad."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Conversor de _unidades"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Calcular conversión de unidades"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Conversor de unidades"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>De</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "_Elemento"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Densidad:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "_Información de densidad"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>A</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Resultado:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Archivo (zip, tarball)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Cargando archivo zip"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Descomprimiendo archivo zip"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "Página Web (HTML)"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Exportando página web"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Exportando recetas a archivos HTML en la carpeta %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Receta guardada como el archivo HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Página original de %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "Opcional"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Exportando página web"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Exportando recetas a archivos HTML en la carpeta %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Receta guardada como el archivo HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Archivo de texto plano"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Exportar como Texto"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Exportando recetas al archivo de texto %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Receta guardada como archivo de texto plano %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Archivo grande"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "El archivo %s es muy grande para importarlo"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2587,81 +2514,54 @@ msgstr ""
 "editor de texto para dividirlo entre varios archivos más pequeños y trate de "
 "importar de nuevo."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Página web"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Descargando %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Lista de compras para %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Descargando %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Archivo XML Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Exportar como XML Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Exportando Recetas al archivo XML de Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Receta guardada en el archivo XML de Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Archivo XML Gourmet (Obsoleto)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Archivo XML Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Archivo de texto Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Se ha terminado la importación de MasterCook."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Limpiando XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "Archivo XML KRecipe"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2670,272 +2570,293 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Diseño de página"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Imprimir recetas"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Formato de Documento Portable)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Exportar como PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Exportando recetas a PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Receta guardada como PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Carta"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Retrato"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Simple"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "puntos"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Tarjeta Indice (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Tarjeta Indice (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Tarjeta Indice (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Tarjeta Indice (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Carta"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Oficio"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Tarjetas Indice (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Tarjeta Indice (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Tarjetas Indice (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Horizontal"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Simple"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s columna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s columna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s columna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s columna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s columna"
 msgstr[1] "%s columnas"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Retrato"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Horizontal"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Tamaño del papel"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientación"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Tamaño de _Fuente"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Esquema de Página"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Tamaño de _Fuente"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Margen Izquierdo"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Margen Derecho"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Margen Superior"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Margen Inferior"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "Opciones de PDF"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "Archivo de Mealmaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Archivos de Mealmaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Exportando recetas al archivo %(file)s de MealMaster."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Receta guardada en archivo %(file)s de MealMaster"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "ración"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr "Archivo MCB"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr "Archivo My CookBook MCB"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr "MCB Export"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Exportando Recetas al archivo My CookBook MCB %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Receta guardada en el archivoMy CookBook MCB %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Lista de compras"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Guardar lista como receta"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Guardar la lista de compras actual como receta para uso futuro"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr "Menú para %s (%s)"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menú"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Información nutrimental refleja la cantidad por %s"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "La información nutricional refleja las cantidades para toda la receta"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Falta información nutricional para %s ingredientes: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Culquier grupo de comida"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "selección"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Convertir unidad para %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Con la finalidad de calcular la información nutricional, Gourmet necesita "
 "que lo ayudes a convertir %s en una unidad que entienda"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Cambiar el ingrediente clave"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2944,29 +2865,29 @@ msgstr ""
 "¿Cambiar las claves de los ingredientes de %(old_key)s a %(new_key)s de "
 "todas o sólo de la receta %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Cambiar _donde sea"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Sólo en la receta %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 "¿Cambiar la entrada de ingrediente de %(old_key)s a %(new_key)s en todas "
 "partes?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Cambiar unidad"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2975,211 +2896,212 @@ msgstr ""
 "Cambiar la unidad de %(old_unit)s a %(new_unit)s para todos los ingredientes "
 "%(ingkey)s o sólo de la receta %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
-"Para calcular la información nutricional de \"%(amount)s %(unit)s %(ingkey)s"
-"\", Gourmet necesita saber su densidad. Nuestra base de datos nutricional "
-"tiene varias descripciones de este ingrediente con diferentes densidades. "
-"Por favor, seleccione la correcta."
+"Para calcular la información nutricional de \"%(amount)s %(unit)s "
+"%(ingkey)s\", Gourmet necesita saber su densidad. Nuestra base de datos "
+"nutricional tiene varias descripciones de este ingrediente con diferentes "
+"densidades. Por favor, seleccione la correcta."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Para aplicar la información nutricional, Gourmet necesita un monto y unidad "
 "válidos"
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Nutrición"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingrediente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Equivalente en el base de datos del USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gramos"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Calorías"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Grasa Total"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Grasa Saturada"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Colesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sodio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Carbohidratos Totales"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Fibra nutricional"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Azúcares"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteína"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa caroteno"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Ceniza"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-caroteno"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta Criptoxanthina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Calcio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Cobre"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Total de Folato"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Ácido Fólico"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Ácido fólico"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Equivalentes dietéticos de folato"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Hierro"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Licopeno"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Carotenos"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnesio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Manganeso"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Ácido Pantoténico"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fósforo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potasio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamina A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selenio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamina A (UI)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamina A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zinc"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitaminas y minerales"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3188,11 +3110,11 @@ msgstr ""
 "Falta información nutricional\n"
 "para %(missing)s de los %(total)s ingredientes."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% Valor _diario"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3201,369 +3123,369 @@ msgstr ""
 "Porcentaje del valor diario recomendado, basado en %i calorías por día. Haga "
 "clic para editar el número de calorías por día."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Cantidad por %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Cantidad por receta"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Cargando Información Nutricional"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Importación de la base de datos nutricional completada!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Recuperando base de datos nutricional del archivo zip %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Extrayendo %s del archivo zip."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Analizando datos nutricionales..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Leyendo información nutricional: importado %s de entradas %s."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Analizando datos de peso..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Cargando información de peso para la información de nutrición: %s de %s "
 "importados."
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Agua"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilocalorías"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g proteínas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lípidos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g ceniza"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g carbohidratos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g fibra"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g azúcar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg calcio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg hierro"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnesio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fósforo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg potasio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg sodio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg zinc"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg cobre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg manganeso"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "Slenio microgramo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg Vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg riboflavina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niacina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg ácido pantoténico"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "microgramos de Folato Total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "microgramo de Ácido Fólico"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "microgramos de ácido fólico"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "microgramo de equivalentes dietéticos de folato"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Colina, total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "microgramo de Vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamina A UI"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamina A (microgramo de Equivalentes de Actividad Retinal"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "microgramo de Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "microgramo de Alfa-caroteno"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "microgramo de Beta-caroteno"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "micrograma betacriptoxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "micrograma licopeno"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "microgramos de carotenos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg de Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g Ácido saturado graso"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g Ácidos Grasos Monoinsaturados"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g Ácidos Grasos Poliinsaturados"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Colesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Porcentaje de rechazo"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Productos perecederos y huevos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Especias y hierbas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Comida de Bebés"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Grasas y Aceites"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Aves"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Sopas y salsas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Carnes y salchichonería"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Cereales para el desayuno"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Frutas y zumos de frutas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Cerdo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Vegetales"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Nueces y semillas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Carne de Res"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Bebidas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Pescados y Mariscos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Legumbres"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Cordero, ternera y caza"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Productos Enlatados"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Dulces"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Granos y pasta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Comida Rápida"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Comidas, entradas y acompañantes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Pasabocas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Comidas étnicas"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "bases de datos completa"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Ingrediente clave"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "Número identificador del USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "Descripción del artículo USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Densidad equivalente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3577,59 +3499,59 @@ msgstr "Herramientas"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Obtener información nutrimental para la lista actual"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Cantidad para la lista de compras"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "Editar información _nutricional"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "estrellas"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Ha exportado %(number)s de %(total)s recetas."
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Exportacion Completa"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Incluir la Receta en el Cuerpo del e-mail (siempre es una buena idea)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Adjuntar receta al e-mail como archivo HTML"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Mandar por correo electronico la Receta como un adjunto en PDF"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Opciones de e-mail"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "No preguntar antes de enviar e-mail."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "No se mandó el e-mail."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3637,235 +3559,189 @@ msgstr ""
 "No ha escogido incluir la receta en el cuerpo del mensaje o como archivo "
 "adjunto."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Guardar receta como..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet no puede exportar un archivo de tipo \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Exportar recetas"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recetas"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Imposible exportar: el tipo de archivo \"%s\" es desconocido"
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Por favor asegúrese de seleccionar un tipo de archivo en el menú desplegable "
 "cuando lo guarde."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Exportar"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr "Recetas correctamente exportadas a <a href=\"file:///%s\">%s</a>"
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "No se puede imprimir: ¡no hay agregados de impresión activos!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Imprimir %s receta"
 msgstr[1] "Imprimir %s recetas"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Descargando archivo"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "porción"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Introduzca la dirección del archivo de recetas o página web con receta"
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Introduzca la direccion de la página web"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Introduzca la URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Introduzca la direccion de la página web o el archivo de recetas"
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "No se pudo importar el URL"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet no tiene un complemento capaz de importar URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Imposible importar dirección URL %(url)s del tipo %(type)s. Archivo guardado "
-"temporalmente en %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Abrir receta..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Introduzca la direccion de la página web"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Modificaciones"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Introduzca la direccion de la página web o el archivo de recetas"
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importar"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Todos los Archivos Importables."
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "%s recetas importadas."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "ración"
 msgstr[1] "raciones"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "%s de %s recetas importadas."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "Bien"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "No reconoce esta página web. Usando importador genérico..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Importación completa"
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Importando receta"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Procesando ingredientes"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Procesando ingredientes."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Raciones"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Subgrupo de ingredientes"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Ocultar"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Texto"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Acciones"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importar receta"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Limpiar etiquetas"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Importar receta"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "en cualquier lugar"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "título"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrediente"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instrucciones"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "Notas"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "cocina"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "fuente"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Usar expresiones regulares en la busqueda"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Usar expresiones regulares (un lenguaje de busquedas avanzadas) en el texto"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Buscar a medida que escribes (desactivar si la busqueda es muy lenta)"
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Mostrar _opciones de busqueda"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Mostrar opciones avanzadas de busquedas"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3874,104 +3750,98 @@ msgstr[1] "%s recetas"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Mostrar ingredientes %(bottom)s hacia %(top)s del %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s en %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Pausado"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "Recetas importadas satisfactoriamente"
 msgstr[1] "Recetas importadas satisfactoriamente"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pausa"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Hecho"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Error"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Error %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Rastrear"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "segundo"
 msgstr[1] "segundos"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuto"
 msgstr[1] "minutos"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "hrs."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "hora"
 msgstr[1] "horas"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "día"
 msgstr[1] "días"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
 msgstr[1] "semanas"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -3980,7 +3850,7 @@ msgstr[1] "meses"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "año"
@@ -3992,77 +3862,30 @@ msgstr[1] "años"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " y "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "y"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "a"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-"El gestor de recetas Gourmet es un organizador de recetas que te permite "
-"guardar, buscar, organizar, y navegar por tus recetas. Gourmet también puede "
-"generar listas de la comprar y calcular la información nutricional."
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-"Un índice simple que te permite ver todas tus recetas como una lista y "
-"buscar rapidamente a través de ellas por ingredientes, título, categoría, "
-"cocina, valoración o instrucciones."
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr "Gourmet"
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr "Gestor de recetas"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organiza recetas, crea listas de la compra, calcula información nutricional, "
-"y más."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr "recetas;cocina;nutrición;información nutricional;listas de la compra;"
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Explorar las recetas"
@@ -4072,7 +3895,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Seleccionando recetas explorándolas por categoría, cocina, etc."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Principal"
@@ -4085,38 +3907,6 @@ msgstr "Buscar recetas duplicadas"
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr "Un asistente para buscar y eliminar o fusionar recetas duplicadas."
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Enviar al correo electrónico"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Enviar recetas por correo electrónico desde Gourmet"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Soporte de Zip, Gzip y Tarball"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Importar recetas de archivos zip y tar"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Importador/Exportador"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4126,6 +3916,18 @@ msgstr "Exportar como PDF"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Crear página web de recetas."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Importador/Exportador"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4138,14 +3940,6 @@ msgid ""
 msgstr ""
 "Importar y exportar recetas como archivos XML de Gourmet, apropiados para "
 "copias de seguridad o intercambiar con otros usuarios de Gourmet."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "Exportar a HTML"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Crear página web de recetas."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4205,22 +3999,6 @@ msgid ""
 msgstr ""
 "Ayudar al usuario a dar formato e importar texto plano. También permite "
 "exportar a texto plano."
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Importar página web"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Importar recetas desde la web."
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Importadores de páginas web"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Importadores para about.com, www.foodnetwork.com y otros"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4288,6 +4066,216 @@ msgstr ""
 "Actívela si sus archivos de UTF16 no se están importando limpiamente en "
 "Gourment. Desactívela si nunca usa UTF16 y considera una molestia constante "
 "el diálogo «Codificación» cuando importa archivos."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Enviar por correo electrónico la receta seleccionada"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "_Enviar la receta por correo electrónico"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (ayuda con la versión Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (instalador para Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (mejoras del convertidor de unidades)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (mejoras de exportación de Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.devianart.com> (logo e imagen de inicio)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (Iconos nutricional y agregar-a-lista de compras)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (Mejoras a la "
+#~ "internacionalizacion, diversos bugfixes)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Versión de Windows en mantenimiento y "
+#~ "rediseño de la web)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Actualizar base de datos"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Dependiendo del tamaño de su base de datos, este puede ser un proceso "
+#~ "intenso y puede tardar un tiempo. Sus datos han sido automáticamente "
+#~ "respaldados en caso de que algo salga mal."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Pegar ingredientes"
+
+#~ msgid "Import from file"
+#~ msgstr "Importar desde un archivo"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Escoja un fichero con su lista de ingredientes."
+
+#~ msgid "No file selected"
+#~ msgstr "No hay ningún archivo seleccionado"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr ""
+#~ "No se seleccionó ningún archivo, por lo que la acción ha sido cancelada"
+
+#~ msgid "_Import file"
+#~ msgstr "_Importar Archivo"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Importar página _web"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Importar recetas desde una página web"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Abrir papelera"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Archivo (zip, tarball)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Cargando archivo zip"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Descomprimiendo archivo zip"
+
+#~ msgid "Webpage"
+#~ msgstr "Página web"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Descargando %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Lista de compras para %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Descargando %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Descargando archivo"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr ""
+#~ "Introduzca la dirección del archivo de recetas o página web con receta"
+
+#~ msgid "Enter URL:"
+#~ msgstr "Introduzca la URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "No se pudo importar el URL"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet no tiene un complemento capaz de importar URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Imposible importar dirección URL %(url)s del tipo %(type)s. Archivo "
+#~ "guardado temporalmente en %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "No reconoce esta página web. Usando importador genérico..."
+
+#~ msgid "Import complete."
+#~ msgstr "Importación completa"
+
+#~ msgid "Importing recipe"
+#~ msgstr "Importando receta"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Procesando ingredientes"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Procesando ingredientes."
+
+#~ msgid ""
+#~ "Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
+#~ "search, organize, and browse your recipes. Gourmet can also generate "
+#~ "shopping lists and calculate nutritional information."
+#~ msgstr ""
+#~ "El gestor de recetas Gourmet es un organizador de recetas que te permite "
+#~ "guardar, buscar, organizar, y navegar por tus recetas. Gourmet también "
+#~ "puede generar listas de la comprar y calcular la información nutricional."
+
+#~ msgid ""
+#~ "A simple index view allows you to look at all your recipes as a list and "
+#~ "quickly search through them by ingredient, title, category, cuisine, "
+#~ "rating, or instructions."
+#~ msgstr ""
+#~ "Un índice simple que te permite ver todas tus recetas como una lista y "
+#~ "buscar rapidamente a través de ellas por ingredientes, título, categoría, "
+#~ "cocina, valoración o instrucciones."
+
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet"
+
+#~ msgid "Recipe Manager"
+#~ msgstr "Gestor de recetas"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organiza recetas, crea listas de la compra, calcula información "
+#~ "nutricional, y más."
+
+#~ msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
+#~ msgstr ""
+#~ "recetas;cocina;nutrición;información nutricional;listas de la compra;"
+
+#~ msgid "Send to Email"
+#~ msgstr "Enviar al correo electrónico"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Enviar recetas por correo electrónico desde Gourmet"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Soporte de Zip, Gzip y Tarball"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Importar recetas de archivos zip y tar"
+
+#~ msgid "HTML Export"
+#~ msgstr "Exportar a HTML"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Crear página web de recetas."
+
+#~ msgid "Webpage import"
+#~ msgstr "Importar página web"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Importar recetas desde la web."
+
+#~ msgid "Website Importers"
+#~ msgstr "Importadores de páginas web"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Importadores para about.com, www.foodnetwork.com y otros"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4420,9 +4408,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "Raciones"
-
-#~ msgid "Select File_type"
-#~ msgstr "Selecciona tipo de archivo"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Un archivo llamado %s ya existe."

--- a/po/et.po
+++ b/po/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-06 19:28+0000\n"
 "Last-Translator: Registry Administrators <Unknown>\n"
 "Language-Team: Estonian <et@li.org>\n"
@@ -20,506 +20,508 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Uus retsept"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Lisa _ostunimekirja"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Fail"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "Ü_ksikasjad"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Ostunimekiri"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Koostisained"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Kustuta Retsept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Kustuta valitud retseptid"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "_Retsept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +529,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +562,287 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "ühik"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
-msgstr ""
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
+msgstr "Vaata retseptikaarti"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,651 +857,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Ostunimekiri"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Redigeeri"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Abi"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Retsept"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Lisa _ostunimekirja"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Vaata retseptikaarti"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Juhised"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Märkmed"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1509,111 +1464,110 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1621,334 +1575,318 @@ msgstr ""
 "  Hans3090 https://launchpad.net/~hans3090\n"
 "  Registry Administrators https://launchpad.net/~registry"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Kustuta valitud retseptid"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Prindi"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "_Retsept"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "_Retsept"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "_Kustuta Retsept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Tegevused"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Programmist"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Tööriistad"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Taimer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1956,12 +1894,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1969,78 +1907,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2049,386 +1987,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Ühikute teisendaja"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2436,81 +2362,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2519,881 +2418,898 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Fail"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3407,288 +3323,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3697,103 +3567,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3802,7 +3666,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3814,70 +3678,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Vaata retseptikaarti"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3887,7 +3711,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3900,44 +3723,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3948,14 +3751,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4009,22 +3804,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-06 19:29+0000\n"
 "Last-Translator: Iman Rahmatizadeh <i_rahmati@yahoo.com>\n"
 "Language-Team: Persian <fa@li.org>\n"
@@ -20,506 +20,506 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "افزودن به ليست خريد"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_پرونده"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+msgid "Copy selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +527,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +560,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,651 +854,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_ویرایش"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_راهنما"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "افزودن به ليست خريد"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1509,445 +1461,425 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Artin https://launchpad.net/~artin\n"
 "  Iman Rahmatizadeh https://launchpad.net/~i-rahmati"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_چاپ"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+msgid "_Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_کنش‌ها"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_درباره"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_ابزارها"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1955,12 +1887,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1968,78 +1900,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2048,386 +1980,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "هیچ‌کدام"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2435,81 +2355,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2518,881 +2411,898 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_پرونده"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3406,288 +3316,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3696,102 +3560,96 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3800,7 +3658,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3812,69 +3670,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3884,7 +3703,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3897,44 +3715,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3945,14 +3743,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4006,22 +3796,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-05-07 22:46+0000\n"
 "Last-Translator: Samuli Seppänen <Unknown>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -20,64 +20,64 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Reseptiluettelo"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "Uusi resepti"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Lisää ostoslistaan"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Näytä resepti"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "Hakusana:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Etsi reseptejä kirjoitettaessa"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Hae hakutuloksista"
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Hakuehdot"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Hakutuloksten rajoitus:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Hakutulokset"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Aseta valittujen reseptien kentät"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -85,129 +85,132 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Määritä valittujen reseptien näkyvät "
 "kentät</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "Lisää kuva"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "Poista kuva"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "Lähde:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Arvostelu:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "Tyyppi:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Luokka:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "Valmisteluaika:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Kypsymisaika"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "Verkkosivu:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Kuva:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "Määrä"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Määrän yksikkö"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "Aseta arvot vain tyhjille kentille"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Aseta valittujen reseptien kaikki arvot"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (oletus, tallennus paikalliseen tiedostoon)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (tallennus paikalliseen tiedostoon)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (vaatii tietokantayhteyden)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Valitse tietokanta"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Valitse Gourmetin käyttämä tietokantajärjestelmä</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "Tietokantajärjestelmä"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Verkkonimi:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Käyttäjätunnus:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Salasana:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Tietokantakäyttäjän salasana"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Tietokannan nimi:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "Tiedosto"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -215,21 +218,21 @@ msgstr ""
 "Tietokantapalvelimen IP-osoite. Jos tietokantapalvelin on paikallisella "
 "koneella, valitse \"localhost\"."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr "Tallenna salasana tiedostoon (ei turvallista)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "Tallenna salasana"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -237,297 +240,298 @@ msgstr ""
 "Gourmetin käyttämän tietokannan nimi. Jos sitä ei ole olemassa, Gourmet luo "
 "sen automaattisesti."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "resepti"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Tietokantakäyttäjän käyttäjänimi"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "Selaa"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "Yksityiskohdat"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Gourmetin asetukset"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Luettelonäkymän asetukset</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Näytä valinnat"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "Reseptejä sivulla:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr "<i>Määritä luettelonäkymässä näkyvät palstat</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Luettelonäkymä"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Reseptinäkymän asetukset</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "Salli yksikkömuunnokset annoskokoa muutettaessa"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "Käytä murtolukuja"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Näytä määrät murtolukuina jos mahdollista"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr "<i>Poista käyttämättömät kohdat reseptinäkymästä</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Reseptinäkymä"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Ostoslistan asetukset</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr "<i>Valinnaisten ainesosien käsittely ostoslistaa luodessa</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "Kysy lisätäänkö valinnaiset ainesosat"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "Muista käyttäjän valinnat"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "Tyhjennä muistissa olevat valinnaiset ainesosat"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "Lisää  aina valinnaiset ainesosat"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "Älä lisää valinnaisia ainesosia ikinä"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Ostoslista"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "annoksia"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Nimi"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Nimi:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Valmisteluaika:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "luokka"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "arvostelu"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Määrä"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Määrän yksikkö"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "Ostokset"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Muokkaa kuvausta"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Kypsennysaika:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Valmisteluaika:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Tyyppi:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Luokka:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Verkkosivu</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>Määrä:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Linkki</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Lähde:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Arvostelu:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>Kerro luvulla:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Ohjeet</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Muokkaa ohjeita"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "Muistiinpanot"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Muokkaa muistiinpanoja"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Resepti"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Ainesosat</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Muokkaa ainesosia"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Lisää ainesoa:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ainekset"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Lisää resepti ostoslistaan"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Lisää ostoslistaan"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Siirry reseptinäkymässä olevaan reseptiin"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Poista valittu resepti"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "Poista resepti"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Muokkaa valittujen reseptien ominaisuuksia"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "Reseptien massamuokkaus"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Lähetä valittu resepti sähköpostilla"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Avaa valittu resepti"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "Lähetä resepti sähköpostilla"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Valitse resepti"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Tulosta valittu resepti"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "Tulosta resepti"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -538,31 +542,31 @@ msgstr ""
 "näytetään ainoastaan \"Ruokakomero\"-kohdassa, ellei sitä erikseen lisätä "
 "ostoslistaan."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Lisää ruokakomeroon"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Näytä valinnat"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Etsi kohteesta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "Käytä säännöllisiä lausekkeita (tarkennettu haku)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Etsi kirjoitettaessa"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Hakuasetukset</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Luokka"
 
@@ -571,290 +575,292 @@ msgstr "Luokka"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Avain"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Luokkien muokkaus"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Hakuperuste"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Etsi kirjoitettaessa"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Käytä säännöllisiä lausekkeita"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Tarkennettu haku"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Lisää luokka: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Ajastin"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Ajastin</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Ajastin valmis!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Ajastin hälyttää kunnes tämä valintaikkuna suljetaan tai ajastin nollataan."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Aseta ajastin: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "Tyhjennä"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Käynnistä"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "Ääni"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "Muistiinpano"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Toista hälytys kunnes se poistetaan käytöstä"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "Asetukset"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Muokka kaikkia tietokannan kenttiä</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Muokattava kenttä:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Jokaiselle valitulle arvolle:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "Älä muuta arvoa"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>Uusi arvo lisätään olemassa olevan tekstin loppuun</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Uusi arvo korvaa olemassa olevan arvon</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Kenttä:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Arvo:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Muuta toinen kenttä:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "Muuta arvoksi: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "Poista arvo"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Valitse vastaava kuin</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>USDA-tietokannasta</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "Muuta ainesosa"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>tai</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "Etsi USDA-ainesosatietokannasta"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Etsi kirjoitettaessa"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Näytä vain ruoat ryhmässä:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Hakutulokset:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>Lähettäjä:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Määrä:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Yksikkö:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "yksikkö"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "Muuta yksikkö"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "Tallenna uusi yksikkö"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>Vastaanottaja:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Yksikkö:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Määritä ravintoarvo kohteelle </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Valitse tiheys</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Ainesosan avain</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>USDA-nimike:</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "Muokkaa USDA-liitäntää"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Ravintoarvo</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "Muokkaa tietoja"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "Ravintoarvot"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Tiheys:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "USDA-vastaavuudet:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Omat vastaavuudet:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "TIheystiedot"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Tunnetut ravintoarvot</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "Tarkennettu haku"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Ravinnetiedot"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "Ohita"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet-reseptienhallinta"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Copyright (c) 2004,2005,2006,2007,2008,2009,2010,2011 Thomas M. Hinkle. GNU "
 "GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -879,217 +885,170 @@ msgstr ""
 "myös kuvien linkittämistä resepteihin ja se osaa laskea reseptien "
 "ravintotiedot sen ainesosien perusteella."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (apu Windows-käännöksessä)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (parannuksia yksikkömuuntimen käyttöliittymään)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (parannuksia Mealmaster-vientiin)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo ja splash screen)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (ravitsemus- ja lisää ostoslistalle -ikonit)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (parannukset ohjelman "
-"kansainvälistämiseen sekä sekalaiset ohjelmavirheiden korjaukset (bugfixes))"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Windows version ylläpito ja sivuston "
-"uudelleen suunnittelu)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Valitse tietokantatiedosto"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Päivitetään tietokantaa"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Uusi resepti"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Tietokannan nimi:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"Tietokantasi koosta riippuen, tämä saattaa olla raskas operaatio ja voi "
-"ottaa jonkin aikaa. Tietosi on automaattisesti varmistettu siltä varalta, "
-"että jotain menee vikaan."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Yksityiskohdat"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Siltä varalta että jotain menee vikaan, ohjelma on tehnyt varmuuskopion "
 "polkuun %s. Jos päivitys epäonnistuu, voit nimetä ksäin varmuustiedoston "
 "nimelle recipes.db käyttääksesi sitä vanhemman Gourmet:n kanssa."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Uusi resepti"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Muuta _Kategoriaa"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Tee uusi kategoria"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Muuta valityn kohteen kategoriaa"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Ruokakomero"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Siirrä ostoslistalle."
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Siirrä _ruokakomeroon"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Poista ostoslistasta"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Siirrä valittu kohde %s:ään"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Ostoslista"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 "Ruokakaapissa olevat ainekset (? tarvitseeko olla sama muoto kuin "
 "englanniksi ?)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Syötä luokka"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Luokka, johon %s lisätään"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategoria (vai Luokka??):"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "Reseptit"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Lisää kohteet:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Poista reseptit"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Poista reseptit ostoslistalta"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "Muokkaa"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Ohje"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Lisää kohteet"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Lisää mielivaltaiset kohteet ostoslistaan"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Reseptejä ei ole valittuna. Haluatko tyhjentää koko listan?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Tallenna ostoslista nimellä..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Valitse valinnaiset ainekset"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1097,57 +1056,59 @@ msgstr ""
 "Määritä ne valinnaiset ainesosat, jotka haluat sisällyttää ostoslistallesi."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Resepti"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Siirry"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Vie resepti"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Vie ulos valittu resepti (talleta tiedostoon)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Poista resepti"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Poista tämä resepti"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Muunna yksiköitä, kun suurennat reseptejä"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Kun suurennat reseptien määriä, muuta yksiköitä luettavampaan muotoon jos "
 "mahdollista."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Tulosta resepti"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Lisää ostoslistaan"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Poista muistista vapaaehtoiset ainekset"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1155,150 +1116,144 @@ msgstr ""
 "Ennen ostoslistalle lisäämistä, kysy kaikista vapaaehtoisista aineiksista, "
 "myös niistä, jotka halusit mukaa aikaisemmin"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Vie resepti"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Muutoksia on tallentamatta."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Toteuta muutokset ennen tulostamista?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Toteuta muutokset ennen tulostamista?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Valinnainen)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Reseptiä %s ei löytynyt tietokannasta."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Muokkaa reseptiä:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Talleta muutokset tietokantaan"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Katso reseptikorttia"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Muokkaa"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Talleta muutokset kohteeseen %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Lisää aines"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Lisää ryhmä"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Liitä aines"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Tuo tiedostosta"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Lisää _resepti"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Lisää toinen resepti tämän reseptin ainekseksi"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Poista"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Ylös"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Alas"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Valitse  ainesosaluettelon sisältävä tiedosto."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Kuvaus"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Ohjeet"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Huomautukset"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Määrä"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Mittayksikkö"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Tarvike"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Valinnainen"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Reseptiä %s (ID %s) ei löydy tietokannasta."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Muunnettu: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Ei muunnettu: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Yksikkö vaihdettu."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1306,248 +1261,247 @@ msgid ""
 msgstr ""
 "Vaihdoit %(item)s:n yksikön %(old)s:sta %(new)s:ksi. Haluatko muuntaa määrän?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "%(old_amt)s %(old_unit)s muunnettu %(new_amt)s:ksi %(new_unit)s:ksi"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Muunnos epäonnistui: %(old_unit)s -> %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Ainesosaryhmän lisääminen"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Anna uuden ainesosaryhmän nimi"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Ryhmän nimi:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Valitse resepti"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Resepti ei voi sisältää itseään ainesosana!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Resepteissä ei sallita päättymätöntä rekursiota!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Reseptejä ei ole valittuna!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Kuinka monta ainesta %(title)s reseptisi tarvitsee?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Reseptit"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Hälytysääni (? riippuen siitä mikä käyttöyhteys ?)"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Varoitusääni"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Virheääni"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Pysäytä ajastin?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Pysäytä  _ajastin"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "Jatka _ajastusta"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Lisäosat"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Liitännäiset lisäävät Gourmetiin toiminnallisuutta"
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Lisäosaa tarvitaan muissa lisäosissa. Haluatko poistaa lisäosan tästä "
 "huolimatta käytöstä?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Seuraavat lisäosat vaativat %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Poista päältä kuitenkin"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Pidä lisäosa aktiivisena"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "tai"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Lisäosan aktivoinnissa tapahtui virhe."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Lisäosan käytöstä poistamisessa tapahtui virhe."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Keittiö"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Arvosana"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Lähde"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Verkkosivu"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Valmistusaika"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Keittoaika"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Muutokset"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Virheellinen syöte."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Ei ole numero."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "Tauko"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Lopeta"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Älä kysy uudestaan."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Haluatko varmasti tehdä tämän"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "erinomainen"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "mainio"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "hyvä"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "kohtalainen"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "huono"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Muunna arvosanat viiden tähden asteikkoon."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Muunna arvosanat."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Ole hyvä ja anna jokaiselle arvosanalle vastine asteikolla yhdestä viiteen."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Tämänhetkinen arvosana"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Arvostelu viiden tähden asteikolla"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Ei tiedostoa valittuna"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Valitse tiedoston tyyppi"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Tiedostoa ei ollut valittu, joten toiminto peruutettiin."
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr "Virheellinen määrä: %s"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Määrien täytyy olla numeroita (murto- tai desimaalilukuja), lukualueita "
 "(esim. 1-5) tai tyhjiä."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1567,86 +1521,86 @@ msgstr ""
 "To enter a range of numbers, use a \"-\" to separate them.\n"
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Käyttäjätunnus:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Salasana:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "vehnäjauhoja"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "sokeria"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "suolaa"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "mustapippuria"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "jäätä"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "vettä"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "rypsiöljyä"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "oliiviöljyä"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Resepti sisältää itsensä ainesosana."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Ainesosa %s jätetään huomioimatta."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Ostoslista (%s)"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Seuraaville resepteille:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Seuraaville resepteille:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Valitse merkistökoodaus"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1654,29 +1608,28 @@ msgstr ""
 "Merkistöjärjestelmän koodausta ei voitu määrittää. Valitse oikea "
 "merkistökoodaus listasta."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Näytä tiedosto merkistökoodauksella"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Tuonti pysäytetty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Peruuta tuonti"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Reseptihakemisto"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Ostoslista"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "kääntäjät\n"
@@ -1691,337 +1644,324 @@ msgstr ""
 "  hpiili https://launchpad.net/~harri-piili\n"
 "  raula https://launchpad.net/~lauraputkivaara"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Tallennettu!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Tallenna muutoksesi %s:aan"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Tuonti on käynnissä."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Vienti on käynnissä."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Poisto on käynnissä."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Poistu silti?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Älä poistu!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Poistettiin pysyvästi %s/%s reseptiä"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Roskakori"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Selaa, poista pysyvästi tai palauta tuhottuja reseptejä"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Palautetut reseptit "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Ostettavana on %(unit)s tavaraa %(title)s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Kerro %s arvolla:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Aseta %(attributes)s %(num)s valittuun reseptiin?"
 msgstr[1] "Aseta %(attributes)s %(num)s valittuihin resepteihin?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Olemassa olevia arvoja ei muuteta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Uudet arvot korvaavat jo olemassa olevat"
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Tätä muutosta ei pysty peruuttamaan"
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Aseta arvot valituille resepteille"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Etsi reseptejä"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Avaa resepti"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Avaa valittu resepti"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Poista resepti"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Poista valitut reseptit"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Muokkaa reseptiä"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Avaa valitut reseptit reseptien muokkausnäkymässä"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "_Vie valitut reseptit"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Vie valitut reseptit tiedostoon"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Tulosta"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "reseptit"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Reseptien massamuokkaus"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Uusi"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Tuo tiedosto"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Tuo resepti"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Tuo resepti tiedostosta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Tuo _verkkosivu"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s resepti"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Tuo resepti verkkosivulta"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Vie _kaikki reseptit"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Vie kaikki reseptit tiedostoon"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Lopeta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "Toiminnot"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Avaa _Roskalaatikko"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Roskakori"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Asetukset"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Liitännäiset"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Hallitse Gourmetin liitännäisiä"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "_Asetukset"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Tietoja"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "Ty_ökalut"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Ajastin"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Näytä ajastin"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Reseptien sisällysluettelo hakutoiminnolla"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Poista %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "Sinulla on tallentamattomia muutoksia tiedostoon %s. Oletko varma että "
 "haluat poistaa sen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Poistettu"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Nimetön"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Poista reseptit pysyvästi?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Poista resepti pysyvästi?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Haluatko varmasti poistaa reseptin <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Haluatko varmasti poistaa seuraavat reseptit?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Haluatko varmasti poistaa %s valittua reseptiä?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Näytä reseptit"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Poista reseptit"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Reseptiluettelo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Poista resepti %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Valmis!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Tuodaan..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Ainesavainten Editori"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Muokkaa ainesavaimia massana"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "avaimen"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "tarvikkeen"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Kenttä"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Arvo"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Lukumäärä"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Muuta kaikki \"%s\" avaimet \"%s\":ksi?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2031,12 +1971,12 @@ msgstr ""
 "Et pysty peruttamaan tätä toimintoa. Jos on jo olemassa resepti avaimella "
 "\"%s\", et pysty erottamaan tuloksia toisistaan."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Muuta kaikki \"%s\" kohteet \"%s\":ksi?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2046,12 +1986,12 @@ msgstr ""
 "Et pysty peruttamaan tätä toimintoa. Jos on jo olemassa aines \"%s\", et "
 "pysty erottamaan tuloksia toisistaan."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Muuta kaikki \"%(unit)s\" esiintymät arvoksi \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2060,13 +2000,13 @@ msgstr ""
 "Muuta \"%(unit)s\" arvoon \"%(text)s\" vain aineksille \"%(item)s\" "
 "avaimella \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Muuta kaikki esiintymät \"%(amount)s\" %(unit)s arvoon %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2075,7 +2015,7 @@ msgstr ""
 "Muuta \"%(amount)s\" %(unit)s arvoon \"%(text)s\" %(unit)s vain aineksille "
 "joilla avaimella  arvo \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2084,11 +2024,11 @@ msgstr ""
 "Muuta \"%(amount)s\" %(unit)s arvoon \"%(text)s\" %(unit)s vain aineksilla "
 "%(key)s ja esiintymillä %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Haluatko muuttaa kaikki valitut rivit?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2097,7 +2037,7 @@ msgstr ""
 "Tätä toimintoa ei voi peruuttaa. Oletko varma, että %s valitulle riville "
 "haluat arvot:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2106,7 +2046,7 @@ msgstr ""
 "\n"
 "Avain arvoon %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2115,7 +2055,7 @@ msgstr ""
 "\n"
 "Esiintymä arvoon %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2124,7 +2064,7 @@ msgstr ""
 "\n"
 "Yksikkö arvoon %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2133,8 +2073,8 @@ msgstr ""
 "\n"
 "Lukumäärä arvoon %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2143,23 +2083,23 @@ msgstr[1] "%s ainekset"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Näytetään aineksia %(bottom)s - %(top)s  / %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Määrä"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Ainesavaimet"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2167,11 +2107,11 @@ msgstr ""
 "Ainesavaimet ovat normalisoituja aineksien nimiä, joita käytetään "
 "ostoslistojen ja laskelmien tekemiseen."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Arvaa avaimet"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2179,58 +2119,58 @@ msgstr ""
 "Arvaa parhaat arvot aineksien avaimille tietokannassa jo olevan sisällön "
 "perusteella"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Muokkaa avainten yhteyksiä"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Muokkaa avainten ja muiden attribuuttien yhteyksiä tietokannassa"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Avainten muokkaus"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "Kohta:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "Avain:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>Muuta valitut ainesosat</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 "... Ostoslistan luokka ... tai ostoslistan kategoria (miten muualla on "
 "käytetty?)..."
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Näytä yksiköt niin kuin ne on reseptiin kirjoitettu (ei muunnoksia)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Näytä aina U.S. yksiköt"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Näytä aina metriset yksiköt"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Säädä automaattisesti yksiköitä"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Aseta yksiköiden näyttöasetukset"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2238,42 +2178,42 @@ msgstr ""
 "Muunna automaattisesti yksiköt valittuun mittajärjestelmään (metrinen, "
 "imperial tms.) kun mahdollista."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Tähtiä"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s sitten"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Yhdistä reseptit automaattisesti"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Käytä aina uusinta reseptiä"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Käytä aina vanhinta reseptiä"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Ei mikään"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2281,97 +2221,97 @@ msgstr ""
 "Osa tuoduista resepteistä näyttävät olevan päällekäisiä. Voit yhdistää ne "
 "tässä yhteydessä tai sulkea ruudun ja jättää ne ennalleen."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Etsi _päällekkäiset reseptit"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Etsi ja poista päällekkäiset reseptit"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Reseptit, joissa on samankaltaisia ohjeita"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Reseptit, joissa on samankaltaisia ainesosia"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Reseptit, joissa on samankaltaisia ainesosia ja ohjeita"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Reseptien kaksoiskappaleet</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "Huomioi roskakorissa olevat reseptit"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>Näytetään:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Yhdistä kaikki kaksoiskappaleet"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Yhdistä reseptit</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "Automaattinen yhdistäminen"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Jokaiselle valitulle arvolle"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Jossa %(field)s:llä on arvo %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Muutos vaikuttaa %s reseptiin"
 msgstr[1] "Muutos vaikuttaa %s reseptiin"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Poista %s missä arvo on %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Muuta %s arvosta %s arvoon \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Tämä muutos ei ole peruttavissa.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Kenttä editori"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Muokkaa kenttiä useassa reseptissä yhtä aikaa."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Lähetä reseptejä sähköpostilla"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Lähetä sähköpostilla valitut reseptit (tai kaikki reseptit jos mitään ei ole "
@@ -2380,162 +2320,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Haluatko todella lähettää sähköpostilla kaikki %s valittua reseptiä?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Kyllä, _lähetä ne"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Ei voitu muuntaa: %s %s:ksi"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Tiheystieto tarvitaan."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Mittayksikkömuunnin"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Laske yksiköiden muunnokset"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Yksikkömuunnin"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Mistä</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "Ainesosa:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "Tiheys:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Tiheystiedot"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Mihin</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "Tulos:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Arkisto (zip, tar)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Ladataan pakattua zip-arkistotiedostoa..."
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Puretaan pakattua zip-arkistotiedostoa..."
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML-sivu"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Viedään HTML-sivua"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Viedään reseptejä HTML-tiedostoihin hakemistossa %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Resepti tallennettu HTML-tiedostoon %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Alkuperäinen sivu kohteesta %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "valinnainen"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Viedään HTML-sivua"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Viedään reseptejä HTML-tiedostoihin hakemistossa %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Resepti tallennettu HTML-tiedostoon %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Tavallinen tekstitiedosto"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Tekstivienti"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Vien reseptit tekstiedostoon %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Resepti talletettu tekstitiedostoon %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Iso tiedosto"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Tiedosto %s on liian iso sisään tuotavaksi"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2546,81 +2474,54 @@ msgstr ""
 "todella halunnut tuoda sitä sisään. Jos todella tarkoitit tuoda tämän "
 "tiedoston, voisit pilkkoa sen pienempiin tiedostoihin ja yrittää uudelleen."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Sivusto"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Noudetaan %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Ostoslista (%s)"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Haetaan %s:ää..."
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML -tiedosto"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML -vienti"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Viedään reseptejä Gourmet XML -tiedostoon %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Resepti tallennettu Gourmet XML -tiedostoon %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML tiedosto (Vanhentunut)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML tiedosto"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook Text tiedosto"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Mastercook-vienti onnistui."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "XML:ää siivotaan"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML tiedosto"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2629,276 +2530,297 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Sivun asettelu"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Tulosta reseptit"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 "???: Muunna PDF:ksi (tai Tallenna PDF-muotoon - tai Vie PDF:ksi, tai PDF "
 "vienti... tai jotain. Riippuen onko valikossa vai missä...)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "???: Tallennetaan reseptejä PDF-tiedostoksi %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Resepti tallennettu PDF-tiedostoksi %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Letter (8x11\")"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Pystysuora"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Raaka (tekstistä)"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "pistettä"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Indeksikortti (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Indeksikortti (10x15 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Indeksikortti (13x20 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Indeksikortti (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Letter (8x11\")"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal/USA"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Indeksikortit (9x13 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Indeksikortit (10x15 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Indeksikortit (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Vaakasuora"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Raaka (tekstistä)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Sarake"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Sarake"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Sarake"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Sarake"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s Sarake"
 msgstr[1] "%s Sarakkeet"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Pystysuora"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Vaakasuora"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "_Paperikoko"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "Si_vun suunta"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Kirjasinkoko"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Sivun ase_mointi"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Kirjasinkoko"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Vasen marginaali"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Oikea marginaali"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Ylämarginaali"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Alamariginaali"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "PDF-valinnat"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster tiedosto"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster Vientitiedosto"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Vien reseptit MealMaster tiedostoon %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Resepti tallennettu MealMaster tiedostoksi %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "annos"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Iso tiedosto"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "HTML-vienti"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Viedään reseptejä Gourmet XML -tiedostoon %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Resepti tallennettu Gourmet XML -tiedostoon %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Ostoslista Tallennin"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Tallenna lista reseptiksi"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Tallenna nykyinen ostoslista reseptiksi tulevaa käyttöä varten"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "%s:n menu"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Ravintosisältö heijastaa määrä per %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Ravitsemuksellisia tietoja heijastavat määrät koko reseptissä"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Ravinnetieto puuttuu %s ainekselle : %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Mikä tahansa ruokaryhmä"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "valinta"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Muunna yksikkö %s:ksi"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Gourmet tarvitsee apuasi muuttamaan \"%s\" (mitta)yksiköksi, jota ohjelma "
 "ymmärtää, että ravitsemustiedot voidaan laskea."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Muuta aineksen avainta"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2907,27 +2829,27 @@ msgstr ""
 "Muuta aineksen %(old_key)s avain avroon %(new_key)s kaikkialla tai vain "
 "reseptissä %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Muuta kaikkialla"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "Vain reseptissä %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Muuta aines %(old_key)s arvoon %(new_key)s kaikkialla?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Muuta (mitta)yksikkö"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2936,11 +2858,11 @@ msgstr ""
 "Muuta yksikkö %(old_unit)s arvoon %(new_unit)s kaikille aineksille "
 "%(ingkey)s tai vain reseptissä %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2948,198 +2870,199 @@ msgstr ""
 "tarvitsee aineen tiheyden. Ravinnetietokannassamme on useita kuvauksia tälle "
 "ruoalle eri tiheyksille. Ole hyvä ja valitse oikea alla olevasta listasta."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Ottaakseen käyttöön ravinnetiedot, Gourmet tarvitsee oikean määrän ja "
 "yksikön."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Ravinteet"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Aines"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "USDA tietokannan vasttaavuudet"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 grammaa"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kaloreita"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Rasvaa yhteensä"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Tyydyttynyttä rasvaa"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Kolesterolia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Natriumia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Hiilihydraatteja yhteensä"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Ravintokuituja"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Sokereita"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-karoteenia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Tuhkaa"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-karoteenia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Kalsiumia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Kupari"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Folaatit yhteensä"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Foolihappo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Ruoan folaatit"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Ruokavalion vastineet"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Rautaa"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Lykopeeneja"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Luteiini+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnesiumia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangaania"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niasiini"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Pantoteenihappo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosforia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Kalium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "A-vitamiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinolia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavinia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Seleeniä"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamiiniä"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "A-vitamiinia (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "A-vitamiinia (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "B6-vitamiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "B12-vitamiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "C-vitamiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "E-vitamiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "K-vitamiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Sinkkiä"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamiineja ja mineraaleja"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3148,11 +3071,11 @@ msgstr ""
 "Ravitsemustietoja puuttuu\n"
 "%(missing)s/%(total)s aineksesta."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% päivittäisestä tarpeesta"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3161,367 +3084,367 @@ msgstr ""
 "Prosenttiosuus päivittäisestä tarpeesta perustuu %i kalorin päivädiettiin. "
 "Klikkaa (napauta) muuttaaksesi päivittäistä kalorimäärää."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Määrä per %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Määrä per resepti"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Lataan Ravinnetietoja"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Ravitsemustietotietokannan tuonti valmis!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Puran ravinnetietokantaa zip paketista %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Puran tiedoston %s zip paketista."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Jäsentää (käsittelee) ravitsemustietoja..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Luetaan ravintoaine tietoja: tuotu %s / %s tiedosta."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Jäsentää (käsittelee) painotietoja..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr "Luetaan ravintoaineiden painotietoja: tuotu %s / %s tiedosta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Vesi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalori"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g proteiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipidejä"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g tuhkaa"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g hiilihydraatteja"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g kuituja"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g sokeria"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg kalsiumia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg rautaa"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnesiumia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosforia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg potassiumia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg natriumia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg sinkkiä"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg kuparia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg mangaania"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mikrogrammaa seleeniä"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg C-vitamiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg tiamiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg riboflavafiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niasiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg pantoteenihappoa"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg B6-vitamiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "mikrogrammaa Folaatteja yhteensä"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "mikrogrammaa foolihappoja"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "mikrogrammaa Folaatteja ruoasta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "mikrogrammaa ruokavalion foolihapon vastineista"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Choline, koko"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mikrogrammaa B12-vitamiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamiini A"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamiini A (mikrogrammoiksi muutettuna)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "mikrogrammaa Retinolin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "mikrogrammaa Alpha-karoteenia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "mikrogrammaa beta-karoteenia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "mikrogrammaa beta kryptoksantiinia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "mikrogrammaa lykopeenejä"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "mikrogrammaa Luteiini+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamiinia E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamiinia K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g tyydyttyneitä rasvahappoja"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g (kerta)tyydyttymättömiä rasvahappoja"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g monityydyttymättömiä rasvahappoja"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg kolesterolia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Prosenttijäte"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Maitotuotteet ja munatuotteet"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Mausteet ja yrtit"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Lasten ruoat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Rasvat ja öljyt"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Siipikarja"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Keitot ja kastikkeet"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Makkarat ja \"lounaslihat\""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Murot ja puurot"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Hedelmät ja hedelmämehut"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Sianliha"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Vihannekset (ja juurekset)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Pähkinät ja siemenet"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Naudanliha"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Juomat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Kalat & Äyriäiset"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Palkokasvit"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Lammas, Nauta & Riista"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Leivotut tuotteet"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Makeiset"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Viljat ja Pasta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Pikaruoat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Ateriat, pääruoat ja höysteet (eli lisukkeet)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Välipalat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Etniset ruoat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "koko tietokanta"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Ainesavain"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "USDA ID numero"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA aines kuvaus"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Vastaava tiheys"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3535,295 +3458,249 @@ msgstr "Työkalut"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Hae ravinnetiedot nykyiselle listalle"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Määrä ostoslistaa varten"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "Muokkaa ravintoarvoja"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "tähteä"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Vietiin %(number)s/%(total)s reseptiä"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Vienti valmis."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Sisällytä resepti itse viestiin."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Lähetä resepti HTML-liitteenä"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Lähetä resepti sähköpostin PDF liitteenä"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Sähköpostiasetukset"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Älä varmista sähköpostin lähetystä"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Sähköpostia ei lähetetty"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 "Reseptiä ei ole valittu sisällytettäväksi itse viestiin eikä sen liitteeksi."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Tallenna resepti nimellä..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet ei voi viedä tiedostotyyppiin \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Vie reseptejä"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "reseptit"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Vienti epäonnisti: tuntematon tiedostotyyppi \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Olen hyvä ja varmista, että olet valinnut tiedostotyypin alasvetovalikosta "
 "tallennuksen yhteydessä."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Vienti"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "En pystynyt tulostamaan: tulostuksen lisäosia ei ole aktiivisena!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Tulosta %s resepti"
 msgstr[1] "Tulosta %s reseptiä"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Haetaan tiedostoa"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "saanti"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Syötä reseptiarkiston tai reseptisivuston internet-osoite (URL)."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Kirjoita sivuston osoite"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Syötä verkko-osoite (URL):"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Kirjoita sivuston tai reseptiarkiston osoite."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Osoitetta ei pysty tuomaan sisään"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Goumet:ssa ei ole lisäosaa osoitteen sisään tuomiseen"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"En pysty tuomaan osoitetta %(url)s tyyppiä %(type)s. Tiedosto talletettu "
-"väliaikaiseen paikkaan %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Avaa resepti..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Kirjoita sivuston osoite"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Muutokset"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Kirjoita sivuston tai reseptiarkiston osoite."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Tuonti"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Kaikki tuotavissa olevat tiedostot"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Tuotiin %s reseptiä."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "annos"
 msgstr[1] "annoksia"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Tuotiin %s/%s reseptiä"
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "ok"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "En tunnista tätä verkkosivua. Käytän yleistä tuontisuodatinta..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Tuonti valmis."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Tuodaan reseptiä"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Käsitellään ainesosia (???)"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Käsittelen raaka-aineita."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Annosmäärä"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Raaka-aineiden alaryhmä"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Piilota"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Teksti"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Toiminnot"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Tuo resepti"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Tyhjennä _Tagit"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Tuo resepti"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "missä vain"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "otsikko"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "aines"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "ohjeet"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "huomautukset"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "keittiö"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "lähde"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Käytä säännöllisiä lausekkeita haussa"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Käytä säännöllisiä lausekkeita (edistynyt merkintätapa, hakukieli) "
 "tekstihakujen kanssa"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Hae kirjoittaessasi (poista päältä, jos haku on liian hidas)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Näytä _hakuasetukset"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Näytä edistyneet hakuasetukset"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3832,104 +3709,98 @@ msgstr[1] "%s reseptit"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Näytetään reseptiä %(bottom)s - %(top)s / %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s yhteensä %s:tä"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Pysäytetty"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "KRecipe-tuonti"
 msgstr[1] "KRecipe-tuonti"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pysäytä"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Valmis"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Virhe: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Virhe"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Virhe %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Jäljitä"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "sekunti"
 msgstr[1] "sekuntia"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min."
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuutti"
 msgstr[1] "minuuttia"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "h."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "tunti"
 msgstr[1] "tuntia"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "päivä"
 msgstr[1] "päivää"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "viikko"
 msgstr[1] "viikkoa"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "kuukausi"
@@ -3938,7 +3809,7 @@ msgstr[1] "kuukautta"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "vuosi"
@@ -3950,71 +3821,30 @@ msgstr[1] "vuotta"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " ja "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "ja"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "-"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML -tiedosto"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet-reseptienhallinta"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr "Järjestä reseptejä, luo ostoslistoja, laske ravintoarvoja ja muuta."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Selaa reseptejä"
@@ -4024,7 +3854,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Valitaan reseptejä luokan, tyypin, yms. mukaan"
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Pääikkuna"
@@ -4036,38 +3865,6 @@ msgstr "Etsi reseptien kaksoiskappaleita"
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:2
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr "Ohjattu toiminto reseptien kaksoiskappaleiden käsittelyyn"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Lähetä sähköpostiosoitteeseen"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Lähetä reseptit sähköpostilla"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Zip, Gzip ja Tar-tuki"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Tuo reseptit zip- tai tar-arkistoista"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Tuonti/Vienti"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
@@ -4081,6 +3878,18 @@ msgstr ""
 msgid "Create an epub book from recipes."
 msgstr "Luo resepteistä verkkosivut."
 
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Tuonti/Vienti"
+
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
 msgstr "Gourmetin XML tuonti ja vienti"
@@ -4092,14 +3901,6 @@ msgid ""
 msgstr ""
 "Tuo ja vie reseptejä Gourmetin XML-muodossa. Käytännöllinen "
 "varmuuskopioidessa tai siirrettäessä reseptejä toisille Gourmet-käyttäjille."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "HTML-vienti"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Luo resepteistä verkkosivut."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4159,22 +3960,6 @@ msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
 msgstr ""
 "Helpottaa tekstitiedostojen tuontia. Tukee myös vientiä tekstitiedostoina."
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Verkkosivujen tuonti"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Tuo reseptejä verkosta"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Verkkosivujen ohjattu tuonti"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Ohjattu tuonti mm. sivustoilta about.com ja www.foodnetwork.com"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4239,6 +4024,193 @@ msgstr ""
 "Ota tämä käyttöön, jos Gourmet ei saa tuotua utf-16 -tekstitiedostoja "
 "oikein. Ota tämä pois käytöstä, jos UTF-16 ei ole käytössä, etkä halua nähdä "
 "merkkikoodaus-valintaikkunaa joka kerta tiedostoja tuotaessa."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Lähetä valittu resepti sähköpostilla"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "Lähetä resepti sähköpostilla"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (apu Windows-käännöksessä)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (parannuksia yksikkömuuntimen käyttöliittymään)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (parannuksia Mealmaster-vientiin)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo ja splash screen)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (ravitsemus- ja lisää ostoslistalle -ikonit)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (parannukset ohjelman "
+#~ "kansainvälistämiseen sekä sekalaiset ohjelmavirheiden korjaukset "
+#~ "(bugfixes))"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Windows version ylläpito ja sivuston "
+#~ "uudelleen suunnittelu)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Päivitetään tietokantaa"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Tietokantasi koosta riippuen, tämä saattaa olla raskas operaatio ja voi "
+#~ "ottaa jonkin aikaa. Tietosi on automaattisesti varmistettu siltä varalta, "
+#~ "että jotain menee vikaan."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Liitä aines"
+
+#~ msgid "Import from file"
+#~ msgstr "Tuo tiedostosta"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Valitse  ainesosaluettelon sisältävä tiedosto."
+
+#~ msgid "No file selected"
+#~ msgstr "Ei tiedostoa valittuna"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Tiedostoa ei ollut valittu, joten toiminto peruutettiin."
+
+#~ msgid "_Import file"
+#~ msgstr "_Tuo tiedosto"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Tuo _verkkosivu"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Tuo resepti verkkosivulta"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Avaa _Roskalaatikko"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Arkisto (zip, tar)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Ladataan pakattua zip-arkistotiedostoa..."
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Puretaan pakattua zip-arkistotiedostoa..."
+
+#~ msgid "Webpage"
+#~ msgstr "Sivusto"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Noudetaan %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Ostoslista (%s)"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Haetaan %s:ää..."
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Haetaan tiedostoa"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Syötä reseptiarkiston tai reseptisivuston internet-osoite (URL)."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Syötä verkko-osoite (URL):"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Osoitetta ei pysty tuomaan sisään"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Goumet:ssa ei ole lisäosaa osoitteen sisään tuomiseen"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "En pysty tuomaan osoitetta %(url)s tyyppiä %(type)s. Tiedosto talletettu "
+#~ "väliaikaiseen paikkaan %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "En tunnista tätä verkkosivua. Käytän yleistä tuontisuodatinta..."
+
+#~ msgid "Import complete."
+#~ msgstr "Tuonti valmis."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Tuodaan reseptiä"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Käsitellään ainesosia (???)"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Käsittelen raaka-aineita."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML -tiedosto"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet-reseptienhallinta"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr "Järjestä reseptejä, luo ostoslistoja, laske ravintoarvoja ja muuta."
+
+#~ msgid "Send to Email"
+#~ msgstr "Lähetä sähköpostiosoitteeseen"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Lähetä reseptit sähköpostilla"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Zip, Gzip ja Tar-tuki"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Tuo reseptit zip- tai tar-arkistoista"
+
+#~ msgid "HTML Export"
+#~ msgstr "HTML-vienti"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Luo resepteistä verkkosivut."
+
+#~ msgid "Webpage import"
+#~ msgstr "Verkkosivujen tuonti"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Tuo reseptejä verkosta"
+
+#~ msgid "Website Importers"
+#~ msgstr "Verkkosivujen ohjattu tuonti"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Ohjattu tuonti mm. sivustoilta about.com ja www.foodnetwork.com"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4368,9 +4340,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "Annoksia"
-
-#~ msgid "Select File_type"
-#~ msgstr "Valitse tiedoston tyyppi"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Tiedosto %s on jo olemassa."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gourmand Recipe Manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-16 21:54+0100\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2021-11-16 22:06+0100\n"
 "Last-Translator: \n"
 "Language-Team: French team\n"
@@ -24,11 +24,11 @@ msgstr "Index des recettes"
 
 #. Set up hard-coded functional buttons...
 #: ../src/gourmand/ui/app.ui.h:2
-#: ../src/gourmand/importers/interactive_importer.py:145
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nouvelle recette"
 
-#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Ajouter à la liste des courses"
 
@@ -200,8 +200,11 @@ msgstr "*"
 msgid "Database _Name:"
 msgstr "Nom de la base de données:"
 
-#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:668
-#: ../src/gourmand/main.py:1031
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Fichier"
 
@@ -240,9 +243,9 @@ msgstr ""
 "n'existe pas déjà."
 
 #: ../src/gourmand/ui/databaseChooser.ui.h:19
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recette"
 
@@ -255,8 +258,8 @@ msgid "_Browse"
 msgstr "_Parcourir"
 
 #: ../src/gourmand/ui/databaseChooser.ui.h:22
-#: ../src/gourmand/gtk_extras/dialog_extras.py:853
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1289
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Détails"
 
@@ -320,8 +323,8 @@ msgid ""
 "<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
-"<i>Que faire avec les ingrédients facultatifs lorsque vous "
-"ajoutez des recettes à la liste de courses ?</i>"
+"<i>Que faire avec les ingrédients facultatifs lorsque vous ajoutez des "
+"recettes à la liste de courses ?</i>"
 
 #: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
@@ -343,9 +346,9 @@ msgstr "_Toujours ajouter les ingrédients facultatifs"
 msgid "_Never add optional ingredients"
 msgstr "_Ne jamais ajouter les ingrédients facultatifs"
 
-#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:144
-#: ../src/gourmand/shopgui.py:533 ../src/gourmand/shopgui.py:843
-#: ../src/gourmand/shopgui.py:994
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Liste de courses"
 
@@ -355,11 +358,9 @@ msgstr "portions"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmand/shopgui.py:744 ../src/gourmand/gglobals.py:31
-#: ../src/gourmand/exporters/rtf_exporter.py:86
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Titre"
 
@@ -372,7 +373,7 @@ msgid "Pre_paration Time:"
 msgstr "_Temps de préparation:"
 
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmand/recindex.py:51 ../src/gourmand/recindex.py:58
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "catégorie"
 
@@ -381,12 +382,12 @@ msgid "rating"
 msgstr "note"
 
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmand/gglobals.py:37
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Part"
 
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmand/gglobals.py:38
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Type de part"
 
@@ -455,10 +456,10 @@ msgid "Edit _notes"
 msgstr "Modifier _les notes"
 
 #: ../src/gourmand/ui/recCardDisplay.ui.h:17
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmand/exporters/exporter.py:620
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recette"
 
@@ -475,16 +476,15 @@ msgid "Add _ingredient:"
 msgstr "Ajouter _un ingrédient :"
 
 #: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmand/reccard.py:1070
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
 #: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:617
-#: ../src/gourmand/exporters/exporter.py:248
-#: ../src/gourmand/importers/interactive_importer.py:39
-#: ../src/gourmand/importers/interactive_importer.py:54
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingrédients"
 
@@ -505,7 +505,7 @@ msgid "Delete selected recipe"
 msgstr "Supprimer la recette sélectionnée"
 
 #. saveEdits
-#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:871
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Supprimer la recette"
 
@@ -570,7 +570,7 @@ msgstr "Rechercher au fur et à mesure que vous _tapez"
 msgid "<i>Search Options</i>"
 msgstr "<i>Options de recherche</i>"
 
-#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Catégorie"
 
@@ -579,11 +579,11 @@ msgstr "Catégorie"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2143
-#: ../src/gourmand/reccard.py:2203
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:116
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Clef"
 
@@ -595,7 +595,7 @@ msgstr "Éditeur de catégories"
 msgid "Search by"
 msgstr "Chercher par"
 
-#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:107
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Rechercher lors de la saisie"
 
@@ -613,8 +613,8 @@ msgstr "Recherche avancée"
 msgid "Add Category: "
 msgstr "Ajouter une catégorie : "
 
-#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:190
-#: ../src/gourmand/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Minuteur"
 
@@ -753,7 +753,7 @@ msgid "Unit:"
 msgstr "Unité :"
 
 #: ../src/gourmand/ui/nutritionDruid.ui.h:12
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "unité"
 
@@ -836,10 +836,10 @@ msgstr "Recherche _avancée"
 #. name
 #. stock
 #: ../src/gourmand/ui/nutritionDruid.ui.h:35
-#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
 #: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
 #: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Information nutritionnelle"
@@ -890,7 +890,7 @@ msgstr ""
 "* Can calculate nutritional information for recipes based on the "
 "ingredients.\n"
 
-#: ../src/gourmand/__version__.py:25
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr "Nyall Dawson (icône du cookie)"
 
@@ -898,160 +898,160 @@ msgstr "Nyall Dawson (icône du cookie)"
 msgid "Kati Pregartner (splash screen image)"
 msgstr "Kati Pregartner (image de démarrage)"
 
-#: ../src/gourmand/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Choisir un fichier de base de données"
 
-#: ../src/gourmand/backends/db.py:1484 ../src/gourmand/reccard.py:942
-#: ../src/gourmand/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Nouvelle recette"
 
-#: ../src/gourmand/backends/db.py:2132 ../src/gourmand/backends/db.py:2133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
 msgid "Database Backup"
 msgstr "Sauvegarde de la base de données"
 
-#: ../src/gourmand/backends/db.py:2134
+#: ../src/gourmand/backends/db.py:2184
 msgid "Depending on the size of your database, this may take some time."
 msgstr ""
 "En fonction de la taille de la base de données, cela peut prendre du temps."
 
-#: ../src/gourmand/backends/db.py:2135 ../src/gourmand/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Détails"
 
-#: ../src/gourmand/backends/db.py:2136
+#: ../src/gourmand/backends/db.py:2188
 #, python-format
 msgid ""
 "A backup will be made as %s in case something goes wrong. If this upgrade "
 "fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
-"Une sauvegarde va être faite en %s en cas d'erreur. "
-"Si la mise à niveau échoue, vous pouvez renommer le fichier de sauvegarde en "
-"recipes.db pour retrouver vos recettes."
+"Une sauvegarde va être faite en %s en cas d'erreur. Si la mise à niveau "
+"échoue, vous pouvez renommer le fichier de sauvegarde en recipes.db pour "
+"retrouver vos recettes."
 
-#: ../src/gourmand/shopgui.py:119 ../src/gourmand/shopgui.py:126
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Changer la _catégorie"
 
-#: ../src/gourmand/shopgui.py:120
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Créer une nouvelle catégorie"
 
-#: ../src/gourmand/shopgui.py:128
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Changer la catégorie de l’élément sélectionné"
 
-#: ../src/gourmand/shopgui.py:134
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Garde-manger"
 
 #. name
 #. stock
-#: ../src/gourmand/shopgui.py:137
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Déplacer vers la _liste de courses"
 
 #. text
-#: ../src/gourmand/shopgui.py:138
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmand/shopgui.py:147
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Déplacer vers le _garde-manger"
 
 #. text
-#: ../src/gourmand/shopgui.py:148
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmand/shopgui.py:149
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Supprimer de la liste de courses"
 
-#: ../src/gourmand/shopgui.py:170
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Déplacer les éléments sélectionnés vers %s"
 
-#: ../src/gourmand/shopgui.py:208
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Liste de cour_ses"
 
-#: ../src/gourmand/shopgui.py:209
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Déjà en stock (ingrédient du _garde-manger)"
 
-#: ../src/gourmand/shopgui.py:472
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Entrer une catégorie"
 
-#: ../src/gourmand/shopgui.py:473
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Catégorie dans laquelle ajouter %s"
 
-#: ../src/gourmand/shopgui.py:474
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Catégorie :"
 
-#: ../src/gourmand/shopgui.py:578
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recettes"
 
-#: ../src/gourmand/shopgui.py:602
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Ajouter des éléments :"
 
-#: ../src/gourmand/shopgui.py:641
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Supprimer les recettes"
 
-#: ../src/gourmand/shopgui.py:642
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Supprimer les recettes de la liste de courses"
 
-#: ../src/gourmand/shopgui.py:646 ../src/gourmand/reccard.py:227
-#: ../src/gourmand/reccard.py:866 ../src/gourmand/main.py:1044
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Édition"
 
-#: ../src/gourmand/shopgui.py:669 ../src/gourmand/shopgui.py:672
-#: ../src/gourmand/reccard.py:229 ../src/gourmand/reccard.py:240
-#: ../src/gourmand/reccard.py:868 ../src/gourmand/main.py:1056
-#: ../src/gourmand/main.py:1059
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Aide"
 
-#: ../src/gourmand/shopgui.py:677
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Ajouter des éléments"
 
-#: ../src/gourmand/shopgui.py:679
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Ajouter des éléments arbitraires à la liste de courses"
 
-#: ../src/gourmand/shopgui.py:745
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmand/shopgui.py:830
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Aucune recette sélectionnée. Voulez-vous effacer la liste entière ?"
 
-#: ../src/gourmand/shopgui.py:841
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Sauvegarder la liste de courses sous…"
 
-#: ../src/gourmand/shopgui.py:897
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Sélectionner des ingrédients facultatifs"
 
-#: ../src/gourmand/shopgui.py:898
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1060,56 +1060,56 @@ msgstr ""
 "votre liste de courses."
 
 #. menus
-#: ../src/gourmand/reccard.py:226 ../src/gourmand/reccard.py:865
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recette"
 
-#: ../src/gourmand/reccard.py:228 ../src/gourmand/main.py:211
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Aller"
 
-#: ../src/gourmand/reccard.py:230
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Exporter la recette"
 
-#: ../src/gourmand/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Exporter la recette sélectionnée (enregistrer dans un fichier)"
 
-#: ../src/gourmand/reccard.py:233
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Supprimer la recette"
 
-#: ../src/gourmand/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Supprimer cette recette"
 
-#: ../src/gourmand/reccard.py:248
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Ajuster les unités après multiplication"
 
-#: ../src/gourmand/reccard.py:250
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr "Changer les unités pour les rendre plus lisibles après multiplication."
 
-#: ../src/gourmand/reccard.py:256
+#: ../src/gourmand/reccard.py:246
 msgid "Copy to clipboard"
 msgstr "Copier dans le presse papier"
 
-#: ../src/gourmand/reccard.py:258
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Imprimer la recette"
 
-#: ../src/gourmand/reccard.py:260 ../src/gourmand/main.py:1025
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 msgid "Add to Shopping List"
 msgstr "Ajouter à la liste des courses"
 
-#: ../src/gourmand/reccard.py:262
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Oublier les ingrédients optionels"
 
-#: ../src/gourmand/reccard.py:263
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1117,142 +1117,142 @@ msgstr ""
 "Avant d’ajouter à la liste de courses, vérifier tous les ingrédients "
 "optionels, même ceux dont vous vouliez précédemment vous rappeler"
 
-#: ../src/gourmand/reccard.py:265
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Exporter la recette"
 
-#: ../src/gourmand/reccard.py:551
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr "Recette exportée vers <a href=\"file:///%s\">%s</a> avec succès"
 
-#: ../src/gourmand/reccard.py:575 ../src/gourmand/reccard.py:588
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Vous avez des changements non enregistrés."
 
-#: ../src/gourmand/reccard.py:576
+#: ../src/gourmand/reccard.py:547
 msgid "Save changes before copying?"
 msgstr "Sauvegarder avant de copier?"
 
-#: ../src/gourmand/reccard.py:589
+#: ../src/gourmand/reccard.py:559
 msgid "Save changes before printing?"
 msgstr "Sauvegarder avant d'imprimer?"
 
-#: ../src/gourmand/reccard.py:701 ../src/gourmand/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Facultatif)"
 
-#: ../src/gourmand/reccard.py:753
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Impossible de trouver la recette %s dans la base de donnée."
 
-#: ../src/gourmand/reccard.py:849
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Modifier la recette :"
 
-#: ../src/gourmand/reccard.py:870
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Enregisrer les modifications apportées à la base de données"
 
 #. show_pref_dialog
-#: ../src/gourmand/reccard.py:879
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Voir la fiche recette"
 
-#: ../src/gourmand/reccard.py:942
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Éditer"
 
-#: ../src/gourmand/reccard.py:1040 ../src/gourmand/reccard.py:1041
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Enregistrer les changements vers %s"
 
-#: ../src/gourmand/reccard.py:1131
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Ajouter un ingrédient"
 
-#: ../src/gourmand/reccard.py:1136
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Ajouter un groupe"
 
-#: ../src/gourmand/reccard.py:1138
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Ajouter une _recette"
 
-#: ../src/gourmand/reccard.py:1139
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Ajouter une autre recette comme ingrédient de cette recette"
 
-#: ../src/gourmand/reccard.py:1144
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../src/gourmand/reccard.py:1150
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Vers le haut"
 
-#: ../src/gourmand/reccard.py:1152
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Vers le bas"
 
-#: ../src/gourmand/reccard.py:1308
-#: ../src/gourmand/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Description"
 
-#: ../src/gourmand/reccard.py:1656 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
 #: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instructions"
 
-#: ../src/gourmand/reccard.py:1662 ../src/gourmand/gglobals.py:46
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
 #: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notes"
 
-#: ../src/gourmand/reccard.py:2140 ../src/gourmand/reccard.py:2170
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Qté"
 
-#: ../src/gourmand/reccard.py:2141 ../src/gourmand/reccard.py:2171
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Unité"
 
-#: ../src/gourmand/reccard.py:2142 ../src/gourmand/reccard.py:2172
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:108
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Élément"
 
-#: ../src/gourmand/reccard.py:2144 ../src/gourmand/reccard.py:2173
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Optionnel"
 
-#: ../src/gourmand/reccard.py:2285
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "La recette %s (ID %s) n’est pas dans notre base de données."
 
-#: ../src/gourmand/reccard.py:2603
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Converti : %(amt)s %(unit)s"
 
-#: ../src/gourmand/reccard.py:2605
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Non converti : %(amt)s %(unit)s"
 
-#: ../src/gourmand/reccard.py:2609
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Unité changée."
 
-#: ../src/gourmand/reccard.py:2610
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1261,142 +1261,142 @@ msgstr ""
 "Vous avez changé l’unité de l’ingrédient %(item)s de %(old)s à %(new)s. "
 "Voulez-vous une conversion de la quantité ?"
 
-#: ../src/gourmand/reccard.py:2621
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "%(old_amt)s %(old_unit)s converti en %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmand/reccard.py:2633
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Impossible de convertir des %(old_unit)s en %(new_unit)s"
 
-#: ../src/gourmand/reccard.py:2688
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Ajouter un groupe d’ingrédients"
 
-#: ../src/gourmand/reccard.py:2689
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Entrer un nom pour le nouveau sous-groupe d’ingrédients"
 
-#: ../src/gourmand/reccard.py:2690
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Nom du groupe :"
 
-#: ../src/gourmand/reccard.py:2953
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Choisir une recette"
 
-#: ../src/gourmand/reccard.py:2990
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Une recette ne peut pas servir d’ingrédient à elle-même !"
 
-#: ../src/gourmand/reccard.py:2991 ../src/gourmand/shopping.py:298
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "La récursion infinie n’est pas autorisée dans les recettes !"
 
-#: ../src/gourmand/reccard.py:3009
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Vous n’avez pas sélectionné de recette !"
 
-#: ../src/gourmand/reccard.py:3021
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "De combien de %(title)s votre recette a-t-elle besoin ?"
 
-#: ../src/gourmand/reccard.py:3031
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmand/exporters/recipe_emailer.py:65
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recettes"
 
-#: ../src/gourmand/timer.py:147 ../src/gourmand/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Sonnerie"
 
-#: ../src/gourmand/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Son d’avertissement"
 
-#: ../src/gourmand/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Son d’erreur"
 
-#: ../src/gourmand/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Arrêter le minuteur ?"
 
-#: ../src/gourmand/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Arrêter le _minuteur"
 
-#: ../src/gourmand/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Conserver le minutage"
 
-#: ../src/gourmand/plugin_gui.py:35
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Modules d’extension"
 
-#: ../src/gourmand/plugin_gui.py:38
+#: ../src/gourmand/plugin_gui.py:39
 msgid "Plugins add extra functionality to Gourmand."
 msgstr "Les modules d’extension ajoutent de nouvelles fonctionnalités."
 
-#: ../src/gourmand/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Le module est nécessaire au fonctionnement d’autres modules. Voulez-vous "
 "tout de même le désactiver ?"
 
-#: ../src/gourmand/plugin_gui.py:126
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Les modules suivants requièrent %s :"
 
-#: ../src/gourmand/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Désactiver quand même"
 
-#: ../src/gourmand/plugin_gui.py:130
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Garder le module actif"
 
-#: ../src/gourmand/plugin_gui.py:144 ../src/gourmand/recindex.py:463
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "ou"
 
-#: ../src/gourmand/plugin_gui.py:148
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Une erreur est survenue durant l’activation du module."
 
-#: ../src/gourmand/plugin_gui.py:152
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Une erreur est survenue durant la désactivation du module."
 
-#: ../src/gourmand/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Cuisine"
 
-#: ../src/gourmand/gglobals.py:34
-#: ../src/gourmand/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Note"
 
-#: ../src/gourmand/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Source"
 
-#: ../src/gourmand/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Site sur la toile"
 
-#: ../src/gourmand/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Temps de préparation"
 
-#: ../src/gourmand/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Temps de cuisson"
 
@@ -1404,88 +1404,88 @@ msgstr "Temps de cuisson"
 msgid "Modifications"
 msgstr "Modifications"
 
-#: ../src/gourmand/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr "Le temps doit être composé d'un nombre et d'une unité."
 
-#: ../src/gourmand/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Entrée invalide."
 
-#: ../src/gourmand/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Ce n'est pas un nombre."
 
 #. setup pause button
-#: ../src/gourmand/gtk_extras/dialog_extras.py:424
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pause"
 
 #. setup stop button
-#: ../src/gourmand/gtk_extras/dialog_extras.py:437
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Arrêter"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:508
-#: ../src/gourmand/gtk_extras/dialog_extras.py:602
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Ne plus poser la question."
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:565
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Voulez-vous vraiment faire cela"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:786
-#: ../src/gourmand/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "excellent"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:787
-#: ../src/gourmand/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "super"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:788
-#: ../src/gourmand/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "bon"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:789
-#: ../src/gourmand/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "assez bon"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:790
-#: ../src/gourmand/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "mauvais"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:802
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Convertir les notes vers une échelle de un à cinq étoiles."
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:803
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Convertir les notes."
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:805
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Merci de donner à chacune des notes un équivalent sur une échelle de 1 à 5"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:819
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Note actuelle"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:824
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Note sur un maximum de 5 étoiles"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1227
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
 msgid "Select File(s)"
 msgstr "Fichier(s) sélectionné(s)"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1285
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1494,14 +1494,14 @@ msgstr ""
 "Désolé, je ne comprends pas\n"
 "la quantité « %s »."
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1288
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Les quantités doivent être des nombres (fractions ou décimales), plages de "
 "valeurs ou rien."
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1290
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1521,83 +1521,83 @@ msgstr ""
 "Pour entrer une suite de nombres, utilisez un \"-\" pour les séparer.\n"
 "Par exemple, vous pouvez entrer 2-4 ou 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1305
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1305
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr "Mot de passe"
 
-#: ../src/gourmand/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "farine, tous types"
 
-#: ../src/gourmand/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "sucre"
 
-#: ../src/gourmand/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sel"
 
-#: ../src/gourmand/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "poivre noir, moulu"
 
-#: ../src/gourmand/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "glace"
 
-#: ../src/gourmand/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "eau"
 
-#: ../src/gourmand/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "huile végétale"
 
-#: ../src/gourmand/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "huile d'olive"
 
-#: ../src/gourmand/shopping.py:144 ../src/gourmand/shopping.py:164
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: ../src/gourmand/shopping.py:297
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "La recette s’indique comme un de ses ingrédients."
 
-#: ../src/gourmand/shopping.py:298
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "L’ingrédient %s sera ignoré."
 
-#: ../src/gourmand/shopping.py:344 ../src/gourmand/shopping.py:358
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Liste de courses pour %s"
 
-#: ../src/gourmand/shopping.py:345
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr "Pour les recettes suivantes :\n"
 
-#: ../src/gourmand/shopping.py:350 ../src/gourmand/shopping.py:363
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmand/shopping.py:359
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Pour les recettes suivantes :"
 
-#: ../src/gourmand/check_encodings.py:104
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Choisir l’encodage"
 
-#: ../src/gourmand/check_encodings.py:105
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1605,340 +1605,344 @@ msgstr ""
 "Impossible de déterminer l’encodage. Merci de sélectionner un encodage "
 "valide dans la liste suivante."
 
-#: ../src/gourmand/check_encodings.py:106
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Voir le _fichier avec l’encodage"
 
-#: ../src/gourmand/main.py:111
+#. Convenience method for showing progress dialogs for import/export/deletion
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importation en pause"
 
-#: ../src/gourmand/main.py:112
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Arrêter l’importation"
 
-#: ../src/gourmand/main.py:191 ../src/gourmand/main.py:1071
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Index des recettes"
 
-#: ../src/gourmand/main.py:192
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Liste de courses"
 
-#: ../src/gourmand/main.py:339
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr "traducteurs"
 
-#: ../src/gourmand/main.py:390
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Enregistré !"
 
-#: ../src/gourmand/main.py:401
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Enregistrer vos éditions dans %s"
 
-#: ../src/gourmand/main.py:412
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Importation en cours."
 
-#: ../src/gourmand/main.py:413
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Exportation en cours."
 
-#: ../src/gourmand/main.py:414
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Suppression en cours."
 
-#: ../src/gourmand/main.py:416
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Quitter l’application quand même ?"
 
-#: ../src/gourmand/main.py:418
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Ne pas quitter !"
 
-#: ../src/gourmand/main.py:464
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "%s des %s recettes ont été supprimées définitivement"
 
-#: ../src/gourmand/main.py:485 ../src/gourmand/main.py:500
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Corbeille"
 
-#: ../src/gourmand/main.py:501
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 "Explorer, supprimer définitivement ou annuler la suppression de recettes"
 
-#: ../src/gourmand/main.py:555
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Recettes récupérées après effacement "
 
-#: ../src/gourmand/main.py:692
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Nombre de %(unit)s de %(title)s à acheter"
 
-#: ../src/gourmand/main.py:704
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multiplier %s par :"
 
-#: ../src/gourmand/main.py:737
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Assigner %(attributes)s pour %(num)s recette sélectionnée ?"
 msgstr[1] "Assigner %(attributes)s pour %(num)s recettes sélectionnées ?"
 
-#: ../src/gourmand/main.py:744
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Aucune des valeurs déjà existantes ne seront modifiées."
 
-#: ../src/gourmand/main.py:746
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Les nouvelles valeurs écraseront les valeurs existantes."
 
-#: ../src/gourmand/main.py:747
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Cette modification ne pourra pas être annulée."
 
-#: ../src/gourmand/main.py:748
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Compléter les valeurs des recettes sélectionnées"
 
-#: ../src/gourmand/main.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Rechercher"
 
-#: ../src/gourmand/main.py:1009
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Ouvrir"
 
-#: ../src/gourmand/main.py:1010
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Ouvrir la recette sélectionnée"
 
-#: ../src/gourmand/main.py:1011
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Supprimer la recette"
 
-#: ../src/gourmand/main.py:1012
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Effacer les recettes sélectionnées"
 
-#: ../src/gourmand/main.py:1013
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Éditer la recette"
 
-#: ../src/gourmand/main.py:1014
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Ouvrir les recettes sélectionnées dans l’éditeur"
 
-#: ../src/gourmand/main.py:1016
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_xporter les recettes sélectionnées"
 
-#: ../src/gourmand/main.py:1017
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Exporter les recettes sélectionnées dans un fichier"
 
-#: ../src/gourmand/main.py:1019
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "Im_primer"
 
-#: ../src/gourmand/main.py:1021
+#: ../src/gourmand/main.py:1000
 msgid "_Copy recipes"
 msgstr "_Copier la recette"
 
-#: ../src/gourmand/main.py:1023
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Modifi_er des recettes par lot"
 
-#: ../src/gourmand/main.py:1032
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nouveau"
 
-#: ../src/gourmand/main.py:1034
+#: ../src/gourmand/main.py:1011
 msgid "_Import Recipe"
 msgstr "Importer une recette"
 
-#: ../src/gourmand/main.py:1035
+#: ../src/gourmand/main.py:1011
 msgid "Import recipe from file or page"
 msgstr "Importer une recette depuis un fichier ou une page"
 
-#: ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1012
 msgid "Paste recipe"
 msgstr "Coller la recette"
 
-#: ../src/gourmand/main.py:1038
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Exporter _toutes les recettes"
 
-#: ../src/gourmand/main.py:1039
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Exporter toutes les recettes dans un fichier"
 
-#: ../src/gourmand/main.py:1040
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Quitter"
 
-#: ../src/gourmand/main.py:1043
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Actions"
 
-#: ../src/gourmand/main.py:1046
-msgid "Open _Trash"
-msgstr "Ouvrir la _corbeille"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Corbeille"
 
-#: ../src/gourmand/main.py:1049
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Préférences"
 
-#: ../src/gourmand/main.py:1051
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Extensions"
 
-#: ../src/gourmand/main.py:1052
+#: ../src/gourmand/main.py:1032
 msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Gérer les modules qui ajoutent des fonctionnalités à Gourmand."
 
-#: ../src/gourmand/main.py:1054
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Préfére_nces"
 
-#: ../src/gourmand/main.py:1057
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_À propos"
 
-#: ../src/gourmand/main.py:1065
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Outils"
 
-#: ../src/gourmand/main.py:1066
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Minuteur"
 
-#: ../src/gourmand/main.py:1067
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Afficher le minuteur"
 
-#: ../src/gourmand/main.py:1072
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Index de recherche des recettes dans la base de données."
 
-#: ../src/gourmand/main.py:1183
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Supprimer %s ?"
 
-#: ../src/gourmand/main.py:1184
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "Des modifications de %s n’ont pas été enregistrées. Êtes-vous sûr de vouloir "
 "supprimer ?"
 
-#: ../src/gourmand/main.py:1213
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Supprimé"
 
-#: ../src/gourmand/main.py:1213
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Sans titre"
 
-#: ../src/gourmand/main.py:1221
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Supprimer définitivement les recettes ?"
 
-#: ../src/gourmand/main.py:1223
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Supprimer définitivement la recette ?"
 
-#: ../src/gourmand/main.py:1224
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Êtes-vous sûr⋅e de vouloir supprimer la recette <i>%s</i>"
 
-#: ../src/gourmand/main.py:1226
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Êtes-vous sûr⋅e de vouloir supprimer les recettes suivantes ?"
 
-#: ../src/gourmand/main.py:1230
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Êtes-vous sûr⋅e de vouloir supprimer les %s recettes sélectionnées ?"
 
-#: ../src/gourmand/main.py:1232
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Voir les recettes"
 
-#: ../src/gourmand/main.py:1240
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Supprimer les recettes"
 
-#: ../src/gourmand/main.py:1242
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr "Recettes supprimées"
 
-#: ../src/gourmand/main.py:1267
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Recette supprimée %s"
 
-#: ../src/gourmand/main.py:1294
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr "Voir la corbeille"
 
-#: ../src/gourmand/main.py:1333
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Terminé !"
 
-#: ../src/gourmand/main.py:1341
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importation…"
 
-#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Éditeur de _clef d’ingrédient"
 
-#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Modifier les clefs d’ingrédients en masse"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "clef"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:265
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "élément"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Champ"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Valeur"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Nombre"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Remplacer toutes les clefs « %s » par « %s » ?"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1949,12 +1953,12 @@ msgstr ""
 "« %s », vous ne pourrez pas les distinguer de ceux que vous êtes en train de "
 "changer."
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Remplacer tous les éléments « %s » par « %s » ?"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1965,12 +1969,12 @@ msgstr ""
 "l’élément « %s », vous ne pourrez pas les distinguer de ceux que vous êtes "
 "en train de changer."
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Rempl_acer toutes les occurences de « %(unit)s » en « %(text)s »"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -1979,14 +1983,14 @@ msgstr ""
 "Remplacer « %(unit)s » en « %(text)s » uniquement pour les ingrédients "
 "« %(item)s » avec la clef « %(key)s »"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Rempl_acer toutes les occurences de « %(amount)s » %(unit)s par %(text)s "
 "%(unit)s"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -1995,7 +1999,7 @@ msgstr ""
 "Remplacer « %(amount)s » %(unit)s par %(text)s %(unit)s _seulement pour les "
 "ingrédients dont la clef est %(key)s"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2004,7 +2008,7 @@ msgstr ""
 "Remplacer « %(amount)s » %(unit)s par « %(text)s » %(unit)s uniquement "
 "lorsque la clef est %(key)s _et lorsque l’élément est %(item)s"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Changer toutes les lignes séléctionées ?"
 
@@ -2054,7 +2058,7 @@ msgstr ""
 "Quantité en %s"
 
 #: ../src/gourmand/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2064,18 +2068,18 @@ msgstr[1] "%s ingrédients"
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
 #: ../src/gourmand/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Montrer les ingrédients %(bottom)s à %(top)s de %(total)s"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Quantité"
 
 #: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Clefs d’ingrédient"
 
@@ -2087,11 +2091,11 @@ msgstr ""
 "Les clefs d’ingrédient sont des noms d’ingrédients normalisés utilisés pour "
 "les listes de courses et les calculs."
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Deviner les clefs"
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2099,11 +2103,11 @@ msgstr ""
 "Deviner les meilleures valeurs pour toutes les clefs d'ingrédient selon les "
 "valeurs actuellement dans la base de donnée"
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Modifier les associations de clef"
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:98
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 "Modifier les associations avec la clef et d’autres attributs dans la base de "
@@ -2144,15 +2148,15 @@ msgstr "Toujours utiliser les unités US"
 msgid "Always display metric units"
 msgstr "Toujours utiliser les unités du système métrique"
 
-#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:20
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Ajuster automatiquement les unités"
 
-#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:30
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Assigner les préférences d’affichage d’unité"
 
-#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2160,42 +2164,42 @@ msgstr ""
 "Convertir automatiquement les unités vers le système préféré (métrique, "
 "impérial, etc.) quand c'est possible."
 
-#: ../src/gourmand/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr "Sans Étoiles"
 
-#: ../src/gourmand/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Étoiles"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "Il y a %s"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Fusion automatique des recettes"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Toujours utiliser la recette la plus récente"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Toujours utiliser la recette la plus ancienne"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmand/plugins/unit_converter/convertGui.py:161
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
 #: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Aucun"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:25
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:61
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2204,11 +2208,11 @@ msgstr ""
 "combiner entre elles, ou fermer cette boîte de dialogue en les laissant "
 "telles quelles."
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:68
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Trouver les recettes en _double"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Trouver et supprimer les recettes en double"
 
@@ -2249,37 +2253,37 @@ msgid "_Auto-merge"
 msgstr "Fusion _automatique"
 
 #. len(vals)==0
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Pour chaque valeur sélectionnée"
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Où %(field)s est %(value)s"
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:168
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Le changement affectera %s recette"
 msgstr[1] "Le changement affectera %s recettes"
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Supprimer %s lorsqu’il vaut %s ?"
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:175
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Changer %s de %s à « %s » ?"
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:181
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Ce changement n’est pas réversible.</i>"
 
-#: ../src/gourmand/plugins/field_editor/__init__.py:19
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Éditeur de champs"
@@ -2289,12 +2293,12 @@ msgstr "Éditeur de champs"
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Modifier les champs de plusieurs recettes en une fois."
 
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:25
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:45
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Envoyer par courriel les recettes"
 
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:26
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Envoyer par courriel toutes les recettes sélectionnées (ou toutes les "
@@ -2303,30 +2307,30 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:49
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 "Voulez-vous réellement envoyer par courriel %s recettes sélectionnées ?"
 
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Oui, les _envoyer par courriel"
 
-#: ../src/gourmand/plugins/unit_converter/convertGui.py:115
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Impossible de convertir %s en %s"
 
-#: ../src/gourmand/plugins/unit_converter/convertGui.py:117
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Besoin de l’information de densité."
 
-#: ../src/gourmand/plugins/unit_converter/__init__.py:17
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Convertisseur d’_unité"
 
-#: ../src/gourmand/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Calculer les conversions d’unité"
 
@@ -2371,32 +2375,32 @@ msgstr "?"
 msgid "HTML Web Page"
 msgstr "Page HTML"
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Export de la page"
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Export des recettes en fichier HTML dans le dossier %(file)s"
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Recette enregistrée comme un fichier HTML %(file)s"
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Page originale de %s"
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:645
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:658
-#: ../src/gourmand/exporters/exporter.py:384
-#: ../src/gourmand/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "optionelle"
 
@@ -2404,49 +2408,49 @@ msgstr "optionelle"
 msgid "Epub File"
 msgstr "Fichier Epub"
 
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr "Export  epub"
 
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Export des recettes en fichier epub  dans le dossier %(file)s"
 
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Recette enregistrée comme un fichier epub  %(file)s"
 
 #: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:42
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Fichier texte brut"
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Exporter au format texte"
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Exportation des recettes vers le fichier texte %(file)s."
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Recette enregistrée dans le fichier texte %(file)s"
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:25
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Gros fichier"
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Le fichier %s est trop gros pour être importé"
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2459,25 +2463,25 @@ msgstr ""
 "petits et essayez à nouveau d’importer."
 
 #: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Fichier XML Gourmet"
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Exporter au format XML Gourmet"
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Exportation des recettes vers le fichier XML Gourmet %(file)s."
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Recette enregistrée dans le fichier XML Gourmet %(file)s."
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Fichier XML Gourmet (obsolète)"
 
@@ -2493,19 +2497,19 @@ msgstr "Fichier texte Mastercook"
 msgid "Mastercook import finished."
 msgstr "Fin de l’importation Mastercook."
 
-#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Nettoyage du XML"
 
-#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "Fichier XML KRecipe"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:60
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr "Could not find Adobe Reader on your system."
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:61
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2519,11 +2523,11 @@ msgstr ""
 "Alternatively, export your recipe(s) to PDF and print it with another PDF "
 "viewer."
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:84
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Mise en page"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:178
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Imprimer des recettes"
 
@@ -2531,156 +2535,154 @@ msgstr "Imprimer des recettes"
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Exporter au format PDF"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Exportation des recettes dans le fichier PDF %(file)s."
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Recette enregistrée dans le fichier PDF %(file)s"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:743
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:762
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:763
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "points"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:837
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11×17″"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:838
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Fiche d’index (3½×5″)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:839
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Fiche d’index (4×6″)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Fiche d’index (5×8″)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Fiche d’index (A7)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
 msgid "Letter"
 msgstr "Lettre"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:843
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Légal"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:872
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:885
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Fiche d’index (3½×5)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:873
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:886
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Fiche d’index (4×6)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:887
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Fiche d’index (A7)"
 
-#. These two dictionaries are here to be able to store the preferences in the persistent toml file.
-#. This allows us to have a locale-agnostic GUI.
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:880
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1021
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
 msgid "Plain"
 msgstr "Brut"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
 msgid "2 Columns"
 msgstr "2 colonnes"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
 msgid "3 Columns"
 msgstr "3 colonnes"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:870
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
 msgid "4 Columns"
 msgstr "4 colonnes"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:871
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:884
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
 msgid "5 Columns"
 msgstr "5 colonnes"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:876
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s colonne"
 msgstr[1] "%s colonnes"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:891
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1025
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1056
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
 msgid "Portrait"
 msgstr "Portrait"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:892
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1007
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1054
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
 msgid "Landscape"
 msgstr "Paysage"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:920
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "_Taille du papier"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:926
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientation"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:932
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Mise en page"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:938
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
 msgid "_Font Size"
 msgstr "Taille de la _police"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:941
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Marge de gauche"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:942
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Marge de droite"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:943
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Marge du haut"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:944
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Marge du bas"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:957
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "Options PDF"
 
@@ -2689,22 +2691,22 @@ msgstr "Options PDF"
 msgid "MealMaster file"
 msgstr "Fichier MealMaster"
 
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Exporter au format Mealmaster"
 
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Exportation des recettes en fichier MealMaster %(file)s."
 
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Recette enregistrée en fichier Mealmaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr "%s portion(s)"
@@ -2713,7 +2715,7 @@ msgstr "%s portion(s)"
 msgid "MCB File"
 msgstr "Fichier MCB"
 
-#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr "Fichier My CookBook MCB"
 
@@ -2738,33 +2740,33 @@ msgstr "Historique de la liste de courses"
 
 #. name
 #. stock
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Enregistrer la liste en tant que recette"
 
 #. text
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 "Enregistrer la liste de courses actuelle comme une recette pour une "
 "utilisation ultérieure"
 
 #. print rr
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr "Menu pour %s(%s)"
 
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:35
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "L'information nutritionnelle reflète la quantité par %s."
@@ -2773,43 +2775,39 @@ msgstr "L'information nutritionnelle reflète la quantité par %s."
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "L’information nutritionnelle reflète la quantité de la recette entière"
 
-#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:41
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "L’information nutritionnelle est manquante pour %s ingrédients : %s"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Pas de groupe d’aliments"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "sélection"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Convertir l’unité en %s"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
 "In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
-"Pour calculer les informations nutritionnelles, Gourmand a besoin d'aide pour "
-"convertir \"%s\" dans un format connu."
+"Pour calculer les informations nutritionnelles, Gourmand a besoin d'aide "
+"pour convertir \"%s\" dans un format connu."
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Changer la clef d’ingrédient"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2818,27 +2816,27 @@ msgstr ""
 "Remplacer la clef d’ingrédient %(old_key)s par %(new_key)s partout ou "
 "seulement dans la recette %(title)s ?"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Remplacer _partout"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Seulement dans la recette %s"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Changer la clef d’ingrédient de %(old_key)s à %(new_key)s partout ?"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Changer l’unité"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2847,7 +2845,7 @@ msgstr ""
 "Convertir l’unité de %(old_unit)s à %(new_unit)s pour tous les ingrédients "
 "de type %(ingkey)s ou seulement dans la recette %(title)s ?"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
@@ -2860,31 +2858,31 @@ msgstr ""
 "nutritionnelle a plusieurs descriptions for cet ingrédient avec différentes "
 "densités, Choisissez l'un d'entre eux."
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
 "To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Pour appliquer I’information nutritionnelle : Gourmand a besoin d'une unité "
 "et d'une quantité."
 
-#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Nutrition"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingrédient"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 "Équivalent de la base de données USDA (Ministère américain de l'agriculture)"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 grammes"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Calories"
 
@@ -2892,167 +2890,167 @@ msgstr "Calories"
 msgid "Total Fat"
 msgstr "Matière grasse totale"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Graisse saturée"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Cholesterol"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sodium"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:23
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Total d’hydrates de carbone"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:25
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Fibres alimentaires"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Sucres"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Protéine"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alpha-carotène"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Cendre"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Bêta-carotène"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Bêta-cryptoxanthine"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Calcium"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Cuivre"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Acide folique total"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Acide folique"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Folacine alimentaire"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Équivalents diététiques de folacine"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Fer"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Lycopène"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:58
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Lutéine+Zeazanthine"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:60
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnésium"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:62
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Manganèse"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:64
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Vitamine B3"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:66
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Acide pantothénique"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:68
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Phosphore"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potassium"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:72
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamine A"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:74
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Rétinol"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:76
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavine"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:78
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Sélénium"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:80
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Thiamine"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:82
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamine A (IU)"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamine A (RAE)"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:86
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamine B6"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:88
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamine B12"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:90
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamine C"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:92
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamine E"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:94
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamine K"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zinc"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:205
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamines et minéraux"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:314
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3061,11 +3059,11 @@ msgstr ""
 "Informations nutritionnelles manquantes\n"
 "pour %(missing)s des %(total)s ingrédients."
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:330
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Valeur journalière"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:374
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3074,19 +3072,19 @@ msgstr ""
 "Pourcentage de la valeur journalière recommandée basé sur %i calories par "
 "jour. Cliquer pour modifier le nombre de calories par jour."
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:464
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Quantité par %s"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:466
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Quantité par recette"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
@@ -3097,345 +3095,345 @@ msgstr "Quantité par recette"
 msgid "Loading Nutritional Data"
 msgstr "Chargement des informations nutritionnelles"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Importation de la base de données nutritionnelles terminée !"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Lecture de la base de données nutritionelles depuis une archive zip %s"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Extraction de %s depuis l’archive zip."
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Analyse des informations nutritionnelles…"
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Lecture des valeurs nutritionelles : %s sur %s entrées importées."
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Analyse des données de poids…"
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Lecture des données de poids pour les aliments : %s sur %s entrées importées"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Eau"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilocalories"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g de protéines"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g de lipides"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g de cendre"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g d’hydrates de carbones"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g de fibres"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g de sucre"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg de calcium"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg de fer"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg de magnésium"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg de phosphore"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg de potassium"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg de sodium"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg de zinc"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg de cuivre"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg de manganèse"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "µg de Sélénium"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg de vitamine C"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg de thiamine"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg de riboflavine"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg de vitamine B3"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg d’acide pantothénique"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg de vitamine B6"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "µg de folacine au total"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "µg d’acide folique"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "µg de folacine"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "µg d’équivalents diététiques folacine"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Total choline"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "µg de vitamine B12"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamine A IU"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamine A (microgramme de rétinol-équivalent)"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "microgramme de Rétinol"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "microgramme d’alpha-carotène"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "microgramme de bêta-carotène"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "microgramme de bêta-cryptoxanthine"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "microgramme de Lycopène"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "microgramme Lutéine+Zeazanthine"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg de Vitamine E"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg de Vitamine K"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g d’acides gras saturés"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g d’acides gras mono-insaturés"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g d’acides gras poly-insaturés"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg de cholestérol"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Pourcentage de déchet"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Œufs et produits laitiers"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Épices et herbes"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Aliments pour bébé"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Graisses et huiles"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Volaille"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Soupes et sauces"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Viandes et saucisses"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Céréales de petit-déjeuner"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Fruits et jus de fruit"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Porc"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Légumes"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Noix et graines"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Bœuf"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Boissons"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Poissons et coquillages"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Légumineux"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Agneau, veau et gibier"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Plats cuisinés"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Sucreries"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Céréales et pâtes"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Restauration rapide"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Repas, plats principaux, et accompagnement"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Snacks"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Cuisines du monde"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "base de donnée complète"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Clef d’ingrédient"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "Identifiant USDA"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "Description d’élément USDA"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Équivalent de densité"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "Numéro USDA"
 
-#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3453,7 +3451,7 @@ msgstr "Outils"
 msgid "Get nutritional information for current list"
 msgstr "Obtenir les informations nutritionnelles pour cette liste"
 
-#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Quantité pour la liste de courses"
 
@@ -3461,47 +3459,47 @@ msgstr "Quantité pour la liste de courses"
 msgid "Edit _nutritional info"
 msgstr "Modifier les informations _nutritionnelles"
 
-#: ../src/gourmand/exporters/exporter.py:211
-#: ../src/gourmand/exporters/exporter.py:213
-#: ../src/gourmand/exporters/exporter.py:532
-#: ../src/gourmand/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "étoiles"
 
-#: ../src/gourmand/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Exportation de la recette %(number)s sur %(total)s"
 
-#: ../src/gourmand/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Exportation complète."
 
-#: ../src/gourmand/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Inclure la recette dans le corps du message (recommandé)"
 
-#: ../src/gourmand/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Envoyer la recette par courriel en tant que fichier HTML joint"
 
-#: ../src/gourmand/exporters/recipe_emailer.py:131
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Envoyer la recette par courriel en tant que fichier PDF joint"
 
-#: ../src/gourmand/exporters/recipe_emailer.py:148
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Options courriel"
 
-#: ../src/gourmand/exporters/recipe_emailer.py:151
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Ne pas demander de confirmation avant d’envoyer un courriel."
 
-#: ../src/gourmand/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Courriel non envoyé"
 
-#: ../src/gourmand/exporters/recipe_emailer.py:171
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3509,40 +3507,40 @@ msgstr ""
 "Vous n’avez pas choisi d’inclure la recette dans le corps du message ou "
 "comme pièce jointe."
 
-#: ../src/gourmand/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Sauvegarder la recette sous…"
 
-#: ../src/gourmand/exporters/exportManager.py:62
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet ne peut pas exporter vers le fichier « %s »"
 
-#: ../src/gourmand/exporters/exportManager.py:105
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Exporter les recettes"
 
-#: ../src/gourmand/exporters/exportManager.py:108
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recettes"
 
-#: ../src/gourmand/exporters/exportManager.py:122
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Exportation impossible : type de fichier inconnu « %s »"
 
-#: ../src/gourmand/exporters/exportManager.py:123
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Prenez soin de sélectionner un type de fichier dans le menu déroulant lors "
 "de l’enregistrement."
 
-#: ../src/gourmand/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Exporter"
 
-#: ../src/gourmand/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr "Recette exporte dans <a href=\"file:///%s\">%s</a>"
@@ -3552,62 +3550,62 @@ msgstr "Recette exporte dans <a href=\"file:///%s\">%s</a>"
 msgid "Unable to print: no print plugins are active!"
 msgstr "Impression impossible : aucun module d’impression n'est actif !"
 
-#: ../src/gourmand/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Imprimer %s recette"
 msgstr[1] "Imprimer %s recettes"
 
-#: ../src/gourmand/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "rendement"
 
-#: ../src/gourmand/importers/importManager.py:62
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Ouverture de la recette…"
 
-#: ../src/gourmand/importers/importManager.py:63
+#: ../src/gourmand/importers/importManager.py:61
 msgid "Enter a recipe file path or website address."
 msgstr "Entrer un fichier de recette ou l’adresse d'un site."
 
-#: ../src/gourmand/importers/importManager.py:64
+#: ../src/gourmand/importers/importManager.py:62
 msgid "Location:"
 msgstr "Source:"
 
-#: ../src/gourmand/importers/importManager.py:65
+#: ../src/gourmand/importers/importManager.py:63
 msgid "Enter the address of a website or recipe archive."
 msgstr "Entrer l’adresse d'un site ou d’une archive de recette."
 
-#: ../src/gourmand/importers/importManager.py:137
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importer"
 
-#: ../src/gourmand/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Tous les fichiers pouvant être importés"
 
-#: ../src/gourmand/importers/plaintext_importer.py:43
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "%s recettes importées."
 
-#: ../src/gourmand/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "portion"
 msgstr[1] "portions"
 
-#: ../src/gourmand/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "%s recettes sur %s importées."
 
-#: ../src/gourmand/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "ok"
 
-#: ../src/gourmand/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Couverts"
 
@@ -3615,83 +3613,83 @@ msgstr "Couverts"
 msgid "Ingredient Subgroup"
 msgstr "Sous-catégorie d’ingrédients"
 
-#: ../src/gourmand/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Masquer"
 
-#: ../src/gourmand/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Texte"
 
-#: ../src/gourmand/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Actions"
 
-#: ../src/gourmand/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importer une recette"
 
-#: ../src/gourmand/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Effacer les é_tiquettes"
 
-#: ../src/gourmand/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Importer une recette"
 
-#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:55
-#: ../src/gourmand/recindex.py:492
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "n’importe où"
 
-#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:56
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "titre"
 
-#: ../src/gourmand/recindex.py:48 ../src/gourmand/recindex.py:57
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrédient"
 
-#: ../src/gourmand/recindex.py:49 ../src/gourmand/recindex.py:61
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instructions"
 
-#: ../src/gourmand/recindex.py:50 ../src/gourmand/recindex.py:62
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "notes"
 
-#: ../src/gourmand/recindex.py:52 ../src/gourmand/recindex.py:59
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "cuisine"
 
-#: ../src/gourmand/recindex.py:53 ../src/gourmand/recindex.py:60
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "source"
 
-#: ../src/gourmand/recindex.py:102
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Utiliser les expressions rationnelles dans la recherche"
 
-#: ../src/gourmand/recindex.py:103
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Utiliser les expressions rationnelles (un language de recherche avancée) "
 "dans la recherche de texte"
 
-#: ../src/gourmand/recindex.py:108
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 "Chercher lors de la saisie (désactivez si la recherche est trop lente)."
 
-#: ../src/gourmand/recindex.py:112
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Afficher les _options de recherche"
 
-#: ../src/gourmand/recindex.py:113
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Afficher les options de recherche avancée"
 
-#: ../src/gourmand/recindex.py:282
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3700,48 +3698,48 @@ msgstr[1] "%s recettes"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmand/recindex.py:290
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Affichage des recettes %(bottom)s à %(top)s sur %(total)s"
 
-#: ../src/gourmand/recindex.py:493
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s dans %s"
 
-#: ../src/gourmand/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Suspendu"
 
-#: ../src/gourmand/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "Recette importée avec succès"
 msgstr[1] "Recettes importées avec succès"
 
-#: ../src/gourmand/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr "Import échoué"
 
-#: ../src/gourmand/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Suspendre"
 
-#: ../src/gourmand/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Terminé"
 
-#: ../src/gourmand/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Erreur : %s"
 
-#: ../src/gourmand/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Erreur"
 
-#: ../src/gourmand/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Erreur %s : %s"
@@ -3750,53 +3748,47 @@ msgstr "Erreur %s : %s"
 msgid "Traceback"
 msgstr "Trace"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmand/convert.py:106 ../src/gourmand/convert.py:605
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "seconde"
 msgstr[1] "secondes"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmand/convert.py:108
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:604
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minute"
 msgstr[1] "minutes"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmand/convert.py:110
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "h."
 
-#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:603
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "heure"
 msgstr[1] "heures"
 
-#: ../src/gourmand/convert.py:111 ../src/gourmand/convert.py:602
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jour"
 msgstr[1] "jours"
 
-#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:601
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semaine"
 msgstr[1] "semaines"
 
-#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:600
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mois"
@@ -3805,7 +3797,7 @@ msgstr[1] "mois"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:599
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "an"
@@ -3817,26 +3809,26 @@ msgstr[1] "ans"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmand/convert.py:649
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " et "
 
-#: ../src/gourmand/convert.py:649
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmand/convert.py:651
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmand/convert.py:782
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "et"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmand/convert.py:804
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "vers"
 
@@ -4020,3 +4012,9 @@ msgstr ""
 "Activer si vos fichiers textes sont en utf-16 et ne s’importent pas "
 "proprement dans Gourmet. Désactiver si vous n’utilisez jamais UTF16 et que "
 "la fenêtre « Encodage » vous dérange à chaque importation."
+
+#~ msgid "Open _Trash"
+#~ msgstr "Ouvrir la _corbeille"
+
+#~ msgid "ml"
+#~ msgstr "ml"

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2011-05-06 00:35+0000\n"
 "Last-Translator: Seanan <Unknown>\n"
 "Language-Team: Irish <ga@li.org>\n"
@@ -19,507 +19,510 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Oideas Nua"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "Comhad"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "oideas"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Sonraí"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Bainisteoir Oidis Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Taispeáin uaineadóir"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Teideal"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Oideas"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Comhábhair"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Scrios an tOideas"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Oscail an t-oideas roghnaithe"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Roghnaigh oideas"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +530,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Aicme"
 
@@ -560,285 +563,287 @@ msgstr "Aicme"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Cuardaigh agus tú ag clóscríobh"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Uaineadóir"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "aonad"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Faisnéis Bheathaithe"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Bainisteoir Oidis Gourmet"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,638 +858,591 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Suiteálaí Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Roghnaigh Comhad Bhunachair Shonraí"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Ag feabhsú an bunachar sonraí"
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr "Sonraí"
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Oideas Nuas"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr "Sonraí"
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Athraigh an _Aicme"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Cruthaigh aicme nua"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Athraigh an aicme ina bhfuil an ní roghnaithe reatha"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Cuile"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Bog na nithe roghnaithe isteach go %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Cuir Isteach Aicme"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Aicme:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Oidis"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Bain Oidis"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "Cuir in _Eagar"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "Cab_hair"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Cuir nithe leis"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Roghnaigh comhábhair roghnacha"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Téigh"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Scrios an t-oideas seo"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Clóbhuail an t-oideas"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 msgid "Add to Shopping List"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Cuir na hathruithe i bhfeidhm roimh é a chlóbhualadh?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Cuir na hathruithe i bhfeidhm roimh é a chlóbhualadh?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Roghnach)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Féach an Cárta Oidis"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Cuir in Eagar"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Cuir comhábhar leis"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Greamaigh comhábhair"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Cuir oideas leis"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Scrios"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Suas"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Síos"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Cur síos"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Treoracha"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Nótaí"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Méid"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Aonad"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Mír"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Roghnach"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Tiontaithe: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Gan tiontú: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Athraíodh an t-aonad."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Ní féidir tiontú ó %(old_unit)s go %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Roghnaigh oideas"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Níl oidis roghnaithe agat!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Oidis"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Stad an t-uaineadóir?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Breiseáin"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Coinnigh an breiseán gníomhach"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "nó"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Cócaireacht"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Measúnú"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Foinse"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Suíomh Idirlín"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Am ullmhúcháin"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Am cócaireachta"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Mionathruithe"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Ní uimhir í sin."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Cur ar sos"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stad"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Ná fiafraigh seo orm arís."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "An bhfuil tú cinnte gur mian leat seo a dhéanamh"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "ar fheabhas"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "iontach"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "maith"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "measartha"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "dona"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Níl comhad roghnaithe"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
+msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Níor roghnaíodh comhad, mar sin cuireadh an gníomh ar ceal"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1493,12 +1451,12 @@ msgstr ""
 "Is dona liom, ní thuigim\n"
 "an méad \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1510,447 +1468,431 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "plúr bán"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "siúcra"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "salann"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "piobar dubh, meilte"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "oighear"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "uisce"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "ola, phlándúil"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "ola, ológach"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Anaithnid"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Déanfar neamhaird den comhábhar %s."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Do na hoidis seo a leanas:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Do na hoidis seo a leanas:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Treorán na nOideas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Seanan https://launchpad.net/~seananoc-gmail"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Ná scoir!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Bosca Bruscair"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Oidis nár scriosadh "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Socraigh luachanna do oidis roghnaithe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Cuardaigh oidis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Oscail oideas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Oscail an t-oideas roghnaithe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Scrios oideas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Scrios na hoidis roghnaithe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Cuir oideas in eagar"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Clóbhuail"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "oidis"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nua"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Clóbhuail Oidis"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s recipe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Scoir"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Gníomhartha"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr ""
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Bosca Bruscair"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Sainroghanna"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Breiseáin"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Socruithe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Maidir Leis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Uirlísí"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Uaineadóir"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Taispeáin uaineadóir"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Scrios %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Scriosta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Gan Teideal"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Scrios na hoidis go buan?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Scrios an t-oideas go buan?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "An bhfuil tú cinnte gur mian leat an t-oideas <i>%s</i> a scriosadh?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "An bhfuil tú cinnte gur mian leat na hoidis seo a leanas a scriosadh?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 "An bhfuil tú cinnte gur mian leat na  %s (h)oidis roghnaithe a scriosadh?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Féach ar oidis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Srios na hOidis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Treorán na nOideas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Oideas scriosta %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Déanta!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "mír"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Réimse"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Luach"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Líon"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1958,12 +1900,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Athraigh gach mír \"%s\" go \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1971,56 +1913,56 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Athraigh gach sraith roghnaithe?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2029,7 +1971,7 @@ msgstr ""
 "\n"
 "Mír go %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2038,7 +1980,7 @@ msgstr ""
 "\n"
 "Aonad go %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2047,8 +1989,8 @@ msgstr ""
 "\n"
 "Méid go %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2057,386 +1999,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Méid"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Réalta"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s ó shin"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Bain feidhm as an oideas is úire i gcónaí"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Bain feidhm as an oideas is sine i gcónaí"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Dada"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Do gach luach roghnaithe"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "San áit a bhfuil %(field)s %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Scrios %s san áit a bhfuil sé %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Ní féidir an t-athrú seo a chealú.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Eagarthóir Réimse"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Seol oidis i ríomhphost"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "An bhfuil tú cinnte gur mian leat na %s oidis roghnaithe a sheoladh?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Cinnte, seol iad"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Ní féidir %s a thiontú go %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Leathanac Bunaidh ó %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "roghnach"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Comhad Mór"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2444,81 +2374,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Ag íosluchtú %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Ag aisghabháil %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2527,881 +2430,898 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Leagan Amach Leathanaigh"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Clóbhuail Oidis"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Litir"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Portráid"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Gnáth"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "poncanna"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Cárta Treoráin (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Cárta Treoráin (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Cárta Treoráin (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Cárta Treoráin (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Litir"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Dlí"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Cártaí Treoráin (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Cártaí Treoráin (4X6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Cártaí Treoráin (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Tírdhreach"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Gnáth"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Portráid"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Tírdhreach"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Méid an Pháipéir"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Treoshuíomh"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Méid na Clófhoirne"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Leagan Amach an Leathanaigh"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Méid na Clófhoirne"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Imeall ar chlé"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Imeall ar dheis"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Imeall ag an mbarr"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Imeall ag an mbun"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Comhad Mór"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Oideas do %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Biachlár"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "roghnúchán"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Tiontaigh an t-aonad do %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Athraigh gach áit"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_San oideas %s amháin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Athraigh an t-aonad"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Comhábhar"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 graim"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Calraí"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Saill Iomlán"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Colaistéaról"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sóidiam"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Siúcraí"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Copar"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Iarann"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Maignéisiam"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangainéis"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfar"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potaisiam"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Seiléiniam"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Sinc"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Luach Laethúil"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Méad an %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Méad i ngach oideas"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Uisce"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g siúcra"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3415,288 +3335,244 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "réalta"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Seol an t-oideas mar iatán HTML"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Seol an t-oideas mar iatán PDF"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Roghanna ríomhphoist"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Ná fiafraigh roimh an ríomhphost a sheoladh."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Níor seoladh an ríomhphost"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "oidis"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Ag aisghabháil comhad"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Cuir isteach seoladh an tsuímh"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Cuir isteach URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Oscail oideas..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Cuir isteach seoladh an tsuímh"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Mionathruithe"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "Tá go maith"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Folaigh"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Téacs"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Gníomhartha"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Glan na Clibeanna"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Taispeáin Roghanna Cuardaigh"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3706,104 +3582,98 @@ msgstr[2] "%s n-oidis"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s i %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Curtha ar sos"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Cuir ar Shos"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Déanta"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Botún: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Botún"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Botún %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "soicind"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "nóim"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "nóiméad"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "uair"
 msgstr[1] "uair"
 msgstr[2] "huaire"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "lá"
 msgstr[1] "lá"
 msgstr[2] "lá"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mhí"
@@ -3813,7 +3683,7 @@ msgstr[2] "mhí"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "bhliain"
@@ -3826,70 +3696,30 @@ msgstr[2] "bliana"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "agus"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "go"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Bainisteoir Oidis Gourmet"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3899,7 +3729,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3912,44 +3741,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3960,14 +3769,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4021,22 +3822,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4095,6 +3880,42 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Suiteálaí Windows)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Ag feabhsú an bunachar sonraí"
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Greamaigh comhábhair"
+
+#~ msgid "No file selected"
+#~ msgstr "Níl comhad roghnaithe"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Níor roghnaíodh comhad, mar sin cuireadh an gníomh ar ceal"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Ag íosluchtú %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Ag aisghabháil %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Ag aisghabháil comhad"
+
+#~ msgid "Enter URL:"
+#~ msgstr "Cuir isteach URL:"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Bainisteoir Oidis Gourmet"
 
 #~ msgid "Select recipe image"
 #~ msgstr "Roghnaigh íomhá an oidis"

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-04-29 12:42+0000\n"
 "Last-Translator: Rafael Ávila Coya <ravilacoya@gmail.com>\n"
 "Language-Team: Galician <gl@li.org>\n"
@@ -20,506 +20,509 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nova receita"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Engadir á _lista da compra"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Categoría:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Imaxe:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "Sistema de Base de _Datos"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Equipo:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Nome do usuario:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Contrasinal:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "_Nome da base de datos:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Ficheiro"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "_Gardar contrasinal"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "receita"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Explorar"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detalles"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Xestor de Receitas Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Lista da Compra"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Título"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "categoría"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Receita"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredientes"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "Eliminar _receita"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Borrar as receitas seleccionadas"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "receita"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +530,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Categoría"
 
@@ -560,285 +563,287 @@ msgstr "Categoría"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Clave"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "C_antidade:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "unidade"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Unidade:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Xestor de Receitas Gourmet"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,651 +858,604 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Asistente de transferencia de Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (melloras no interfaz do conversor de unidades)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (melloras na exportación a Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Nova Receita"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "_Nome da base de datos:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Lista da compra"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Introduza a Categoría"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Borrar Receitas"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Borrar receitas dende a lista de compras"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Editar"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Axuda"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Gardar Lista da Compra Como..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Receita"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Imprimir receita"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Engadir á _lista da compra"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Ver Tarxeta da Receita"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instruccións"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notas"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Amt"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Unidade"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Artigo"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Opcional"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Engadindo Grupo de Ingredientes"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Introduza un nome para o novo subgrupo de ingredientes"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Receitas"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Estilo de cociña"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Puntuación"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Orixe"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Tempo de preparación"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Tempo de cocción"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Modificacións"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pausa"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Parar"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Non me pregunte esto máis."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Seguro que quere facer esto"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Ficheiro non seleccionado"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Seleccione _tipo de Ficheiro"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Non se seleccionou ningún ficheiro, polo que se cancelou a acción"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1509,86 +1467,86 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Nome do usuario:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Contrasinal:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "fariña, para calquera uso"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "azucre"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sal"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "pementa negra, moída"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "xeo"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "auga"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "aceite, vexetal"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "aceite, de oliva"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Descoñecido"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "O Ingrediente %s será ignorado."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Lista da compra para %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Para as seguintes receitas:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Para as seguintes receitas:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Seleccionar codificación"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1596,29 +1554,28 @@ msgstr ""
 "Non se pode precisar a codificación correcta. Por favor, seleccione a "
 "codificación precisa da seguinte lista."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Ver _ficheiro con codificación"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importación detida"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Importación parada"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Índice de Receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Lista da Compra"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Carlos Garcia\n"
@@ -1630,335 +1587,319 @@ msgstr ""
 "  carlisg https://launchpad.net/~carlisgg\n"
 "  estevo https://launchpad.net/~estevo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "¡Gardado!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Garde os seus cambios a %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Estase a producir unha importación."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Estase a producir unha exportación."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Estase a producir un borrado."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "¿Saír do programa de tódolos xeitos?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "¡Non saír!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Receitas recuperadas "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Borrar as receitas seleccionadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "Im_primir"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "receitas"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Exportar receitas"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "Imprimir receita"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Accións"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Sobre"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Ferramentas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Temporizador"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "¿Borrar receitas permanentemente?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "¿Borrar receita permanentemente?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Seguro que desexa borrar a receita <i>%s</s>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "¿Seguro que desexa borrar as receitas seguintes?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "¿Seguro que desexa borrar as %s receitas seleccionadas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Ver receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "_Índice de Receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Borradas receita %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "¡Feito!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importando..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "clave"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "artigo"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Conta"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1966,12 +1907,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1979,78 +1920,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2059,387 +2000,375 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Cantidade"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Categoría de Compra"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "NIngún"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Non se pode convertir %s en %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Necesítase densidade de información"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Conversor de _unidades"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Conversor de unidades"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Densidade:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Resultado:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "Páxina Web HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Exportando Páxina Web"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Exportando receitas a ficheiros HTML no directorio %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Gardouse a receita no ficheiro HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "opcional"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Exportando Páxina Web"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Exportando receitas a ficheiros HTML no directorio %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Gardouse a receita no ficheiro HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Exportar a texto"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2447,81 +2376,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Lista da compra para %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Ficheiro XML Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Exportar a Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Importación de Mastercook rematada."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2530,882 +2432,899 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Imprimir Receitas"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Marxe Esquerda"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Marxe Superior"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Marxe Inferior"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "Porcións"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Ficheiro"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Exportar a texto"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Exportando receitas a ficheiros HTML no directorio %(file)s"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Gardouse a receita no ficheiro HTML %(file)s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3419,59 +3338,59 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Incluír a Receita no Corpo do correo (Unha boa idea de tódolos xeitos)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Enviar Receita como ficheiro HTML Adxunto"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Opcións de Correo"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Non pregunte antes de enviar o correo."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-mail non enviado"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3479,230 +3398,185 @@ msgstr ""
 "Non decidiu incluír a receita no corpo da mensaxe ou como un ficheiro "
 "adxunto."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet non pode exportar o ficheiro de tipo \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Exportar receitas"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "receitas"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Imprimir %s receita"
 msgstr[1] "Imprimir %s receitas"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Modificacións"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Tódolos ficheiros importables"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Importadas %s de %s receitas."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Porcións"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "título"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrediente"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instruccións"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "Notas"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "estilo de cociña"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "orixe"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3711,103 +3585,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3816,7 +3684,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3828,71 +3696,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Ficheiro XML Gourmet"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Xestor de Receitas Gourmet"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3902,7 +3729,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3915,38 +3741,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -3954,6 +3748,18 @@ msgstr "Exportar a texto"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3964,14 +3770,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4025,22 +3823,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4100,6 +3882,33 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Asistente de transferencia de Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (melloras no interfaz do conversor de unidades)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (melloras na exportación a Mealmaster)"
+
+#~ msgid "No file selected"
+#~ msgstr "Ficheiro non seleccionado"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Non se seleccionou ningún ficheiro, polo que se cancelou a acción"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Lista da compra para %s"
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Ficheiro XML Gourmet"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Xestor de Receitas Gourmet"
+
 #~ msgid "Gourmet Recipe Manager starting up..."
 #~ msgstr "Xestor de Receitas de Gourmet está a arrancar..."
 
@@ -4120,9 +3929,6 @@ msgstr ""
 
 #~ msgid "There was an error launching the url: %s"
 #~ msgstr "Sucedeu un erro ó abrir a url: %s"
-
-#~ msgid "Select File_type"
-#~ msgstr "Seleccione _tipo de Ficheiro"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Un ficheiro con nome %s xa existe"

--- a/po/gourmand.pot
+++ b/po/gourmand.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-15 10:46+0200\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,11 +24,11 @@ msgstr ""
 
 #. Set up hard-coded functional buttons...
 #: ../src/gourmand/ui/app.ui.h:2
-#: ../src/gourmand/importers/interactive_importer.py:151
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:105
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr ""
 
@@ -197,8 +197,11 @@ msgstr ""
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:669
-#: ../src/gourmand/main.py:1035
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
@@ -229,9 +232,9 @@ msgid ""
 msgstr ""
 
 #: ../src/gourmand/ui/databaseChooser.ui.h:19
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
@@ -244,8 +247,8 @@ msgid "_Browse"
 msgstr ""
 
 #: ../src/gourmand/ui/databaseChooser.ui.h:22
-#: ../src/gourmand/gtk_extras/dialog_extras.py:853
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1288
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
@@ -327,9 +330,9 @@ msgstr ""
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:145
-#: ../src/gourmand/shopgui.py:534 ../src/gourmand/shopgui.py:844
-#: ../src/gourmand/shopgui.py:995
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
@@ -339,11 +342,9 @@ msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmand/shopgui.py:745 ../src/gourmand/gglobals.py:28
-#: ../src/gourmand/exporters/rtf_exporter.py:86
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
@@ -356,7 +357,7 @@ msgid "Pre_paration Time:"
 msgstr ""
 
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmand/recindex.py:51 ../src/gourmand/recindex.py:58
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
@@ -365,12 +366,12 @@ msgid "rating"
 msgstr ""
 
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmand/gglobals.py:34
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmand/gglobals.py:35
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
@@ -439,10 +440,10 @@ msgid "Edit _notes"
 msgstr ""
 
 #: ../src/gourmand/ui/recCardDisplay.ui.h:17
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmand/exporters/exporter.py:620
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
@@ -459,16 +460,15 @@ msgid "Add _ingredient:"
 msgstr ""
 
 #: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmand/reccard.py:1070
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
 #: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:617
-#: ../src/gourmand/exporters/exporter.py:248
-#: ../src/gourmand/importers/interactive_importer.py:45
-#: ../src/gourmand/importers/interactive_importer.py:60
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
@@ -489,7 +489,7 @@ msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:871
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2138
-#: ../src/gourmand/reccard.py:2198
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:116
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:107
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
@@ -592,8 +592,8 @@ msgstr ""
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:190
-#: ../src/gourmand/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgid "Unit:"
 msgstr ""
 
 #: ../src/gourmand/ui/nutritionDruid.ui.h:12
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
@@ -813,10 +813,10 @@ msgstr ""
 #. name
 #. stock
 #: ../src/gourmand/ui/nutritionDruid.ui.h:35
-#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
 #: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
 #: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
@@ -852,7 +852,7 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmand/__version__.py:25
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
@@ -860,593 +860,593 @@ msgstr ""
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmand/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmand/backends/db.py:1472 ../src/gourmand/reccard.py:942
-#: ../src/gourmand/importers/interactive_importer.py:100
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmand/backends/db.py:2120 ../src/gourmand/backends/db.py:2121
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
 msgid "Database Backup"
 msgstr ""
 
-#: ../src/gourmand/backends/db.py:2122
+#: ../src/gourmand/backends/db.py:2184
 msgid "Depending on the size of your database, this may take some time."
 msgstr ""
 
-#: ../src/gourmand/backends/db.py:2123 ../src/gourmand/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr ""
 
-#: ../src/gourmand/backends/db.py:2124
+#: ../src/gourmand/backends/db.py:2188
 #, python-format
 msgid ""
 "A backup will be made as %s in case something goes wrong. If this upgrade "
 "fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:120 ../src/gourmand/shopgui.py:127
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:121
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:129
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:135
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmand/shopgui.py:138
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmand/shopgui.py:139
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmand/shopgui.py:148
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmand/shopgui.py:149
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmand/shopgui.py:150
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:171
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:209 ../src/gourmand/main.py:1050
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:210
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:473
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:474
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:475
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:579
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:603
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:642
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:643
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:647 ../src/gourmand/reccard.py:227
-#: ../src/gourmand/reccard.py:866 ../src/gourmand/main.py:1048
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:670 ../src/gourmand/shopgui.py:673
-#: ../src/gourmand/reccard.py:229 ../src/gourmand/reccard.py:240
-#: ../src/gourmand/reccard.py:868 ../src/gourmand/main.py:1062
-#: ../src/gourmand/main.py:1065
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:678
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:680
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:746
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:831
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:842
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:898
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmand/shopgui.py:899
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmand/reccard.py:226 ../src/gourmand/reccard.py:865
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:228 ../src/gourmand/main.py:212
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:230
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:233
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:248
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:250
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#: ../src/gourmand/reccard.py:256
+#: ../src/gourmand/reccard.py:246
 msgid "Copy to clipboard"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:258
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:260 ../src/gourmand/main.py:1029
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 msgid "Add to Shopping List"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:262
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:263
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:265
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:551
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:575 ../src/gourmand/reccard.py:588
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmand/reccard.py:576
+#: ../src/gourmand/reccard.py:547
 msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:589
+#: ../src/gourmand/reccard.py:559
 msgid "Save changes before printing?"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:701 ../src/gourmand/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:753
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmand/reccard.py:849
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:870
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmand/reccard.py:879
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:942
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1040 ../src/gourmand/reccard.py:1041
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1131
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1136
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1138
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1139
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1144
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1150
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1152
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1308
-#: ../src/gourmand/importers/interactive_importer.py:53
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1656 ../src/gourmand/gglobals.py:42
-#: ../src/gourmand/gglobals.py:47
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:1662 ../src/gourmand/gglobals.py:43
-#: ../src/gourmand/gglobals.py:48
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2135 ../src/gourmand/reccard.py:2165
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2136 ../src/gourmand/reccard.py:2166
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2137 ../src/gourmand/reccard.py:2167
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:108
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2139 ../src/gourmand/reccard.py:2168
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2280
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2598
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2600
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2604
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2605
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2616
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2628
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2683
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2684
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2685
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2948
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2985
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:2986 ../src/gourmand/shopping.py:298
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:3004
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:3016
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmand/reccard.py:3026
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmand/exporters/recipe_emailer.py:65
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmand/timer.py:147 ../src/gourmand/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmand/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmand/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmand/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmand/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmand/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmand/plugin_gui.py:35
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmand/plugin_gui.py:38
+#: ../src/gourmand/plugin_gui.py:39
 msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmand/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmand/plugin_gui.py:126
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmand/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmand/plugin_gui.py:130
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmand/plugin_gui.py:144 ../src/gourmand/recindex.py:463
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmand/plugin_gui.py:148
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmand/plugin_gui.py:152
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmand/gglobals.py:30
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmand/gglobals.py:31
-#: ../src/gourmand/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmand/gglobals.py:33
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmand/gglobals.py:36
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmand/gglobals.py:37
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmand/gglobals.py:49
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmand/gtk_extras/dialog_extras.py:424
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmand/gtk_extras/dialog_extras.py:437
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:508
-#: ../src/gourmand/gtk_extras/dialog_extras.py:602
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:565
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:786
-#: ../src/gourmand/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:787
-#: ../src/gourmand/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:788
-#: ../src/gourmand/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:789
-#: ../src/gourmand/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:790
-#: ../src/gourmand/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:802
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:803
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:805
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:819
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:824
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1226
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
 msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1284
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1287
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1289
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1458,419 +1458,422 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1304
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1304
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:144 ../src/gourmand/shopping.py:164
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:297
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmand/shopping.py:298
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmand/shopping.py:344 ../src/gourmand/shopping.py:358
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:345
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:350 ../src/gourmand/shopping.py:363
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmand/shopping.py:359
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmand/check_encodings.py:104
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmand/check_encodings.py:105
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmand/check_encodings.py:106
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
-#: ../src/gourmand/main.py:112
+#. Convenience method for showing progress dialogs for import/export/deletion
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmand/main.py:113
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmand/main.py:192 ../src/gourmand/main.py:1077
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmand/main.py:193
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmand/main.py:340
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 
-#: ../src/gourmand/main.py:391
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmand/main.py:402
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmand/main.py:413
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmand/main.py:414
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmand/main.py:415
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmand/main.py:417
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmand/main.py:419
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmand/main.py:465
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:486 ../src/gourmand/main.py:501
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmand/main.py:502
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:556
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmand/main.py:695
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmand/main.py:707
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmand/main.py:740
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmand/main.py:747
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmand/main.py:749
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmand/main.py:750
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmand/main.py:751
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:980
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:1013
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmand/main.py:1014
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmand/main.py:1015
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmand/main.py:1016
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:1017
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmand/main.py:1018
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmand/main.py:1020
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:1021
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmand/main.py:1023
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#: ../src/gourmand/main.py:1025
+#: ../src/gourmand/main.py:1000
 msgid "_Copy recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:1027
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmand/main.py:1038
+#: ../src/gourmand/main.py:1011
 msgid "_Import Recipe"
 msgstr ""
 
-#: ../src/gourmand/main.py:1039
+#: ../src/gourmand/main.py:1011
 msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmand/main.py:1040
+#: ../src/gourmand/main.py:1012
 msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmand/main.py:1042
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:1043
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmand/main.py:1044
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmand/main.py:1047
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmand/main.py:1052
+#: ../src/gourmand/main.py:1025
 msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmand/main.py:1055
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmand/main.py:1057
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmand/main.py:1058
+#: ../src/gourmand/main.py:1032
 msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmand/main.py:1060
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmand/main.py:1063
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmand/main.py:1071
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmand/main.py:1072
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmand/main.py:1073
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmand/main.py:1078
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmand/main.py:1187
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmand/main.py:1188
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmand/main.py:1217
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmand/main.py:1217
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmand/main.py:1225
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmand/main.py:1227
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmand/main.py:1228
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmand/main.py:1230
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmand/main.py:1234
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmand/main.py:1236
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:1244
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmand/main.py:1246
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmand/main.py:1271
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmand/main.py:1298
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmand/main.py:1337
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmand/main.py:1345
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:265
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1878,12 +1881,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1891,38 +1894,38 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
@@ -1962,7 +1965,7 @@ msgid ""
 msgstr ""
 
 #: ../src/gourmand/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -1972,18 +1975,18 @@ msgstr[1] ""
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
 #: ../src/gourmand/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
 #: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
@@ -1993,21 +1996,21 @@ msgid ""
 "for calculations."
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:98
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
@@ -2044,66 +2047,66 @@ msgstr ""
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:20
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:30
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmand/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmand/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmand/plugins/unit_converter/convertGui.py:161
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
 #: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:25
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:61
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:68
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
@@ -2144,37 +2147,37 @@ msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:168
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:175
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:181
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmand/plugins/field_editor/__init__.py:19
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
@@ -2184,41 +2187,41 @@ msgstr ""
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:25
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:45
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:26
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:49
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmand/plugins/unit_converter/convertGui.py:115
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmand/plugins/unit_converter/convertGui.py:117
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmand/plugins/unit_converter/__init__.py:17
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmand/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
@@ -2263,32 +2266,32 @@ msgstr ""
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:10
-msgid "Exporting Webpage"
-msgstr ""
-
 #: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
-#, python-format
-msgid "Exporting recipes to HTML files in directory %(file)s"
+msgid "Exporting Webpage"
 msgstr ""
 
 #: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
+msgid "Exporting recipes to HTML files in directory %(file)s"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:645
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:658
-#: ../src/gourmand/exporters/exporter.py:384
-#: ../src/gourmand/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
@@ -2296,49 +2299,49 @@ msgstr ""
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
 #: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:42
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:9
-msgid "Text Export"
-msgstr ""
-
 #: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
-#, python-format
-msgid "Exporting recipes to text file %(file)s."
+msgid "Text Export"
 msgstr ""
 
 #: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
+msgid "Exporting recipes to text file %(file)s."
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:25
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2347,25 +2350,25 @@ msgid ""
 msgstr ""
 
 #: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
@@ -2381,19 +2384,19 @@ msgstr ""
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:60
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:61
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2402,11 +2405,11 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:84
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:178
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
@@ -2414,156 +2417,154 @@ msgstr ""
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:10
-msgid "PDF Export"
-msgstr ""
-
 #: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
-#, python-format
-msgid "Exporting recipes to PDF %(file)s."
+msgid "PDF Export"
 msgstr ""
 
 #: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
+msgid "Exporting recipes to PDF %(file)s."
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:743
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:762
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:763
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:837
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:838
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:839
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
 msgid "Letter"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:843
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:872
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:885
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:873
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:886
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:887
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#. These two dictionaries are here to be able to store the preferences in the persistent toml file.
-#. This allows us to have a locale-agnostic GUI.
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:880
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1021
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
 msgid "Plain"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
 msgid "2 Columns"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
 msgid "3 Columns"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:870
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
 msgid "4 Columns"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:871
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:884
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
 msgid "5 Columns"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:876
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:891
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1025
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1056
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
 msgid "Portrait"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:892
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1007
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1054
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
 msgid "Landscape"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:920
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:926
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:932
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:938
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
 msgid "_Font Size"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:941
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:942
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:943
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:944
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:957
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
@@ -2572,22 +2573,22 @@ msgstr ""
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
@@ -2596,7 +2597,7 @@ msgstr ""
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
@@ -2621,31 +2622,31 @@ msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:35
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
@@ -2654,75 +2655,71 @@ msgstr ""
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:41
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
 "In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
@@ -2731,28 +2728,28 @@ msgid ""
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
 "To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
@@ -2760,197 +2757,197 @@ msgstr ""
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:23
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:25
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:58
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:60
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:62
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:64
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:66
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:68
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:72
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:74
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:76
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:78
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:80
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:82
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:86
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:88
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:90
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:92
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:94
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:205
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:314
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:330
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:374
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:464
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:466
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
@@ -2961,344 +2958,344 @@ msgstr ""
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3316,7 +3313,7 @@ msgstr ""
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
@@ -3324,84 +3321,84 @@ msgstr ""
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmand/exporters/exporter.py:211
-#: ../src/gourmand/exporters/exporter.py:213
-#: ../src/gourmand/exporters/exporter.py:532
-#: ../src/gourmand/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmand/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmand/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmand/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmand/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmand/exporters/recipe_emailer.py:131
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmand/exporters/recipe_emailer.py:148
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmand/exporters/recipe_emailer.py:151
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmand/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmand/exporters/recipe_emailer.py:171
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmand/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmand/exporters/exportManager.py:62
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmand/exporters/exportManager.py:105
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmand/exporters/exportManager.py:108
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmand/exporters/exportManager.py:122
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmand/exporters/exportManager.py:123
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmand/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmand/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
@@ -3411,143 +3408,143 @@ msgstr ""
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmand/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmand/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmand/importers/importManager.py:63
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmand/importers/importManager.py:64
+#: ../src/gourmand/importers/importManager.py:61
 msgid "Enter a recipe file path or website address."
 msgstr ""
 
-#: ../src/gourmand/importers/importManager.py:65
+#: ../src/gourmand/importers/importManager.py:62
 msgid "Location:"
 msgstr ""
 
-#: ../src/gourmand/importers/importManager.py:66
+#: ../src/gourmand/importers/importManager.py:63
 msgid "Enter the address of a website or recipe archive."
 msgstr ""
 
-#: ../src/gourmand/importers/importManager.py:140
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmand/importers/importManager.py:191
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmand/importers/plaintext_importer.py:43
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmand/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmand/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmand/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#: ../src/gourmand/importers/interactive_importer.py:44
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmand/importers/interactive_importer.py:46
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmand/importers/interactive_importer.py:47
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmand/importers/interactive_importer.py:59
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmand/importers/interactive_importer.py:61
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmand/importers/interactive_importer.py:107
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmand/importers/interactive_importer.py:153
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmand/importers/interactive_importer.py:194
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:55
-#: ../src/gourmand/recindex.py:492
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:56
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:48 ../src/gourmand/recindex.py:57
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:49 ../src/gourmand/recindex.py:61
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:50 ../src/gourmand/recindex.py:62
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:52 ../src/gourmand/recindex.py:59
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:53 ../src/gourmand/recindex.py:60
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:102
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:103
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:108
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmand/recindex.py:112
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:113
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:282
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3556,48 +3553,48 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmand/recindex.py:290
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmand/recindex.py:493
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmand/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmand/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmand/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmand/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmand/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmand/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmand/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmand/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
@@ -3606,53 +3603,47 @@ msgstr ""
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmand/convert.py:106 ../src/gourmand/convert.py:605
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmand/convert.py:108
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:604
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmand/convert.py:110
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:603
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmand/convert.py:111 ../src/gourmand/convert.py:602
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:601
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:600
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3661,7 +3652,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:599
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3673,26 +3664,26 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmand/convert.py:649
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmand/convert.py:649
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmand/convert.py:651
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmand/convert.py:782
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmand/convert.py:804
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gourmet Recipe Manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2011-12-10 16:02+0000\n"
 "Last-Translator: Dror Mor <Unknown>\n"
 "Language-Team: Hebrew <he@li.org>\n"
@@ -20,508 +20,511 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "מתכון _חדש"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "הוסף לרשימת _הקניות"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "יחידת תנובה"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_קובץ"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "מתכון"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_פרטים"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "מנהל המתכונים גורמה"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "הצג טיימר"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "רשימת קניות"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "כותרת"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "קטגוריה"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "תנובה"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "יחידת תנובה"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "מתכון"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "מרכיבים"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_מחק מתכון"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "פתח את המתכון שנבחר"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "פתח מתכון"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -529,31 +532,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "קטגוריה"
 
@@ -562,285 +565,287 @@ msgstr "קטגוריה"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "יחידה"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "מנהל המתכונים גורמה"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -855,647 +860,594 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "דניאל פולקשטיין  <nanotube@gmail.com> (תוכנת התקנה בחלונות)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "ריצ'רד פרגסון (שיפורים לממשק המרת היחידות)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "ר. ס. בורן (שיפורים לייצוא ל-Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (לוגו ותמונת פתיחה"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "יולה זובריצקי (צלמיות עבור תזונה והוספה-לרשימת-קניות)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"סיימון דארלינגטון <simon.darlington@gmx.net> (שיפורים לתמיכה בבינלאומיות, "
-"תיקוני-באגים אחרים)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"ברנארד רייטר <ockham@raz.or.at> (תחזוקת גירסאת חלונות ועיצוב מחדש של האתר)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "יש לבחור את קובץ מסד-הנתונים"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "משדרג את מסד-הנתונים"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "מתכון חדש"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
 msgstr ""
-"ייתכן והתהליך יהיה מסובך ויקח זמן, תלוי בגודל מסד-הנתונים שלך. המידע שלך "
-"מגובה אוטומטית, על כל מקרה שיהיה."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "פרטים"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "נעשה גיבוי אל %s על כל מקרה שיהיה. במידה והשידרוג נכשל, יש ביכולתך לשנות את "
 "שם קובץ הגיבוי ל-recipes.db על מנת לשחזר אותו לשימוש עם גירסה ישנה של גורמה."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "מתכון חדש"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "רשימת _קניות"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "קיים בבית (פריט _מהמזווה)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_מתכונים"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_ערוך"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_עזרה"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_עבור"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "הדפס מתכון"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "הוסף לרשימת _הקניות"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "תיאור"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "הוראות"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "רשימות"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "יחידה"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "פריט"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "מתכונים"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "תוספים"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
-msgstr ""
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
+msgstr "נהל תוספים המוסיפים עוד יכולות לגורמה."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr "תוסף זה נחוץ עבור תוספים אחרים. לכבות את התוסף בכל-זאת?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "%s נחוץ עבור התוספים להלן:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "לכבות בכל-זאת"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "אפשר לתוסף להמשיך לפעול"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "או"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "שגיאה בעת הפעלת התוסף."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "שגיאה בעת כיבוי התוסף."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "מטבח"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "דירוג"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "מקור"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "אתר אינטרנט"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "זמן הכנה"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "זמן בישול"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "שינויים"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "קלט שגוי."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "לא מספר."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_הפסק"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_עצור"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "אל תשאל שוב בעתיד."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "האם באמת ברצונך לעשות זאת"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "מצויין"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "טוב מאוד"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "טוב"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "פחות טוב"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "גרוע"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "המר ציונים לטווח של 5 כוכבים."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "המרת ציונים."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "יש לתת לכל ציון ערך מקביל בתחום 1 עד 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "ציון נוכחי"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "ציון מתוך 5 כוכבים"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "לא נבחר קובץ"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "בחר סוג_קובץ"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "הפעולה בוצעה, כיוון שלא נבחר קובץ."
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1504,13 +1456,13 @@ msgstr ""
 "אני מתנצל, אבל איני מבין את משמעות\n"
 "הכמות \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "כמויות מוכרחות להיות מספרים (שברים או עשרוניים), טווחי מספרים, או ריקות."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1530,113 +1482,112 @@ msgstr ""
 "על מנת להזין טווח של ערכים, יש להשתמש בסימן \"-\"\n"
 "להפריד ביניהם. לדוגמא, ניתן להזין 2-4 או 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "%s נחוץ עבור התוספים להלן:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "בחירת קידוד"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 "אין ביכולתי לזהות את הקידוד הנכון. יש לבחור את הקידוד המתאים מהרשימת להלן."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "צפייה בקובץ עם _קידוד"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "ייבוא הופסק"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "עצור ייבוא"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "אינדקס_מתכונים"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "רשימת_קניות"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1649,335 +1600,322 @@ msgstr ""
 "  jarondl https://launchpad.net/~jarondl\n"
 "  matt1988 https://launchpad.net/~matt1988-nana"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "נשמר!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "שמור את השנויים ל-%s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "תהליך ייבוא בביצוע."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "תהליך ייצוא בביצוע."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "מחיקה מתבצעת."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "לצאת מהתוכנה בכל זאת?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "לא לצאת!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "מתכונים %s מתוך %s נמחקו לצמיתות"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "השלכה לאשפה"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "עיון, מחיקה לצמיתות וביטול מחיקה של מתכונים שנמחקו"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "ביטול מחיקת מתכונים "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "הכפל %s ב:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "ערכים קיימים לא ישונו."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "הערכים החדשים יחליפו ערכים קיימים."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "שינוי זה לא ניתן לבטל."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "קביעת ערכים עבור המתכונים שנבחרו"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "חיפוש מתכונים"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "פתח מתכון"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "פתח את המתכון שנבחר"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "מחק מתכון"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "מחק מתכונים שנבחרו"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "ערוך מתכון"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "פתח את המתכונים שנבחרו בתצוגת עורך-המתכונים"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "יי_צא את המכונים שנבחרו"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "מייצא את המתכונים שנבחרו לקובץ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_הדפס"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "מתכונים"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "ערוך קבוצת מתכונים _בו-זמנית"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_חדש"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "יי_בא קובץ"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "יבא מתכון"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "ייבא מתכון מתוך קובץ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "ייבא _דף אינטרנט"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "הדפס מתכון"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "ייבא מתכון מדף אינטרנט"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "ייצא את _כל המתכונים"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "מייצא את כל המתכונים לקובץ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "י_ציאה"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_פעולות"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "פתח את פ_ח האשפה"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "השלכה לאשפה"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_העדפות"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "תו_ספים"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "נהל תוספים המוסיפים עוד יכולות לגורמה."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "ה_גדרות"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_אודות"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_כלים"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_טיימר"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "הצג טיימר"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "אינדקס בר-חיפוש של מתכונים במסד-הנתונים."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "מחק %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "יש לך שינויים שלא נשמרו אל %s. האם ברצונך למחוק?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "נמחק"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "ללא כותרת"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "האם למחוק את המתכונים לצמיתות?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "האם למחוק את המתכון לצמיתות?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "הינך בטוח/ה שברצונך למחוק את המתכון <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "הינך בטוח/ה שברצונך למחוק את המתכונים להלן?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "הינך בטוח/ה שברצונך למחוק את %s המתכונים שנבחרו?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "ראיית מתכונים"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "מחיקת מתכונים"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "אינדקס_מתכונים"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "מחיקת מתכון %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "בוצע!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "מייבא..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "מפתח"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "פריט"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "שדה"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "ערך"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "ספירה"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "לשנות את כל המפתחות \"%s\" להיות \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1987,12 +1925,12 @@ msgstr ""
 "לא תוכל/י לבטל פעולה זו. אם יש כבר רכיבים פעילים עם המפתח \"%s\", לא תוכל/י "
 "להבחין בינם לבין הפריטים שאת/ה משנה כעת."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "לשנות את כל הפריטים \"%s\" להיות \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2002,78 +1940,78 @@ msgstr ""
 "לא תוכל/י לבטל פעולה זו. אם יש כבר רכיבים פעילים עם הפריט \"%s\", לא תוכל/י "
 "להבחין בינם לבין הפריטים שאת/ה משנה כעת."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2082,129 +2020,129 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "כמות"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "קטגוריית קניות"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "כוכבים"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "לפני %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "מזג מתכונים אוטומטית"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "תמיד השתמש במתכון החדש ביותר"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "תמיד השתמש במתכון הישן ביותר"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "כלום"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2212,259 +2150,247 @@ msgstr ""
 "ככל הנראה יש כפילויות במתכונים המיובאים. באפשרותך למזג אותם כאן, או לסגור את "
 "החלון ולהשאירת כמות-שהם."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "ח_פש מתכונים כפולים"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "חפש והסר מתכונים כפולים"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "עבור כל ערך שנבחר"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "כאשר %(field)s הינו %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "השינוי ישפיע על %s מתכון"
 msgstr[1] "השינוי ישפיע על %s מתכונים"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "למחוק את %s כאשר הוא %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "לשנות את %s מ-%s להיות \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>שינוי זה הינו בלתי-הפיך.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "עורך השדות"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "ערוך שדות בכמה מתכונים בו-זמנית"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "שלח מתכונים באימייל"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr "שלח באימייל את כל המתכונים המסומנים (או כל המתכונים, אם לא סומנו"
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "האם ברצונך לשלוח באימייל את כל %s המתכונים שסומנו?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "_כן, שלח אותם"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "לא יכול להמיר %s ל %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "חסר מידע על משקל סגולי."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "המרת _יחידות"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "טוען קובץ zip"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "פותח קובץ zip"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "דף HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "מייצא דף אינטרנט"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "מייצא מתכונים לקבצי HTML בספריה %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "המתכון נשמר כקובץ HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "הדף המקורי מתוך %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "לא מחייב"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "מייצא דף אינטרנט"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "מייצא מתכונים לקבצי HTML בספריה %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "המתכון נשמר כקובץ HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "קובץ טקסט רגיל"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "ייצוא טקסט"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "מייצא מתכונים לקובץ טקסט %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "המתכונים נשמרו בקובץ טקסט רגיל %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "קובץ גדול"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "הקובץ %s גדול מכדי לייבא"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2475,81 +2401,54 @@ msgstr ""
 "באמת רצית לייבא את הקובץ הזה, יש להשתמש בעורך טקסט על מנת לפצל את הקובץ "
 "לקבצים יותר קטנים, ולנסות שוב."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "דף אינרטנט"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "מתבצעת הורדת %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "מאחזר %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "קובץ XML של גורמט"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "גורמה ייצוא XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "מייצא מתכונים אל קובץ XML של גורמט %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "המתכון נשמר בקובץ XML של גורמט %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "קובץ XML של גורמט (מיושן)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "קובץ XML של Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "קובץ טקסט של Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "הייבוא מ-Mastercook הסתיים."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "מנקה XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "קובץ XML של KRecipe"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2558,882 +2457,903 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "פריסת העמוד"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "הדפסת מתכונים"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "ייצוא PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "מייצא את המתכונים לקובץ PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "המתכון נשמר בקובץ PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "מכתב"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "דיוקן"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "רגיל"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "ס״מ"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "נקודות"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17 אינצ'ים"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "דף כרטסת (3.5x5 אינצ'ים)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "דף כרטסת (4x6 אינצ'ים)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "דף כרטסת (5x8 אינצ'ים)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "דף כרטסת (A4)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "מכתב"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "דף Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "דף כרטסת (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "דף כרטסת (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "דף כרטסת (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "לרוחב"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "רגיל"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s עמודה"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s עמודה"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s עמודה"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s עמודה"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s עמודה"
 msgstr[1] "%s עמודות"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "דיוקן"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "לרוחב"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "גו_דל נייר"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_כיוון הדפסה"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_גודל הגופן"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_גודל הגופן"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "שוליים שמאליים"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "שוליים ימניים"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "שוליים עליונים"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "שוליים תחתונים"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "קובץ MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "ייצוא MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "מייצא מתכונים לקובץ MealMaster %(file)s"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "המתכון נשמר כקובץ MealMaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "מנה"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "קובץ גדול"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "ייצוא"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "מייצא מתכונים אל קובץ XML של גורמט %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "המתכון נשמר בקובץ XML של גורמט %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3447,288 +3367,244 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "כוכבים"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "הייצוא הסתיים."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "כלול מתכון בגוף הדואל (מומלץ בחום)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "שלח מתכון כקובץ HTML"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "שליחת המתכון כדבוקת PDF בדואר אלקטרוני"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "אפשרויות דואל"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "אל תשאל לפני משלוח דואל"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "דואל לא נשלח"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr "לא בחרת לצרף את המתכון בגוף ההודעה או כקובץ נילווה להודעה."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "שמור מתכון בשם..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "גורמה לא יכול לייצא קבצים מסוג \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "ייצוא מתכונים"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "מתכונים"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "לא ניתן לייצא: סוג הקובץ \"%s\" לא מוכר"
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "יש לוודא בעת השמירה שבחרת את סוג הקובץ מתוך הרשימה."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "ייצוא"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "לא ניתן להדפיס: אין תוספי-הדפסה פעילים!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "הדפס מתכון %s"
 msgstr[1] "הדפסת %s מתכונים"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "מאחזר קובץ"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "תנובה"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "יש להזין את הכתובת של ארכיון המתכונים או אתר דף המתכון."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "יש להזין את כתובת אתר האינטרנט"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "הזנ/י כתובת:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "יש להזין את כתובת האתר או ארכיון המתכונים."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "לא ניתן לייבא את הכתובת"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "אין לגורמה תוסף המסוגל לייבא את הכתובת"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "פותח מתכון..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "יש להזין את כתובת אתר האינטרנט"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "שינויים"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "יש להזין את כתובת האתר או ארכיון המתכונים."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "ייבוא"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "כל הקבצים שניתן לייבא"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "יובאו %s מתכונים."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "מנה"
 msgstr[1] "מנות"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "יובאו %s מתוך %s מתכונים."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "בסדר"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "דף האינטרנט לא מזוהה. משתמש במייבא כללי..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "הייבוא הושלם."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "מייבא מתכון"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "מעבד רשימת מרכיבים"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "מעבד רשימת מרכיבים."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "מנות"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "תת-רשימת מרכיבים"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "הסתר"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "מלל"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "פעולות"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "ייבא מתכון"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "מחק תגיות"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "יבא מתכון"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "כותרת"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "מרכיב"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "הוראות"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "מטבח"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "מקור"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3737,103 +3613,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "שנייה"
 msgstr[1] "שניות"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "דק'"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "דקה"
 msgstr[1] "דקות"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "ש'"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "שעה"
 msgstr[1] "שעות"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "יום"
 msgstr[1] "ימים"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "שבוע"
 msgstr[1] "שבועות"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "חודש"
@@ -3842,7 +3712,7 @@ msgstr[1] "חודשים"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "שנה"
@@ -3854,71 +3724,30 @@ msgstr[1] "שנים"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " ו "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "וגם"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "אל"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "קובץ XML של גורמט"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "מנהל המתכונים גורמה"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr "סידור מתכונים, עריכת רשימת קניות, חישובי ערכים תזונתיים, ועוד."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3928,7 +3757,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3941,38 +3769,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -3980,6 +3776,18 @@ msgstr "ייצוא PDF"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3990,14 +3798,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4051,22 +3851,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4125,6 +3909,124 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "דניאל פולקשטיין  <nanotube@gmail.com> (תוכנת התקנה בחלונות)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "ריצ'רד פרגסון (שיפורים לממשק המרת היחידות)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "ר. ס. בורן (שיפורים לייצוא ל-Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (לוגו ותמונת פתיחה"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "יולה זובריצקי (צלמיות עבור תזונה והוספה-לרשימת-קניות)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "סיימון דארלינגטון <simon.darlington@gmx.net> (שיפורים לתמיכה בבינלאומיות, "
+#~ "תיקוני-באגים אחרים)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "ברנארד רייטר <ockham@raz.or.at> (תחזוקת גירסאת חלונות ועיצוב מחדש של האתר)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "משדרג את מסד-הנתונים"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "ייתכן והתהליך יהיה מסובך ויקח זמן, תלוי בגודל מסד-הנתונים שלך. המידע שלך "
+#~ "מגובה אוטומטית, על כל מקרה שיהיה."
+
+#~ msgid "No file selected"
+#~ msgstr "לא נבחר קובץ"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "הפעולה בוצעה, כיוון שלא נבחר קובץ."
+
+#~ msgid "_Import file"
+#~ msgstr "יי_בא קובץ"
+
+#~ msgid "Import _webpage"
+#~ msgstr "ייבא _דף אינטרנט"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "ייבא מתכון מדף אינטרנט"
+
+#~ msgid "Open _Trash"
+#~ msgstr "פתח את פ_ח האשפה"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "טוען קובץ zip"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "פותח קובץ zip"
+
+#~ msgid "Webpage"
+#~ msgstr "דף אינרטנט"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "מתבצעת הורדת %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "מאחזר %s"
+
+#~ msgid "Retrieving file"
+#~ msgstr "מאחזר קובץ"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "יש להזין את הכתובת של ארכיון המתכונים או אתר דף המתכון."
+
+#~ msgid "Enter URL:"
+#~ msgstr "הזנ/י כתובת:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "לא ניתן לייבא את הכתובת"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "אין לגורמה תוסף המסוגל לייבא את הכתובת"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "דף האינטרנט לא מזוהה. משתמש במייבא כללי..."
+
+#~ msgid "Import complete."
+#~ msgstr "הייבוא הושלם."
+
+#~ msgid "Importing recipe"
+#~ msgstr "מייבא מתכון"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "מעבד רשימת מרכיבים"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "מעבד רשימת מרכיבים."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "קובץ XML של גורמט"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "מנהל המתכונים גורמה"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr "סידור מתכונים, עריכת רשימת קניות, חישובי ערכים תזונתיים, ועוד."
 
 #~ msgid "Select recipe image"
 #~ msgstr "בחירת תמונה למתכון"
@@ -4196,9 +4098,6 @@ msgstr ""
 #~ msgid "Time must be expressed in hours, minutes, seconds, etc."
 #~ msgstr "זמן מוכרח להתבטא בשעות, דקות, שניות, וכו'."
 
-#~ msgid "Select File_type"
-#~ msgstr "בחר סוג_קובץ"
-
 #~ msgid "A file named %s already exists."
 #~ msgstr "קיים קובץ עם השם %s."
 
@@ -4256,9 +4155,9 @@ msgstr ""
 #~ "database will no longer work with older versions of %(progname)s.  A "
 #~ "backup has been saved in %(backupfile)s"
 #~ msgstr ""
-#~ "גירסה %(version)s של %(progname)s שינתה את פורמט מסד-הנתונים שלה. מסד-"
-#~ "הנתונים שלך כבר לא תואם עם גירסאות ישנות של %(progname)s. נשמר עותק בקובץ "
-#~ "%(backupfile)s."
+#~ "גירסה %(version)s של %(progname)s שינתה את פורמט מסד-הנתונים שלה. "
+#~ "מסד-הנתונים שלך כבר לא תואם עם גירסאות ישנות של %(progname)s. נשמר עותק "
+#~ "בקובץ %(backupfile)s."
 
 #~ msgid ""
 #~ "In case anything goes wrong, a backup copy of your recipe database is "

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-18 06:49+0000\n"
 "Last-Translator: PriyaKumar <Unknown>\n"
 "Language-Team: Hindi <hi@li.org>\n"
@@ -19,506 +19,507 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "चुने हुए नुस्खा को हटाएँ"
+
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
-
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -526,31 +527,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -559,285 +560,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -852,650 +854,601 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 msgid "Add to Shopping List"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1507,444 +1460,424 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  PriyaKumar https://launchpad.net/~sweetcorncake"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "चुने हुए नुस्खा को हटाएँ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+msgid "_Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1952,12 +1885,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1965,78 +1898,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2045,386 +1978,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2432,81 +2353,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2515,880 +2409,897 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3402,288 +3313,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3692,103 +3557,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3797,7 +3656,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3809,69 +3668,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3881,7 +3701,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3894,44 +3713,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3942,14 +3741,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4003,22 +3794,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2011-02-22 19:18+0000\n"
 "Last-Translator: perki <peric.tomislav@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -15,511 +15,512 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gourmet Recipe Manager"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+msgid "Copy selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +528,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +561,287 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet Recipe Manager"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,650 +856,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 msgid "Add to Shopping List"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr ""
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Odaberi tip datoteke"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1508,445 +1463,426 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Uvoz pauziran"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Zaustavi uvoz"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Index_Recepata"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  perki https://launchpad.net/~peric-tomislav"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Uvoz pauziran"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Index_Recepata"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1954,12 +1890,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1967,78 +1903,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2047,386 +1983,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2434,81 +2358,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2517,880 +2414,897 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3404,288 +3318,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3694,104 +3562,98 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3800,7 +3662,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3812,72 +3674,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet Recipe Manager"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organiziraj recepte, kreiraj liste za kupovinu, izračunaj nutricionističke "
-"vrijednosti i više."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3887,7 +3707,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3900,44 +3719,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3948,14 +3747,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4009,22 +3800,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4084,8 +3859,16 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
-#~ msgid "Select File_type"
-#~ msgstr "Odaberi tip datoteke"
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet Recipe Manager"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organiziraj recepte, kreiraj liste za kupovinu, izračunaj "
+#~ "nutricionističke vrijednosti i više."
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Datoteka sa imenom %s već postoji."

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2014-03-05 10:48+0000\n"
 "Last-Translator: Úr Balázs <urbalazs@gmail.com>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -20,64 +20,64 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Recept index"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "Ú_j recept"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Hozzáadás a _bevásárlólistához"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Recept _megtekintése"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "Keresés _erre:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Recept keresése gépelés közben"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_ebben"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Keresés egyéb feltétel szerint a jelenlegi keresési eredményben."
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Keresési _feltétel hozzáadása"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Keresés korlátozása erre:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Keresés _eredménye"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Mezők beállítása a kijelölt receptekhez"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -85,129 +85,132 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Receptmezők beállítása a kijelölt "
 "receptekhez</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "Kép _hozzáadása"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "Kép _eltávolítása"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "_Forrás:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "É_rtékelés:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "_Konyha:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Kategória:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "_Előkészítés ideje:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "_Főzés ideje:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Weboldal:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Kép:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Adag:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Adag egység"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "_Csak azon értékek beállítása, ahol a mező jelenleg üres"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "_Minden érték beállítása az összes kijelölt recepthez"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (alapértelmezett, helyi fájlban tárolva)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (helyi fájlban tárolva)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (kapcsolat szükséges az adatbázishoz)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Adatbázis választása"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Válasszon adatbázis-rendszert a Gourmet használatához</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "_Adatbázis-rendszer"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Gép:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Felhasználónév:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Jelszó:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Az adatbázis felhasználójának jelszava."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Adatbázis _neve:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Fájl"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -215,11 +218,11 @@ msgstr ""
 "A rendszer gépneve, ahol az adatbázis-kiszolgáló fut. Ha az adatbázis-"
 "kiszolgáló a helyi rendszeren fut, használja a localhostot."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -227,11 +230,11 @@ msgstr ""
 "Jelszó elmentése a következő belépéshez. Ez azt jelenti, hogy a jelszó a "
 "beállítófájlban lesz tárolva nem biztonságos módon."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "Jelszó _mentése"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -239,302 +242,303 @@ msgstr ""
 "Az adatbázis neve, amelyben a Gourmet az információit tárolja. A Gourmet "
 "megpróbálja létrehozni ezt az adatbázist, ha az még nem létezik."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recept"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Felhasználónév az adatbázishoz."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Tallózás"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Részletek"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "A Gourmet receptkezelő beállításai"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Indexnézet beállítások</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "_Beállítások megjelenítése"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Receptek oldalanként:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 "<i>Annak beállítása, hogy mely oszlopokat tartalmaza a recept indexnézet.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Indexnézet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Kártyanézet beállítások</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "_Mértékegységek váltásának lehetővé tétele szorszáskor"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Törtek használata"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Törtek használata a megjelenítéshez, ha lehetséges"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 "<i>Azon elemek eltávolítása a recept kártyafelületről, amelyeket nem használ."
 "</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Kártyanézet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Bevásárlólista beállítások</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Mit csináljon a Gourmet az opcionális hozzávalókkal a receptek "
 "hozzáadásakor a bevásárlólistához?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "_Kérdezzen rá, hogy vegye-e fel az opcionális hozzávalókat"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "_Emlékezzen a felhasználói kiválasztásokra alapértelmezetten"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "Megjegyzett _opcionális hozzávalók törlése"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "_Mindig adja hozzá az opcionális hozzávalókat"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Soha ne adja hozzá az opcionális hozzávalókat"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Bevásárlólista"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "adag"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Cím"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Cím:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "_Előkészítés ideje:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategória"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "értékelés"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Adag"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Adag egység"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Bolt"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "_Leírás szerkesztése"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Főzés ideje:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Előkészítés ideje:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Konyha:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Kategória:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Weboldal:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Adagok:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Hivatkozás</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Forrás:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Értékelés:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Szorozva ezzel:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Elkészítés módja</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "El_készítés módjának szerkesztése"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Megjegyzések</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "_Megjegyzések szerkesztése"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recept"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Hozzávalók</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "_Hozzávalók szerkesztése"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "_Hozzávaló hozzáadása:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Hozzávalók"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Recept hozzáadása a bevásárlólistához"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Hozzáadás a _bevásárlólistához"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Ugrás a recepthez a recept kártyanézetben"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "A kijelölt recept törlése"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "Recept _törlése"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "A kijelölt receptek jellemzőinek szerkesztése"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "Receptek _kötegelt szerkesztése"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "A kijelölt recept küldése e-mailben"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "A kijelölt recept megnyitása"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "Recept küldése _e-mailben"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Recept választása"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "A kijelölt recept nyomtatása"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "Recept _nyomtatása"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -542,31 +546,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Hozzáadás az élés_kamrához"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "_Beállítások megjelenítése"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Keresés _ebben"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "_Reguláris kifejezés használata (speciális keresés)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Keresés _gépelés közben"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Keresési beállítások</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategória"
 
@@ -575,289 +579,291 @@ msgstr "Kategória"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Kulcs"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Kategória szerkesztő"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Keresési kulcs"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Keresés gépelés közben"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Reguláris kifejezések használata"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Speciális keresés"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Kategória hozzáadása: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Stopper"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Stopper</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>A stopper befejeződött!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "A stopper tovább fog menni, amíg be nem zárja ezt a párbeszédablakot vagy "
 "vissza nem állítja a stoppert."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "_Stopper beállítása: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Visszaállítás"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Indítás"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "_Hang"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Megjegyzés"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Riasztás _ismétlése, amíg ki nem kapcsolom"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Beállítások"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Mezők szerkesztése az egész adatbázisban</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "_Szerkesztendő mező:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Minden egyes kijelölt értékhez:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "_Hagyja úgy az értéket, ahogy van"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>Az új érték hozzá lesz adva bármely meglévő szöveg végéhez<i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Az új érték le fog cserélni bármilyen meglévő értéket</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Mező:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "É_rték:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "_Egyéb mező cseréje:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "Érték _cseréje erre: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "Érték _törlése"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Egyenértékű kiválasztása ehhez</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>az USDA adatbázisból</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "_Hozzávaló változtatása"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>vagy</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "_Keresés az USDA hozzávaló adatbázisban:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Keresés gé_pelés közben"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Csak a _csoportban lévő étel megjelenítése:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Keresési _eredmények:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>Erről:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Mennyiség:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Mértékegység:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "mértékegység"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "_Mértékegység változtatása"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "Új mértékegység _mentése"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>Erre:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Egység:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Tápanyag információk megadása a következőhöz </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Sűrűség kiválasztása</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Hozzávalókulcs: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>USDA elem: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "_USDA társítás szerkesztése"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Tápanyag információk</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "_Információk szerkesztése"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "_Tápanyag információk"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Sűrűség:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "USDA egyenértékesek:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Egyéni egyenértékesek:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "_Sűrűség információk"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Ismert tápanyag információk</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "_Speciális keresés"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Tápanyag információk"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "_Mellőzés"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet receptkezelő"
 
-#: ../src/gourmet/version.py:5
-#, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr "Copyright © Thomas M. Hinkle, 2004-2011. GNU GPL v2"
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr "Copyright © Thomas M. Hinkle, 2004-2011. GNU GPL v2"
+
+#: ../src/gourmand/__version__.py:9
+#, fuzzy
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -881,216 +887,169 @@ msgstr ""
 "Képes továbbá a receptek tápanyag információinak számítására a hozzávalókon "
 "alapulva."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (segítség az átíráshoz Windowsra)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows telepitő)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (mértékegység átváltó felület javítása)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (a Mealmaster exportálás továbbfejlesztése)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logó és indítóképernyő)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (tápanyag és a hozzáadás a bevásárlólistához ikonok)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (a nemzetköziesítés "
-"továbbfejlesztése, válogatott hibajavítások)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (a Windows verzió karbantartása és a "
-"weboldal kinézetének átalakítása)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Adatbázisfájl kiválasztása"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Adatbázis frissítése"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Új recept"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Adatbázis _neve:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"Az adatbázis méretétől függően ez hosszú folyamat lehet és eltarthat egy "
-"ideig. Az adatai automatikusan mentésre kerültek arra az esetre, ha valami "
-"rosszul sikerülne."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Részletek"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Biztonsági mentés készült a(z) %s helyre arra az esetre, ha valami rosszul "
 "sikerülne. Ha ez a frissítés nem sikerül, átnevezheti kézzel a biztonsági "
 "mentés fájlt recipies.db névre a visszaállításhoz és a régebbi Gourmet "
 "programmal való használathoz."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Új recept"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Kategória _módosítása"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Új kategória létrehozása"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "A jelenleg kiválasztott elem kategóriájának módosítása"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Éléskamra"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Áthelyezés a _bevásárlólistára"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Áthelyezés az élés_kamrába"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Eltávolítás a bevásárlólistáról"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "A kijelölt elemek áthelyezése ebbe: %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Bevásárlólista"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Már van (élés_kamra elemek)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Kategória megadása"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "A hozzáadandó kategória ehhez: %s"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategória:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Receptek"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Elemek hozzáadása:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Receptek eltávolítása"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Receptek eltávolítása a bevásárlólistáról"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Szerkesztés"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Súgó"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Elemek hozzáadása"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Tetszőleges elemek hozzáadása a bevásárlólistához"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Nincs recept kiválasztva. Szeretné törölni az egész listát?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Bevásárlólista mentése másként…"
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Opcionális hozzávalók kiválasztása"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1099,57 +1058,59 @@ msgstr ""
 "bevásárlólistára."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recept"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Ugrás"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Recept exportálása"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Kijelölt recept exportálása (mentés fájlba)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "Recept _törlése"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "A recept törlése"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Mértékegységek igazítása szorzáskor"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Mértékegységek változtatása szorzáskor, hogy olvashatóbbak legyenek, ahol "
 "lehetséges."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Recept nyomtatása"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Hozzáadás a _bevásárlólistához"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "A megjegyzett opcionális hozzávalók elfelejtése"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1157,150 +1118,144 @@ msgstr ""
 "A bevásárlólistához adás előtt kérdezzen rá minden opcionális hozzávalóra "
 "akkor is, ha korábban szerette volna megjegyezni"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Recept exportálása"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Mentetlen módosításai vannak."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Alkalmazza a változtatásokat nyomtatás előtt?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Alkalmazza a változtatásokat nyomtatás előtt?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Opcionális)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Nem található a(z) %s recept az adatbázisban."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Recept szerkesztése:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Szerkesztések mentése az adatbázisba"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Receptkártya megtekintése"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Változások mentése ide: %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Hozzávaló hozzáadása"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Csoport hozzáadása"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Hozzávalók beillesztése"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importálás fájlból"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "_Recept hozzáadása"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Másik recept hozzáadása hozzávalóként ehhez a recepthez"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Fel"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Le"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Válassza ki a hozzávalólistát tartalmazó fájlt."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Leírás"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Elkészítés"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Megjegyzések"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Egység"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Mértékegység"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Elem"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Opcionális"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "A(z) %s recept (azonosító: %s) nincs az adatbázisban."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Átváltva: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Nincs átváltva: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Átváltott mértékegység."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1309,234 +1264,233 @@ msgstr ""
 "Átváltotta a(z) %(item)s mértékegységet %(old)s értékről %(new)s értékre. "
 "Szeretné a mennyiséget is átváltani vagy sem?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "A(z) %(old_amt)s %(old_unit)s átváltva erre: %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Nem lehet átváltani a(z) %(old_unit)s egységet %(new_unit)s egységre"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Hozzávalócsoport hozzáadása"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Adjon nevet a hozzávalók új alcsoportjának"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Csoport neve:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Recept választása"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "A recept nem hivatkozhat önmagára mint hozzávalóra!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Hivatkozási hurok nem lehet a receptek között!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Nem választott ki receptet!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Receptek"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Csengőhang"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Figyelmeztető hang"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Hiba hang"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Stopper leállítása?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "_Stopper leállítása"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "Időzítés _folytatása"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Bővítmények"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "A bővítmények további funkciókat adnak a Gourmet programhoz."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "A bővítmény szükséges más bővítményekhez. Mindenképpen deaktiválja a "
 "bővítményt?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "A következő bővítményekhez a(z) %s szükséges:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Deaktiválás mindenképp"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Maradjon a bővítmény aktív"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "vagy"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Hiba történt a bővítmény aktiválása során."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Hiba történt a bővítmény deaktiválása során."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Konyha"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Értékelés"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Forrás"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Weboldal"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Előkészítési idő"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Főzési idő"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Módosítások"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Érvénytelen bemenet."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Ez nem szám."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Szünet"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Leállítás"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Ne kérdezze meg többet."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Biztosan ezt akarja tenni"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "tökéletes"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "nagyszerű"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "jó"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "közepes"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "szegényes"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Értékelések átalakítása 5-csillagos skálára."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Értékelések átalakítása."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Kérem adjon meg minden értékeléshez egyenértékűt az 1-től 5-ig tartó skálán"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Jelenlegi értékelés"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Az értékelés 5 csillagon kívül van"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Nincs fájl kiválasztva"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Fájl_típus kiválasztása"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Nincs kiválasztott fájl, ezért a művelet megszakadt"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1545,12 +1499,12 @@ msgstr ""
 "Elnézést, nem értem\n"
 "a(z) „%s” mennyiséget."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr "A mennyiség szám (egész vagy tört), számtartomány, vagy üres lehet."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1570,86 +1524,86 @@ msgstr ""
 "Számtartomány megadásához a számokat a „-” jellel válassza el.\n"
 "Például megadhat 2-4 vagy 1 1/2-3 1/2 értékeket.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Felhasználónév:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Jelszó:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "liszt, minden célra"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "cukor"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "só"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "fekete bors, őrölt"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "jég"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "víz"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "olaj, növényi"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "olaj, olíva"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "A recept önmagára hivatkozik mint hozzávaló."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "A(z) %s hozzávaló mellőzve lesz."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Bevásárlólista ehhez: %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "A következő receptekhez:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "A következő receptekhez:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Kódolás kiválasztása"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1657,29 +1611,28 @@ msgstr ""
 "Nem sikerült meghatározni a megfelelő karakterkódolást. Kérem válassza ki a "
 "helyes kódolást a következő listából."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "_Fájl megtekintése a kódolással"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importálás szüneteltetve"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Importálás leállítása"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Recept _index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Bevásárló_lista"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1704,335 +1657,322 @@ msgstr ""
 "  worxefoz https://launchpad.net/~worxefoz\n"
 "  Úr Balázs https://launchpad.net/~urbalazs"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Elmentve!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Módosítások mentése ide: %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Egy importálás folyamatban van."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Egy exportálás folyamatban van."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Egy törlés folyamatban van."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Mindenképpen kilép a programból?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Ne lépjen ki!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "%s/%s recept véglegesen törölve"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Kuka"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Tallózás, azonnali törlés, vagy törölt receptek visszaállítása"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Helyreállított receptek "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "%s szorzási tényezője:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "%(attributes)s beállítása %(num)s kijelölt recepthez?"
 msgstr[1] "%(attributes)s beállítása %(num)s kijelölt recepthez?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Bármely korábban meglévő érték változatlanul marad."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Az új értékek felülírnak minden korábban létezőt."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Ez a változás nem vonható vissza."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Értékek beállítása a kijelölt receptekhez"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Receptek keresése"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Recept megnyitása"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "A kijelölt recept megnyitása"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Recept törlése"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "A kijelölt receptek törlése"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Recept szerkesztése"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "A kijelölt receptek megnyitása receptszerkesztő nézetben"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "A kiválasztott receptek e_xportálása"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "A kiválasztott receptek exportálása fájlba"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Nyomtatás"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "receptek"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Receptek kötegelt _szerkesztése"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "Ú_j"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "Fájl _importálása"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Recept importálása"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Recept importálása fájlból"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "_Weboldal importálása"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Recept importálása weboldalról"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "_Minden recept exportálása"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Az összes recept exportálása fájlba"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Kilépés"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Műveletek"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "_Kuka megnyitása"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Kuka"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Beállítások"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Bővítmények"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Bővítmények kezelése, amelyek további funkciókat adnak a Gourmethez."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Beállí_tások"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Névjegy"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Eszközök"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Stopper"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Stopper megjelenítése"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "A receptek kereshető indexe az adatbázisban."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Törli ezt: %s ?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Nem mentett változtatásai vannak ehhez: %s. Biztosan törölni szeretné?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Törölve"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Névtelen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Véglegesen törli a recepteket?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Véglegesen törli a receptet?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Biztosan törölni szeretné ezt a receptet: <i>%s</i>?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Biztosan törölni szeretné a következő recepteket?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Biztosan törölni szerete %s kiválasztott receptet?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Receptek megtekintése"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Receptek törlése"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Recept index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Törölt recept: %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Kész!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importálás…"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Hozzávaló_kulcs szerkesztő"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Hozzávalókulcsok tömeges szerkesztése"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "kulcs"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "elem"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Mező"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Érték"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Mennyiség"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Minden „%s” kulcs cseréje erre: „%s”?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2043,12 +1983,12 @@ msgstr ""
 "kulccsal, akkor nem lesz képes különbséget tenni azon elemek és a most "
 "megváltoztatottak között."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Minden „%s” elem cseréje erre: „%s”?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2059,12 +1999,12 @@ msgstr ""
 "elemmel, akkor nem lesz képes különbséget tenni azon elemek és a most "
 "megváltoztatottak között."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "A(z) „%(unit)s” _minden példányának cseréje erre: „%(text)s”"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2073,14 +2013,14 @@ msgstr ""
 "A(z) „%(unit)s” cseréje „%(text)s” értékre csak a(z) „%(key)s” kulcsú "
 "„%(item)s” _hozzávalóknál"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "A(z) „%(amount)s” %(unit)s _minden példányának cseréje erre: %(text)s "
 "%(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2089,7 +2029,7 @@ msgstr ""
 "A(z) „%(amount)s” %(unit)s cseréje „%(text)s” %(unit)s értékre csak ott, "
 "_ahol a hozzávaló kulcs értéke %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2098,11 +2038,11 @@ msgstr ""
 "A(z) „%(amount)s” %(unit)s cseréje „%(text)s” %(unit)s értékre csak ott, "
 "ahol a hozzávaló kulcs értéke %(key)s és ahol az _elem értéke %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Minden kijelölt sor változtatása?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2111,7 +2051,7 @@ msgstr ""
 "Ez a művelet nem lesz visszavonható. Biztos benne, hogy az összes %s "
 "kijelölt sort a következő értékekre szeretné beállítani:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2120,7 +2060,7 @@ msgstr ""
 "\n"
 "Kulcs erre: %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2129,7 +2069,7 @@ msgstr ""
 "\n"
 "Elem erre: %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2138,7 +2078,7 @@ msgstr ""
 "\n"
 "Mértékegység erre: %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2147,8 +2087,8 @@ msgstr ""
 "\n"
 "Mennyiség erre: %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2157,23 +2097,23 @@ msgstr[1] "%s hozzávaló"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Hozzávalók megjelenítése: %(bottom)s - %(top)s / %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Mennyiség"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Hozzávalókulcsok"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2181,11 +2121,11 @@ msgstr ""
 "A hozzávalókulcsok a bevásárlólistákhoz és a számításokhoz használt "
 "normalizált hozzávalónevek."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Kulcsok kitalálása"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2193,59 +2133,59 @@ msgstr ""
 "A legjobb értékek kitalálása minden hozzávalókulcshoz az adatbázisban már "
 "meglévő értékeken alapulva"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Kulcstársítások szerkesztése"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 "A kulcs és egyéb attribútumok társításainak szerkesztése az adatbázisban"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Kulcsszerkesztő"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "_Elem:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Kulcs:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>_Kiválasztott hozzávalók változtatása</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Vásárlási kategória"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 "Mértékegységek megjelenítése minden receptnél úgy, ahogy vannak (nincs "
 "változtatás)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Mindig U.S. mértékegységek megjelenítése"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Mindig metrikus mértékegységek megjelenítése"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Mértékegységek automatikus igazítása"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "_Mértékegység megjelenítési beállítások megadása"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2253,42 +2193,42 @@ msgstr ""
 "Mértékegységek automatikus átalakítása az előnyben részesített rendszerre "
 "(metrikus, birodalmi, stb.), ahol lehetséges."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Csillagok"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "ennyi ideje: %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Receptek automatikus egyesítése"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Mindig az újabb receptet használja"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Mindig a régebbi receptet használja"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Nincs"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2296,97 +2236,97 @@ msgstr ""
 "Az importált receptek közül néhány azonosnak tűnik. Egyesítheti őket itt, "
 "vagy meghagyhatja őket a párbeszédablak bezárásával."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "_Azonos receptek keresése"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Azonos receptek keresése és eltávolítása"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Hasonló recept információkkal rendelkező receptek"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Hasonló hozzávalókkal rendelkező receptek"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Hasonló recept információkkal és hozzávalókkal rendelkező receptek"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Azonos receptek</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "Receptek _felvétele a kukából"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Megjelenítés:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "_Minden azonos recept egyesítése"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Receptek egyesítése</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "_Automatikus egyesítés"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Minden egyes kijelölt értékhez"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Ahol %(field)s = %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "A módosítás %s receptet fog érinteni"
 msgstr[1] "A módosítás %s receptet fog érinteni"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "%s törlése, ahol az %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "%s módosítása %s értékről „%s” értékre?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Ez a változtatás nem vonható vissza.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Mezőszerkesztő"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Mezők szerkesztése egyszerre több receptnél."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Receptek küldése e-mailben"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Minden kiválasztott recept küldése e-mailben (vagy az összes recept küldése, "
@@ -2395,162 +2335,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Biztosan el akarja küldeni e-mailben a kiválasztott %s receptet?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Igen, küldd el e-_mailben"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Nem sikerült %s átalakítása erre: %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Sűrűséginformáció szükséges."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Mértékegység-átváltó"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Mértékegység-átváltások számítása"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Mértékegység-átváltó"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Innen</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "_Elem:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Sűrűség:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Sűrűség _információ"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Ide</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "Ere_dmény:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Archívum (zip, tarball)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Zip archívum betöltése"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Zip archívum kibontása"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML weboldal"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Weboldal exportálása"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Receptek exportálása HTML fájlokba a(z) %(file)s könyvtárba."
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "A recept elmentve %(file)s HTML fájlként"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Eredeti oldal innen: %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "opcionális"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Weboldal exportálása"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Receptek exportálása HTML fájlokba a(z) %(file)s könyvtárba."
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "A recept elmentve %(file)s HTML fájlként"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Egyszerű szövegfájl"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Szöveg exportálás"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Receptek exportálása a(z) %(file)s szövegfájlba."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "A recept elmentve %(file)s egyszerű szövegfájlként"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Nagy fájl"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "A(z) %s fájl túl nagy az importáláshoz"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2562,81 +2490,54 @@ msgstr ""
 "szeretné ezt a fájlt, akkor egy szövegszerkesztő használatával darabolja fel "
 "kisebb fájlokra és próbálja meg importálni ismét."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Weboldal"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "%s letöltése"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Bevásárlólista ehhez: %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "%s lekérése"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML fájl"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML exportálás"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Receptek exportálása Gourmet XML fájlként ide: %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "A recept elmentve a(z) %(file)s Gourmet XML fájlba."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML fájl (elavult)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML fájl"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook szövegfájl"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Mastercook importálás befejezve."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "XML rendezése"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML fájl"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2645,276 +2546,297 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Oldalelrendezés"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Receptek nyomtatása"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF exportálás"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Receptek exportálása a(z) %(file)s PDF fájlba."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "A recept elmentve %(file)s PDF fájlként"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Levél"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Álló"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Sima"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "pont"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Katalóguscédula (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Katalóguscédula (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Katalóguscédula (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Katalóguscédula (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Levél"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Katalóguscédulák (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Katalóguscédulák (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Katalóguscédulák (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Fekvő"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Sima"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s oszlop"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s oszlop"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s oszlop"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s oszlop"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s oszlop"
 msgstr[1] "%s oszlop"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Álló"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Fekvő"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "_Papírméret"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Tájolás"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Betűméret"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "_Oldalelrendezés"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Betűméret"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Bal margó"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Jobb margó"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Felső margó"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Alsó margó"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "PDF-beállítások"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster fájl"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster exportálás"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Receptek exportálása a(z) %(file)s MealMaster fájlba."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "A recept elmentve %(file)s MealMaster fájlként"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "adag"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Nagy fájl"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "HTML exportálás"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Receptek exportálása Gourmet XML fájlként ide: %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "A recept elmentve a(z) %(file)s Gourmet XML fájlba."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Bevásárlólista mentő"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Lista mentése receptként"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "A jelenlegi bevásárlólista mentése receptként későbbi használatra"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "%s menüje"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menü"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "A tápanyag információk a mennyiség / %s arányt tükrözik."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 "A tápanyag információk az teljes recepthez tartozó mennyiségeket tükrözik"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "A tápanyag információk hiányoznak %s hozzávalóhoz: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Bármely ételcsoport"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "kiválasztás"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Mértékegység átalakítása ehhez: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "A tápanyag információk kiszámítása érdekében a Gourmet programnak szüksége "
 "van ön segítségére, hogy átalakítsa a(z) „%s” értéket olyan mértékegységre, "
 "amelyet megért."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Hozzávalókulcs változtatása"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2923,29 +2845,29 @@ msgstr ""
 "Hozzávalókulcs változtatása a meglévő %(old_key)s értékről %(new_key)s "
 "értékre mindenhol vagy csak a(z) %(title)s receptben?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Változtatás _mindenhol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Csak a(z) %s receptben"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 "Hozzávalókulcs változtatása a meglévő %(old_key)s értékről %(new_key)s "
 "értékre mindenhol?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Mértékegység változtatása"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2954,11 +2876,11 @@ msgstr ""
 "Mértékegység változtatása a meglévő %(old_unit)s értékről %(new_unit)s "
 "értékre minden %(ingkey)s hozzávalónál vagy csak a(z) %(title)s receptben?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2967,198 +2889,199 @@ msgstr ""
 "adatbázisunk ennek az ételnek számos leírásával rendelkezik különböző "
 "sűrűségekkel. Kérjük válassza ki lent a helyeset."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "A tápanyag információk alkalmazásához a Gourmet programnak szüksége van egy "
 "érvényes mennyiségre és mértékegységre."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Tápanyag"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Hozzávaló"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "USDA adatbázis egyenértékes"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gramm"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalóriák"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Teljes zsírtartalom"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Telített zsírtartalom"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Koleszterin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Nátrium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Teljes szénhidrát"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Rost tartalom"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Cukor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Fehérje"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-karotin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Hamu"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Béta-karotin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Béta-kriptoxantin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Kalcium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Réz"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Folsav tartalom"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Folsav"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Étel folsav"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Étrendi folsav egyenértékes"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Vas"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Likopin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Lutein+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnézium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangán"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Pantoténsav"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Foszfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Kálium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "A-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Szelén"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "A-vitamin (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "A-vitamin (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "B6-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "B12-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "C-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "E-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "K-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Cink"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitaminok és ásványi anyagok"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3167,11 +3090,11 @@ msgstr ""
 "Hiányzó tápanyag információk\n"
 "%(missing)s hozzávalóhoz az összes %(total)s hozzávalóból."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Napi adag"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3180,367 +3103,367 @@ msgstr ""
 "Az ajánlott napi érték százaléka napi %i kalórián alapulva. Kattintson a "
 "napi kalória értékének szerkesztéséhez."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Mennyiség per %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Mennyiség per recept"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Tápanyag adatok betöltése"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "A tápanyag adatbázis importálása kész!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Tápanyag adatbázis lekérése a(z) %s zip archívumból"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "%s kibontása zip archívumból."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Tápanyag adatok feldolgozása…"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Tápanyag adatok olvasása: %s/%s bejegyzés importálva."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Súlyadatok feldolgozása…"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr "Súlyadatok olvasása a tápanyag elemekhez: %s/%s bejegyzés importálva"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Víz"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalóriák"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g protein"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipid"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g hamu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g carbohidrát"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g rost"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g cukor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg kalcium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg vas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnézium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg foszfor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg kálium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg nátrium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg cink"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg réz"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg mangán"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mikrogramm szelén"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg c-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg tiamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niacin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg pantoténsav"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg B6-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "mikrogramm folsav tartalom"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "mikrogramm folsav"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "mikrogramm étkezési folsav"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "mikrogramm étrendi folsav egyenértékes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Kolin, összesen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mikrogramm B12-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "A-vitamin IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "A-vitamin (mikrogramm retina aktivitás egyenértékes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "mikrogramm retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "mikrogramm alfa-karotin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "mikrogramm béta-karotin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "mikrogramm béta-kriptoxantin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "mikrogramm likopin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "mikrogramm lutein+zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg E-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg K-vitamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g telített zsírsav"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g monotelítetlen zsírsav"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g politelítetlen zsírsav"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg koleszterin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Emészthetetlen százalék"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Tej- és tojáskészítmények"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Fűszerek és gyógynövények"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Bébiételek"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Zsírok és olajok"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Baromfi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Levesek és szószok"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Felvágottak és löncshúsok"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Reggeli gabonafélék"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Gyümölcsök és gyümölcslevek"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Sertéshús"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Zöldségek"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Diófélék és magvak"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Marhahús"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Italok"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Halak és kagylók"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Hüvelyesek"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Bárány-, borjú- és vadhús"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Sültek"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Édességek"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Gabonaételek és tészták"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Gyorsételek"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Ételek, előételek és köretek"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Rágcsálnivalók"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Etnikai ételek"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "teljes adatbázis"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Hozzávalókulcs"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "USDA azonosítószám"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA elem leírás"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Sűrűség egyenértékes"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA azonosító"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3554,60 +3477,60 @@ msgstr "Eszközök"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Tápanyag információk lekérése a jelenlegi listához"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Mennyiség a bevásárlólistához"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "_Tápanyag információk szerkesztése"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "csillag"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "%(number)s recept exportálva %(total)s receptből"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Exportálás befejezve."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 "Recept felvétele az e-mail törzsébe (nem számít, hogy miért, de jó ötlet)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Recept küldése e-mailben HTML mellékletként"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Recept küldése e-mailben PDF mellékletként"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "E-mail beállítások"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Ne kérdezzen e-mail küldés előtt."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Az e-mail nincs elküldve"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3615,237 +3538,190 @@ msgstr ""
 "Nem választotta ki, hogy a receptet a levél törzsébe szertné felvenni vagy "
 "mellékletként küldi."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Recept mentése másként…"
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "A Gourmet nem tudta exportálni a(z) „%s” formátumú fájlt"
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Receptek exportálása"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "receptek"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Nem lehet exportálni: ismeretlen fájltípus: „%s”"
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Győződjön meg arról, hogy mentéskor választott-e fájltípust a lenyíló "
 "menüből."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Exportálás"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Nem lehet nyomtatni: nincs aktív nyomtatás bővítmény!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "%s recept nyomtatása"
 msgstr[1] "%s recept nyomtatása"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Fájl letöltése"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "adag"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Adja meg a receptarchívum vagy recept weboldal URL-jét."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Írja be a weboldal címét"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Adja meg az URL-t:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Adja meg a weboldal vagy receptarchívum címét."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Nem lehetséges az URL importálása"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-"A Gourmet programnak nincs olyan bővítménye, amely alkalmas URL importálására"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Nem lehet importálni a(z) %(type)s MIME-típusú %(url)s URL-t. A fájl az "
-"átmeneti %(fn)s helyre lett elmentve."
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Recept megnyitása…"
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Írja be a weboldal címét"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Módosítások"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Adja meg a weboldal vagy receptarchívum címét."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importálás"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Minden importálható fájl"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "%s recept importálva."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "adag"
 msgstr[1] "adag"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "%s recept importálva a(z) %s receptből."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "rendben"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Ne ismerje fel ezt a weboldalt. Általános importáló használata…"
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Importálás kész."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Recept importálása"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Hozzávalók feldolgozása"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Hozzávalók feldolgozása."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Adag"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Hozzávalók alcsoportja"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Elrejt"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Szöveg"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Műveletek"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Recept importálása"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "_Címkék törlése"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Recept importálása"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "bárhol"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "cím"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "hozzávaló"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "elkészítés"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "jegyzetek"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "konyha"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "forrás"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Reguláris kifejezések használata a keresésnél"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Reguláris kifejezések (egy speciális keresési nyelv) használata a szöveges "
 "keresésnél"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Keresés gépelés közben (kapcsolja ki, ha a keresés túl lassú)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Keresési _beállítások megjelenítése"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Speciális keresési beállítások megjelenítése"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3854,104 +3730,98 @@ msgstr[1] "%s recept"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Receptek megjelenítése: %(bottom)s - %(top)s / %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s ebben: %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Szüneteltetve"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "KRecipe importálás"
 msgstr[1] "KRecipe importálás"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Szünet"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Kész"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Hiba: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Hiba"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Hiba %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Visszakövetés"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "másodperc"
 msgstr[1] "másodperc"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "perc"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "perc"
 msgstr[1] "perc"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "óra"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "óra"
 msgstr[1] "óra"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "nap"
 msgstr[1] "nap"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hét"
 msgstr[1] "hét"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "hónap"
@@ -3960,7 +3830,7 @@ msgstr[1] "hónap"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "év"
@@ -3972,73 +3842,30 @@ msgstr[1] "év"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " és "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "és"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "-"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML fájl"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet receptkezelő"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Receptek rendezése, bevásárlólisták készítése, tápérték-információk "
-"számítása és egyéb szolgáltatások."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Receptek tallózása"
@@ -4048,7 +3875,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Receptek kiválasztása böngészéssel kategória, konyha, stb. szerint."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Fő"
@@ -4062,38 +3888,6 @@ msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 "Egy varázsló azonos receptek kereséséhez, eltávolításához vagy egyesítéséhez."
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Küldés e-mailben"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Receptek küldése e-mailben a Gourmet programból"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Zip, gzip és tarball támogatás"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Receptek importálása zip és tar archívumokból"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Importáló/Exportáló"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4103,6 +3897,18 @@ msgstr "PDF exportálás"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Receptweblapok létrehozása a receptekből."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Importáló/Exportáló"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4115,14 +3921,6 @@ msgid ""
 msgstr ""
 "Receptek importálása és exportálása Gourmet XML fájlként, amely megfelelő "
 "biztonsági mentéshez vagy más Gourmet felhasználóval való adatcseréhez."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "HTML exportálás"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Receptweblapok létrehozása a receptekből."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4184,22 +3982,6 @@ msgid ""
 msgstr ""
 "Segítség a felhasználói jelöléshez és egyszerű szöveg importálása. Továbbá "
 "egyszerű szöveges exportálást biztosít."
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Weboldal importálás"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Receptek importálása a webről."
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Weboldal importálók"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Importálók az about.com, www.foodnetwork.com és egyéb oldalakhoz"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4269,6 +4051,196 @@ msgstr ""
 "importálva a Gourmet programba. Tiltsa le, ha sohasem használt UTF-16 "
 "kódolást és állandóan zavarja a „Kódolás” párbeszédablak, amikor fájlokat "
 "importál."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "A kijelölt recept küldése e-mailben"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "Recept küldése _e-mailben"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (segítség az átíráshoz Windowsra)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows telepitő)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (mértékegység átváltó felület javítása)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (a Mealmaster exportálás továbbfejlesztése)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logó és indítóképernyő)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (tápanyag és a hozzáadás a bevásárlólistához ikonok)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (a nemzetköziesítés "
+#~ "továbbfejlesztése, válogatott hibajavítások)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (a Windows verzió karbantartása és a "
+#~ "weboldal kinézetének átalakítása)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Adatbázis frissítése"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Az adatbázis méretétől függően ez hosszú folyamat lehet és eltarthat egy "
+#~ "ideig. Az adatai automatikusan mentésre kerültek arra az esetre, ha "
+#~ "valami rosszul sikerülne."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Hozzávalók beillesztése"
+
+#~ msgid "Import from file"
+#~ msgstr "Importálás fájlból"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Válassza ki a hozzávalólistát tartalmazó fájlt."
+
+#~ msgid "No file selected"
+#~ msgstr "Nincs fájl kiválasztva"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Nincs kiválasztott fájl, ezért a művelet megszakadt"
+
+#~ msgid "_Import file"
+#~ msgstr "Fájl _importálása"
+
+#~ msgid "Import _webpage"
+#~ msgstr "_Weboldal importálása"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Recept importálása weboldalról"
+
+#~ msgid "Open _Trash"
+#~ msgstr "_Kuka megnyitása"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Archívum (zip, tarball)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Zip archívum betöltése"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Zip archívum kibontása"
+
+#~ msgid "Webpage"
+#~ msgstr "Weboldal"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "%s letöltése"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Bevásárlólista ehhez: %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "%s lekérése"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Fájl letöltése"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Adja meg a receptarchívum vagy recept weboldal URL-jét."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Adja meg az URL-t:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Nem lehetséges az URL importálása"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr ""
+#~ "A Gourmet programnak nincs olyan bővítménye, amely alkalmas URL "
+#~ "importálására"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Nem lehet importálni a(z) %(type)s MIME-típusú %(url)s URL-t. A fájl az "
+#~ "átmeneti %(fn)s helyre lett elmentve."
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Ne ismerje fel ezt a weboldalt. Általános importáló használata…"
+
+#~ msgid "Import complete."
+#~ msgstr "Importálás kész."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Recept importálása"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Hozzávalók feldolgozása"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Hozzávalók feldolgozása."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML fájl"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet receptkezelő"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Receptek rendezése, bevásárlólisták készítése, tápérték-információk "
+#~ "számítása és egyéb szolgáltatások."
+
+#~ msgid "Send to Email"
+#~ msgstr "Küldés e-mailben"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Receptek küldése e-mailben a Gourmet programból"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Zip, gzip és tarball támogatás"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Receptek importálása zip és tar archívumokból"
+
+#~ msgid "HTML Export"
+#~ msgstr "HTML exportálás"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Receptweblapok létrehozása a receptekből."
+
+#~ msgid "Webpage import"
+#~ msgstr "Weboldal importálás"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Receptek importálása a webről."
+
+#~ msgid "Website Importers"
+#~ msgstr "Weboldal importálók"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Importálók az about.com, www.foodnetwork.com és egyéb oldalakhoz"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4397,9 +4369,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "_Adag"
-
-#~ msgid "Select File_type"
-#~ msgstr "Fájl_típus kiválasztása"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Már létezik %s nevű fájl."

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-17 20:30+0000\n"
 "Last-Translator: reza <edja_kun@yahoo.co.uk>\n"
 "Language-Team: Indonesian <id@li.org>\n"
@@ -19,506 +19,509 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "Resep _baru"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Tambah ke _Shopping List"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gourmet Recipe Manager"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Daftar Belanja"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Hapus resep-resep yang dipilh"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "%s resep"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -526,31 +529,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -559,285 +562,287 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "timer"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet Recipe Manager"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -852,639 +857,591 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Resep baru"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Sudah punya(barang_Pantry)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Masukkan kategori"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Kategori untuk menambah %s ke"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategori:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Resep"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Tidak ada resep yang dipilih. Anda ingin membersihkan seluruh daftar?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Cetak Resep"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Tambah ke _Shopping List"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Anda tidak menyimpan perubahan"
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Opsional)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Sunting Resep:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Pilih berkas yang berisi daftar bahan dasar anda:"
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "dikonversi: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Tidak dikonversi: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Ubah unit"
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Tidak dapat mengkonversi dari %(old_unit)s ke %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Menambahkan grup bahan dasar"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Resep-resep"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "hentikan _timer"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "atau"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Sumber"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Waktu persiapan"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Waktu memasak"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Modifikasi"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Input tidak valid."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Bukan nomor"
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Apakah anda yakin untuk melakukan ini"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "Bagus sekali"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "Hebat"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Tidak ada berkas yang dipilih"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Pilih tipe_berkas"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Tidak ada file yang dipilih, maka aksi dibatalkan"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1493,12 +1450,12 @@ msgstr ""
 "Maafkan saya, Saya tidak mengerti\n"
 "Jumlah \"%s\""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1510,446 +1467,429 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "Tepung, untuk apa saja"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "gula"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "garam"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Resep Menyebut dirinya sebagai bahan dasar"
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Bahan dasar %s akan diacuhkan"
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Mengimpor resep"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Impor di-pause"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Hentikan impor"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  reza https://launchpad.net/~edja-kun"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Tersimpan!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Sumpan suntingan anda ke %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Impor dalam proses"
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Expor dalam proses"
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Penghapusan dalam proses"
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Keluar program?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Jangan Keluar!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Resep yang takdihapus "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multplikasikan %s dengan:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Hapus resep-resep yang dipilh"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "Lihat resep"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Mengimpor resep"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s resep"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Apakah anda yakin ingin menghapus %s resep yang dipilih?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Lihat resep"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Resep-resep"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Hapus resep %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Mengimpor..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "barang"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Bagian"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Nilai"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Hitung"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Ubah semua kunci \"%s\" ke \"%s\":"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1960,12 +1900,12 @@ msgstr ""
 "kunci \"%s\", anda tidak akan dapat membedakan antara barang-barang tersebut "
 "dan Barang-barang yang anda ubah sekarang."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Ubah semua barang \"%s\" ke \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1976,78 +1916,78 @@ msgstr ""
 "barang \"%s\", anda tidak akan dapat membedakan antara barang-barang "
 "tersebut dan Barang-barang yang anda ubah sekarang."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Ubah semua instansi dari \"%(unit)s\" ke \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2055,387 +1995,375 @@ msgstr[0] "%s bahan dasar"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Jumlah"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Kategori belanja"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Membutuhkan informasi yang detail."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Memuat arsip zip"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "halaman Web HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Mengimpor resep"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Ekspor teks"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2443,81 +2371,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Medapatkan kembali %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "berkas Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Ekspor Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Impor Mastercook selesai"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2526,516 +2427,536 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Cetak resep"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Ekspor PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "berkas MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "Pelayanan"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Ekspor PDF"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "ada Grup makanan"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
+"Untuk mengapikasikan informasi nutrisional, Gourmet membutuhkan sebuah "
+"jumlah yang valid dan unit"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Ubah unit"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Untuk mengapikasikan informasi nutrisional, Gourmet membutuhkan sebuah "
 "jumlah yang valid dan unit"
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gram"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalori"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Lemak Total"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Protein"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alpha-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Debu"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Kalsium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Tembaga"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Total Folat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Asam Folic"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Food Folate"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamin A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selenium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Thiamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamin A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamin A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamin C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "SEng"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamin dan mineral"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _nilai harian"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3044,367 +2965,367 @@ msgstr ""
 "Persentase dari nilai harian yang direkomendasikan berdasarkan pada %i "
 "kalori per hari. Klik untuk menyunting jumlah kalori per hari"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Jumlah per resep"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "impor Basis data nutrisional selesai!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Mengambil basis sata nutrisional dari arsip zip %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g fiber"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g gula"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "g kalsium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg besi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg potassium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg sodium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg seng"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg tembaga"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "mikrogram Food Folate"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mikrogram Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamin A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "mikrogram Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "mikrogram Alpha-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "mikrogram Beta-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Rempah-rempah dan herbal"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Makanan bayi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Lemak dan minyak"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Poultry"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Sup dan Saus"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Sosis dan Daging"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Sereal sarapan"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Buah dan jus buah"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Babi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Makanan cepat saji"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Makanan ringan"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Makanan Etnis"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3418,287 +3339,243 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Simpan resep sebagai..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Cetak resep %s"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Medapatkan kembali berkas"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Masukkan URL dari sebuah arsip resep atau website resep"
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Masukkan URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Masukkan URL dari sebuah arsip resep atau website resep"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Modifikasi"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "semua Berkas-berkas yang dapat diimpor"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Impor selesai."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Mengimpor resep"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Memproses bahan-bahan dasar"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Pelayanan"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "Judul"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "Catatan"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3706,102 +3583,96 @@ msgstr[0] "%s resep"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "Jam."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3810,7 +3681,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3822,71 +3693,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "untuk"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "berkas Gourmet XML"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet Recipe Manager"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3896,7 +3726,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3909,38 +3738,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -3948,6 +3745,18 @@ msgstr "Ekspor PDF"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3958,14 +3767,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4019,22 +3820,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4094,6 +3879,45 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Pilih berkas yang berisi daftar bahan dasar anda:"
+
+#~ msgid "No file selected"
+#~ msgstr "Tidak ada berkas yang dipilih"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Tidak ada file yang dipilih, maka aksi dibatalkan"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Memuat arsip zip"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Medapatkan kembali %s"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Medapatkan kembali berkas"
+
+#~ msgid "Enter URL:"
+#~ msgstr "Masukkan URL:"
+
+#~ msgid "Import complete."
+#~ msgstr "Impor selesai."
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Memproses bahan-bahan dasar"
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "berkas Gourmet XML"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet Recipe Manager"
+
 #~ msgid "Unable to open URL"
 #~ msgstr "Tidak dapat membuka URL"
 
@@ -4111,9 +3935,6 @@ msgstr ""
 
 #~ msgid "Time must be expressed in hours, minutes, seconds, etc."
 #~ msgstr "Waktu harus diekspresikan dalam jam, menit, detik, dll."
-
-#~ msgid "Select File_type"
-#~ msgstr "Pilih tipe_berkas"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Sebuah file bernama %s sudah ada."

--- a/po/is.po
+++ b/po/is.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-06 19:29+0000\n"
 "Last-Translator: Salvör <salvor@gmail.com>\n"
 "Language-Team: Icelandic <is@li.org>\n"
@@ -20,506 +20,506 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+msgid "Copy selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +527,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +560,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,650 +854,601 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 msgid "Add to Shopping List"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1508,444 +1460,424 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Salvör https://launchpad.net/~salvor"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+msgid "_Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1953,12 +1885,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1966,78 +1898,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2046,386 +1978,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2433,81 +2353,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2516,880 +2409,897 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3403,288 +3313,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3693,103 +3557,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3798,7 +3656,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3810,69 +3668,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3882,7 +3701,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3895,44 +3713,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3943,14 +3741,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4004,22 +3794,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-08-19 17:24+0000\n"
 "Last-Translator: Gianfranco Frisani <gfrisani@libero.it>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -20,64 +20,64 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Indice delle ricette"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nuova ricetta"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Aggiungi alla Lista della _Spesa"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Visualizza Ri_cetta"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "C_erca:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Ricerca delle ricette durante la digitazione"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_in"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Cerca con un altro parametro nei risultati correnti"
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Aggiungi criteri _di ricerca"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Limita la ricerca a:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "_Risultati della ricerca"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Imposta i Campi per le Ricette Selezionate"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -85,129 +85,132 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Imposta i Campi per le ricette "
 "selezionate</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Aggiungi immagine"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Rimuovi Immagine"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "S_orgente:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Giudizio:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "C_ucina:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Categoria:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "Tempo di _Preparazione"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Tempi di cottura:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "Pagina _Web:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Immagine:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Quantità:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Unità di misura"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "Imposta valori solo dove i campi sono vuoti"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Imposta tutti i valori per tutte le ricette selezionate"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (predefinito, salvato su file locale)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (salvato su file locale)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (richiede una connessione al database)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Scegli Database"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Scegli il Tipo di Database da usare in Gourmet</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "Tipo di _Database"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Host:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "Nome _Utente:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Password:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Password per il tuo nome utente sul database."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "_Nome Database:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_File"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -215,11 +218,11 @@ msgstr ""
 "Nome dell'host del sistema dove è in esecuzione il server del database. Se "
 "il server è in esecuzione in locale, usa \"localhost\"."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -227,11 +230,11 @@ msgstr ""
 "Ricorda la password. Questo significa che la password sarà salvata in chiaro "
 "nel tuo file di configurazione."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "_Salva Password"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -239,300 +242,301 @@ msgstr ""
 "Nome del database dove Gourmet salverà le informazioni. Gourmet proverà a "
 "crearlo se non esiste."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "ricetta"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Nome utente sul database."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Sfoglia"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Dettagli"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Preferenze del Gestore di Ricette Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Preferenze di Visualizzazione dell'Indice</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Mostra _Opzioni"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Ricette per pagina:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr "<i>Imposta le colonne visibili nalla vista a indice delle ricette.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Vista a Indice"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Preferenze di Visualizzazione della Scheda</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "Moltiplic_ando permetti il cambio di unità"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Usa frazioni"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Usa frazioni quando possibile per le quantità"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 "<i>Rimuovi elementi non usati nell'interfaccia a Scheda delle Ricette.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Vista a Scheda"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Preferenze della Lista della spesa</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Cosa deve farne Gourmet degli ingredienti Opzionali quando si aggiungono "
 "ricette alla lista della spesa?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "Chiedi se includere ingredienti opzionali"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "_Ricorda le scelte dell'utente in maniera predefinita"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "Pulis_ci gli ingredienti opzionali memorizzati"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "_Aggiungi sempre gli ingredienti opzionali"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Non aggiungere mai ingredienti opzionali"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Lista della Spesa"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "porzioni"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Titolo"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Titolo:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Tempo di Pre_parazione:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "categoria"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "giudizio"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Quantità"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Unità di misura"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Spesa"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Modifica _descrizione"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Tempo di cottura:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Tempo di preparazione:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Cucina:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Categoria:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Pagina Web:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Quantità:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Collegamento</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Sorgente:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Giudizio:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>Fattore di _moltiplicazione:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Procedimento</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Modifica proced_imento"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Note</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Modifica _note"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Ricetta"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Ingredienti</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Modifica _ingredienti"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Aggiungi _ingrediente:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredienti"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Aggiungi ricetta alla lista della spesa"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Aggiungi alla lista della _spesa"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Vai alla ricetta nella vista a Scheda"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Cancella ricetta selezionata"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "Eliminazione _della ricetta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Modifica le caratteristiche delle ricette selezionate"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "Modifica in batch le ricette"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Invia ricetta selezionata per e-mail"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Apri la ricetta selezionata"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "Invia ricetta via _e-mail"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Scegli ricetta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Stampa la ricetta selezionata"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "Stam_pa ricetta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -544,31 +548,31 @@ msgstr ""
 "fatto che serve, ma non verrà incluso quando si salverà e/o stamperà la "
 "lista a meno che non venga specificato il bisogno di acquistarlo."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Aggiungi alla dis_pensa"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Mostra _Opzioni"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Cerca _in"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "_Usa espressioni regolari (ricerca avanzata)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Cerca quando si digi_ta qualcosa"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Opzioni di ricerca</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Categoria"
 
@@ -577,291 +581,293 @@ msgstr "Categoria"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Chiave"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Editor delle Categorie"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Cerca per"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Cerca quando si digita qualcosa"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Usa espressioni regolari"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Ricerca avanzata"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Aggiungi categoria: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Timer"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Tempo</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Tempo terminato!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Il timer continuerà a scorrere a meno che questa finestra di dialogo non "
 "venga chiusa o il timer venga azzerato."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Imposta _Timer: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Azzera"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Avvia"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "Su_ono"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Note"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Ri_petere l'allarme finché non lo spengo"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Impostazioni"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Modifica i campi in tutto il database</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Campo da Modificar_e:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Per ogni valore selezionato:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "_Lascia valore così com'è"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>Il nuovo valore verrà inserito alla fine del testo esistente</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Il nuovo valore rimpiazzerà quello esistente</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Campo:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Valore:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Cambia altr_o campo:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "Modifica valore in: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "Elimina valore"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Seleziona equivalente di</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>dal database USDA</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "_Modifica ingrediente"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>o</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "_Cerca Database Ingredienti USDA:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Cerca quando di digita qualcosa"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Visualizza solo il cibo in _group"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Cerca_risultati:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>Da:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Ammontare:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Unità:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "unità"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "_Modifica unità di misura"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "_Salva unità di misura"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>A:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Unità:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Inserisci informazioni nutrizionali</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Scegli una Densità</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Ingrediente Chiave:</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "elemento USDA:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "Edita associazione _USDA"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Informazioni nutrizionali</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "Modifica _informazione"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "_Informazioni Nutrizionali"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Densità:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "USDA equivalente"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Usi equivalenti:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "_Densità Informazioni"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Informazioni Nutrizionali Conosciute</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "Ricerca _Avanzata"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Informazioni Nutrizionali"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "I_gnora"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet - Gestore ricette"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Copyright (c) 2004,2005,2006,2007,2008,2009,2010,2011 Thomas M. Hinkle. GNU "
 "GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -885,215 +891,168 @@ msgstr ""
 "alle ricette. Gourmet permette anche di calcolare i fattori nutrizionali per "
 "le ricette, sulla base degli ingredienti."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (assistenza in porting su Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (installatore Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (migliorie all'interfaccia di Unit Converter)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (migliorie all'esportazione Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo e schermata d'avvio)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (icone nutrizione ed aggiungi-alla-lista-della-spesa)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (miglioramenti "
-"all'internazionalizzazione, correzioni varie)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Manutenzione della versione per windows "
-"e re-progettazzione sito web)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Scegli il Database"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Aggiornamento database in corso"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Nuova ricetta"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "_Nome Database:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"A seconda della dimensione del tuo database, questo potrebbe essere un "
-"processo lungo e richiedere del tempo. E' stato effettuato automaticamente "
-"un back-up dei tuoi dati nel caso in cui qualcosa andasse storto."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Dettagli"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Un backup è stato fatto in %s nel caso qualcosa vada storto. Se questo "
 "aggiornamento fallisce potrai rinominare manualmente il file di backup "
 "recipes.db per recuperarlo ed usarlo con la vecchia versione di Gourmet."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Nuova ricetta"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Cambia _Categoria"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Crea nuova categoria"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Cambia la categoria dell'articolo selezionato"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Dispensa"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Muovi alla Lista della _Spesa"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Muovi in _dispensa"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Rimuovi dalla lista della spesa"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Muovi gli oggetti selezionati in %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Lista della _Spesa"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Già Presenti (Oggetti _Dispensa)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Inserisci la Categoria"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Categoria a cui aggiungere %s"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Categoria:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Ricette"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Aggiungi oggetti"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Rimuovi Ricette"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Rimuovi le ricette dalla lista della spesa"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Modifica"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Aiuto"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Aggiungi oggetti"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Aggiungi oggetti a tua scelta alla lista della spesa"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "X"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Nessuna ricetta selezionata. Vuoi cancellare l'intera lista?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Salva la lista della spesa come..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Seleziona ingredienti opzionali"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1102,57 +1061,59 @@ msgstr ""
 "lista della spesa."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Ricetta"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "Vai"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Esporta ricetta"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Esporta ricetta selezionata (salva su file)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Cancella ricetta"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Cancella questa ricetta"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Converti automaticamente le unità durante le moltiplicazioni"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Cambia le unità per renderle più leggibili (dove possibile) mentre "
 "moltiplichi."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Stampa Ricetta"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Aggiungi alla Lista della _Spesa"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Dimentica gli ingrendienti opzionali ricordati"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1161,150 +1122,144 @@ msgstr ""
 "ingredienti opzionali, anche quelli che volevi precedentemente che fossero "
 "ricordati"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Esporta Ricetta"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Non hai salvato le modifiche."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Applicare le variazioni prima di stampare?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Applicare le variazioni prima di stampare?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Opzionale)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Impossibile trovare la ricetta %s nel database."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Modifica Ricetta:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Salva le modifiche nel database"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Mostra Scheda Ricetta"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Modifica"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Salva cambiamenti in %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Aggiungi ingrediente"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Aggiungi gruppo"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Incolla ingredienti"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importa da file"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Aggiungi _ricetta"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Aggiungi un'altra ricetta come un ingrediente in questa ricetta"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Elimina"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Su"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Giù"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Seleziona un file contenente la tua lista ingredienti."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Descrizione"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Procedimento"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Note"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Qta"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Unità"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Articolo"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Opzionale"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "La ricetta %s (ID %s) non e` presente nel database."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Convertito: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Non Convertito: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Unità cambiata"
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1313,232 +1268,231 @@ msgstr ""
 "Hai cambiato l'unità per %(item)s da %(old)s a %(new)s. Vuoi che la quantità "
 "sia convertita oppure no?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Convertito %(old_amt)s %(old_unit)s in %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Impossibile convertire da %(old_unit)s a %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Aggiungi gruppo di ingredienti"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Inserisci un nome per il nuovo sottogruppo di ingredienti"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Nome del gruppo:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Scegli ricetta"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Il nome della ricetta non puo' essere quello di un ingrediente!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "La ricorsione infinita non e' ammessa nelle ricette!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Non hai selezionato alcuna ricetta!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Quanti %(title)s richiama la tua ricetta?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Ricette"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Suono Campanello"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Suono Allarme"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Suono errore"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Fermare il timer?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Arresta il _timer"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "Prosegui il _conteggio"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Aggiungi Plugins extra a Gourmet."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Un plugin è richiesto per altri plugin. Vuoi disattivare comunque il plugin?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Il seguente plugin richiede %s"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Disattiva comunque"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Mantieni attivo il plugin"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "o"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Si è verificato un errore nell'attivazione del plugin"
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Si è verificato un errore nella disattivazione del plugin."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Cucina"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Giudizio"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Fonte"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Sito web"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Tempo di preparazione"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Tempo di cottura"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Modifiche"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Input non valido"
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Non un numero."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pausa"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stop"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Non chiedermelo più."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Vuoi realmente farlo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "eccellente"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "ottimo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "buono"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "giusto"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "scarso"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Converti Valutazioni in una scala di 5 stelle"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Converti valutazioni"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Dai ad ogni valutazione una equivalente su una scala di 1 - 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Valutazione Corrente"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Valuta su 5 stelle"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Nessun file selezionato"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Seleziona il _tipo di File"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Nessun file è stato selezionato. Azione cancellata"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1547,14 +1501,14 @@ msgstr ""
 "Mi spiace, non capisco \n"
 "la quantità \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Le quantità devono essere numeri (frazioni o decimali), intervalli di "
 "numeri, o vuote."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1574,86 +1528,86 @@ msgstr ""
 "Per inserire un intervallo di numeri, usa un \"-\" per separarli.\n"
 "Per esempio, potresti inserire 2-4 oppure 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "Nome _Utente:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Password:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "farina, comune"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "zucchero"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sale"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "pepe nero, macinato"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "ghiaccio"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "acqua"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "olio, vegetale"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "olio, d'oliva"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "La ricetta fa riferimento a se stessa come ingrediente."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "L'ingrediente %s verrà ignorato."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Lista della spesa per %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Per le seguenti ricette:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Per le seguenti ricette:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Seleziona codifica"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1661,29 +1615,28 @@ msgstr ""
 "Non riesco a determinare la codifica esatta. Per cortesia seleziona la "
 "corretta codifica dalla seguente lista."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Vedi _file con codifica"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importazione in pausa"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Interrompi importazione"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Indice ricette"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Lista della spesa"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "translator-credits\n"
@@ -1734,335 +1687,322 @@ msgstr ""
 "  sinus_asperitatis https://launchpad.net/~sinus-asperitatis\n"
 "  stefanomasini https://launchpad.net/~stefano-stefanomasini"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Salvato!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Salva le modifiche a %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Un importazione è in corso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Un esportazione è in corso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Una cancellazione è in corso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Uscire ugualmente?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Non uscire!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "%s di %s ricette eliminate definitivamente"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Cestino"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Naviga, cancella definitivamente o recupera ricette cancellate"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Ricette recuperate "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Numero di %(unit)s di %(title)s da acquistare"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Moltiplica %s per:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Impostare %(attributes)s per %(num)s ricetta selezionata?"
 msgstr[1] "Impostare %(attributes)s per %(num)s ricette selezionate?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "I valori preesistenti non saranno modificati."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "I nuovi valori sovrascriveranno quelli preesistenti."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Questa modifica non può essere annullata."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Imposta i valori per le ricette selezionate"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Cerca ricette"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Apri ricetta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Apri la ricetta selezionata"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Elimina ricetta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Elimina ricette selezionate"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Modifica ricetta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Apri la ricetta selezionata nel visualizzatore ricette"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_sporta le ricette selezionate"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Esporta le ricette selezionate su file"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Stampa"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "ricette"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Modifica più ricette"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nuova"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Importa file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Importa ricetta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Importa ricetta da file"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Importa _pagina web"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s ricetta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Importa ricetta da pagina web"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Esporta _tutte le ricette"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Esporta tutte le ricette su file"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Esci"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Azioni"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Apri il _Cestino"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Cestino"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Preferenze"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Plugin"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Gestisci i plugin che aggiungono funzionalità extra a Gourmet."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Opzi_oni"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "Informazioni su"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Strumenti"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Timer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Mostra timer"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Indice per la ricerca delle ricette nel database"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Cancellare %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Hai dei cambiamenti non salvati in %s. Cancellare ugualmente?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Cancellato"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Senza nome"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Cancello definitivamente le ricette?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Cancello definitivamente le ricette?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Sei sicuro di voler cancellare la ricetta <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Sei sicuro di voler cancellare queste ricette?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Sei sicuro di voler cancellare le %s ricette selezionate?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Vedi ricette"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Elimina Ricette"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Indice delle ricette"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Ricetta cancellata %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Fatto!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importazione in corso ..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Editor per _Chiave Ingrediente"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Modifica categorie in blocco"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "chiave"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "articolo"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Campo"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Valore"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Numero"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Cambiare tutte le chiavi \"%s\" in \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2073,12 +2013,12 @@ msgstr ""
 "con la chiave \"%s\", non sarà possibile distinguere questi ingredienti da "
 "quelli che state per modificare."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Cambiare tutti gli articoli \"%s\" in \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2089,12 +2029,12 @@ msgstr ""
 "con la voce \"%s\", non sarà possibile distinguere questi ingredienti da "
 "quelli che state per modificare."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Cambi_a tutte le occorrenze di \"%(unit)s\" in \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2103,13 +2043,13 @@ msgstr ""
 "Cambia \"%(unit)s\" in \"%(text)s\" solo per gli _ingredienti \"%(item)s\" "
 "con chiave \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Cambi_a tutte le occorrenze di \"%(amount)s\" %(unit)s in %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2118,7 +2058,7 @@ msgstr ""
 "Cambia \"%(amount)s\" %(unit)s in \"%(text)s\" %(unit)s solo _dove la chiave "
 "ingrediente è %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2127,11 +2067,11 @@ msgstr ""
 "Cambia \"%(amount)s\" %(unit)s in \"%(text)s\" %(unit)s solo dove la chi_ave "
 "ingrediente è %(key)s e dove l'oggetto è %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Modificare tutte le righe selezionate?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2140,7 +2080,7 @@ msgstr ""
 "Questa operazione non può essere annullata. Stai per impostare i seguenti "
 "valori per tutte le %s righe selezionate:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2149,7 +2089,7 @@ msgstr ""
 "\n"
 "Chiave in %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2158,7 +2098,7 @@ msgstr ""
 "\n"
 "Articolo in %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2167,7 +2107,7 @@ msgstr ""
 "\n"
 "Unità in %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2176,8 +2116,8 @@ msgstr ""
 "\n"
 "Valori in %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2186,23 +2126,23 @@ msgstr[1] "%s ingredienti"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Visualizzazione ingredienti %(bottom)s a %(top)s di %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Ammontare"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Ingredienti chiave"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2210,11 +2150,11 @@ msgstr ""
 "Gli ingredienti chiave sono nomi di ingredienti normalizzati per la lista "
 "della spesa e per i calcoli."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Categorie automatiche"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2222,56 +2162,56 @@ msgstr ""
 "Intuisci i valori migliori per tutte le chiavi di ingredienti basandoti sui "
 "valori che sono già nel tuo database"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Modifica le associazioni di chiave"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Modifica le associazioni con la chiave e altri attributi nel database"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Editor delle Chiavi"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "Elemento:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Chiave:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>_Modifica ingrediente selezionato</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Categoria di spesa"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Mostra le unità come scritte per ogni ricetta (nessun cambiamento)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Mostra sempre unità U.S."
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Mostra sempre unità metriche"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Regola automaticamente le unità di misura"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Seleziona _unità di misura visualizzate"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2279,42 +2219,42 @@ msgstr ""
 "Converti automaticamente le unità al sistema preferito (metrico, imperiale, "
 "etc.) dove possibile."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Stelle"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s fà"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Unisci automaticamente le ricette"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Usa sempre la ricetta più recente"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Usa sempre la ricetta più vecchia"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Nulla"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2322,97 +2262,97 @@ msgstr ""
 "Alcune delle ricette importate sembrano essere doppioni. Puoi unirle qui, o "
 "chiudere questa finestra di dialogo per lasciarle come sono."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Trova ricette _doppioni"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Trova e rimuovi ricette doppioni"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Ricette con informazioni simili"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Ricette con ingredienti simili"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Ricette con ingredienti e informazioni simili"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Duplica le ricette</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "_Inserisci le ricette nel cestino"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Mostra:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Unisci tutti _i doppioni"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Unisci le ricette</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "_Unione automatica"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Per ogni valore selezionato"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Dove %(field)s sono %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "La modifica avrà effetto su %s ricetta"
 msgstr[1] "La modifica avrà effetto su %s ricette"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Vuoi cancellare %s dove è %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Vuoi cambiare %s da %s a %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Questo cambiamento non è reversibile.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Modifica i campi"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Modifica i campi per più di una ricetta alla volta."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Manda ricette via e-mail"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Manda tutte le ricette selezionate via e-mail (o tutte le ricette se non è "
@@ -2421,162 +2361,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Vuoi davvero inviare %s ricette selezionate?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Si, mandale via e-mail"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Non posso convertire %s a %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Mancano informazioni"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Convertitore"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Calcola le conversioni di unità"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Convertitore di unità"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Da</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "Elemento:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Densità:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Valor_i di densità"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>A</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Risultato:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Archivio (zip, tarball)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Carcamento archivio zip"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Unzipping archivio zip"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "Pagina WEB HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Esportazione pagina web"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Esportazione ricette su file HTML nella directory %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Ricette salvate in formato HTML su file %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Pagina originale da %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "opzionale"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Esportazione pagina web"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Esportazione ricette su file HTML nella directory %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Ricette salvate in formato HTML su file %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "File di testo normale"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Esporta testo"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Esporta le ricette sul file di testo %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Ricetta salvata come file di testo semplice %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "File Grande"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Il file %s è troppo grande per essere importato"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2588,81 +2516,54 @@ msgstr ""
 "questo file, usa un editor di testo per dividerlo in file più piccoli e "
 "prova ad importare nuovamente."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Pagina web"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Download di %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Lista della spesa per %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Ricezione %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML File"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet esportazione XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Espostazione ricette su file tipo Gourmet XML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Ricette salvate in formato Gourmet XML su file %(file)s"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML File (Obsoleto)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML File"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook Text File"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Importazione Mastercook terminata"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Pulizia XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML File"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2671,275 +2572,296 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Aspetto pagina"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Stampa ricette"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Esporta in PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Esportazione ricette nei file PDF %(file)s in corso..."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Ricetta salvata come PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Lettera"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Orientamento verticale"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Normale"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "punti"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "27,9x43,1 cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Scheda (8,9x12,7 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Scheda (10,2X15,2 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Scheda (12,7x20,3 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Scheda (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Lettera"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legale"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Schede (8,9x12,7 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Schede (10,2X15,2 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Schede (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Orientamento orizzontale"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Normale"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Colonna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Colonna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Colonna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Colonna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s Colonna"
 msgstr[1] "%s Colonne"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Orientamento verticale"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Orientamento orizzontale"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "_Dimensione Foglio"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientamento"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Dimensione carattere"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "_Layout della pagina"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Dimensione carattere"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Margine sinistro"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Margine destro"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Margine superiore"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Margine inferiore"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "Opzioni PDF"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "File tipo MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Esportazione MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Esportazione ricette in formato MealMaster su file %(file)s"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Ricetta salvata in formato MealMaster su file %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "porzione"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "File Grande"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Esporta HTML"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Espostazione ricette su file tipo Gourmet XML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Ricette salvate in formato Gourmet XML su file %(file)s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Salva la Lista della Spesa"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Salva Lista come Ricetta"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Salva la lista della spesa corrente come una ricetta per riutilizzarla"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Menu per %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Le informazioni nutrizionali riflettono l'ammontare per %s"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 "Le informazioni nutrizionali riflettono l'ammontare per l'intera ricetta"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Manca l'informazione nutrizionale per %s ingredienti: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Qualsiasi gruppo di alimenti"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "selezione"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Converti l'unità per %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Per poter calcolare le informazioni nutrizionali, Gourmet ha bisogno di un "
 "aiuto epr convertire \"%s\" in una unità di misura riconosicuta."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Cambia ingrediente chiave"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2948,27 +2870,27 @@ msgstr ""
 "Cambio la chiave ingredienti da %(old_key)s a %(new_key)s dappertutto o solo "
 "nella ricetta %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Cambia tutto"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Solo nella ricetta %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Cambia categoria da %(old_key)s a %(new_key)s ovunque?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Modifica unità"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2977,11 +2899,11 @@ msgstr ""
 "Cambio l'unità di misura %(old_unit)s in %(new_unit)s in tutti gli "
 "ingredienti %(ingkey)s o solo nella ricetta %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2991,198 +2913,199 @@ msgstr ""
 "densità differenti. Si prega di scegliere la voce corretta fra quelle sotto "
 "elencate."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Per poter applicare le informazioni nutrizionali, Gourmet necessita di "
 "valori e unità corretti."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Nutrizione"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingredienti"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Equivalente Database USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 grammi"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Calorie"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Grassi Totali"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Grasso saturo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Colesterolo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sodio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Carboidrati totali"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Fibre"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Zuccheri"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteine"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Cenere"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta Criptoxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Calcio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Rame"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Folati Totali"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Acido folico"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Folati"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Folati equivalenti"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Ferro"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Licopene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Luteina+Zeaxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnesio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Manganese"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Acido pantotenico"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosforo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potassio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamina A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinolo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selenio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamina A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamina A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zinco"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamine e minerali"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3191,11 +3114,11 @@ msgstr ""
 "Informazioni nutrizionali mancanti\n"
 "per %(missing)s su %(total)s ingredienti."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Valore Giornaliero"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3204,368 +3127,368 @@ msgstr ""
 "Percentuale del valore giornaliero raccomandato in base alle %i calorie "
 "giornaliere. Clicca per modificare il valore delle calorie giornaliere."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Importo per %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Quantità per ricetta."
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Caricamento dei Dati Nutrizionali"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Caricamento del database nutrizionale completato!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Recupero il database nutrizionale dall'archivio zip %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Estrazione di %s dall'archivio zip."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Elaborazione dati nutizionali..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Lettura dei dati nurizionali: importati %s di %s elementi."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Elaborazione dati di peso..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Lettura dati peso degli elementi nutrizionali: importati %s di %s elementi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Acqua"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Chilocalorie"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g proteine"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipidi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g ceneri"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g carboidrati"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g fibre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g glucidi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg calcio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg ferro"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnesio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosforo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg potassio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg sodio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg zinco"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg rame"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg manganese"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "μg selenio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg riboflavina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niacina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg acido pantotenico"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "μg Folati Totali"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "μg acido Folico"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "μg folati"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "μg folati equivalenti"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Choline, totale"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "μg Vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamina A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamina A (equivalente al retinale attivo microgrammo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "μg Retinolo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "μg Alfa-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "μg Beta-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "μg Beta-criptoxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "μg Licopene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "μg Luteina+Zeaxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g Acidi Grassi Saturi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g Acidi Grassi Monoinsaturi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g Acidi Grassi Polinsaturi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Colesterolo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Percentuale rifiutata"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Uova & Latticini"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Spezie ed Erbe Aromatiche"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Alimenti per Bambini"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Grassi ed Oli"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Pollame"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Zuppe e Salse"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Salsiccie e Carni da Pranzo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Cereali per la Colazione"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Frutta e Succhi di Frutta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Maiale"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Verdura"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Frutta Secca e Sementi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Manzo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Bevande"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Pesce e Molluschi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Legumi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Agnello, Vitello e Cacciagione"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Prodotti da Forno"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Dolciumi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Pasta e Legumi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Spuntini"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Secondi, antipasti e contorni"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Snack"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Cucina Etnica"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "tutto il database"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Chiave Ingrediente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "Numero ID secondo USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "Descrizione articolo USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Densità equivalente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA Numero#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3579,59 +3502,59 @@ msgstr "Strumenti"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Ottieni le informazioni nutrizionali per la lista corrente"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Ammontare per Lista della Spesa"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "Modifica_le informazioni nutrizionali"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "stelle"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Esportato %(number)s ricette su %(total)s"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Esportazione completata."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Inserisci ricetta nel testo del messaggio"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Invia ricetta come allegato HTML"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Manda la ricetta via e-mail come Allegato PDF"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Opzini Email"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Non chiedere conferma prima di inviare la mail"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Messaggio non inviato"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3639,235 +3562,189 @@ msgstr ""
 "Non avete selezionato l'invio della ricetta nel testo del messaggio o come "
 "allegato"
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Salva ricetta come ..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet non puo' esportare file di tipo \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Esporta ricette"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "ricette"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Impossibile esportare: tipo di file sconosciuto \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Per favore assicurarsi di selezionare un tipo di file dal menu a discesa "
 "mentre si salva."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Esporta"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Impossibile stampare: non ci sono plugin di stampa attivi!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Stampa %s ricetta"
 msgstr[1] "Stampa %s ricette"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Ricezione file"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "quantità"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Inserisci l'URL di un archivio di ricette o di un sito di ricette."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Inserire l'indirizzo web"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Inserisci l'URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Inserisci l'indirizzo di un sito web o di un archivio di ricette"
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Non è possibile importare l'URL"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet non ha un plugin capace di importare l'URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Impossibile importare %(url)s di tipo MIME %(type)s. File salvato "
-"temporaneamente in %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Apri ricetta..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Inserire l'indirizzo web"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Modifiche"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Inserisci l'indirizzo di un sito web o di un archivio di ricette"
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importa"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Tutti i file importabili"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Importate %s ricette."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "porzione"
 msgstr[1] "porzioni"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Importato %s ricette su %s."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "OK"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Non comprendo questa pagina web. Uso un importatore generico..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Import completato."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Importazione della ricetta"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Elaborazione degli ingredienti"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Elaborazione degli ingredienti."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Porzioni"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Sottogruppo Ingredienti"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Nascondi"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Testo"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Azioni"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importa ricetta"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Pulisci _Etichette"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Importa ricetta"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "ovunque"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "titolo"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrediente"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "Procedimento"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "Note"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "cucina"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "fonte"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Usa espressioni regolari nella ricerca"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Usa espressioni regolari nella ricerca (linguaggio di ricerca avanzato)"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Ricerca mentre digiti (disattivare se la ricerca è troppo lenta)"
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Mostra _Opzioni di Ricerca"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Mostra opzioni di ricerca avanzate"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3876,104 +3753,98 @@ msgstr[1] "%s ricette"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Visualizzazione ricette %(bottom)s a %(top)s di %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s in %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "In pausa"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "Importa da KRecipe"
 msgstr[1] "Importa da KRecipe"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pausa"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Fatto"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Errore: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Errore"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Errore %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Traccia"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "secondo"
 msgstr[1] "secondi"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuto"
 msgstr[1] "minuti"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "h."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ora"
 msgstr[1] "ore"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "giorno"
 msgstr[1] "giorni"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "settimana"
 msgstr[1] "settimane"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mese"
@@ -3982,7 +3853,7 @@ msgstr[1] "mesi"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "anno"
@@ -3994,73 +3865,30 @@ msgstr[1] "anni"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " e "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "e"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "a"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML File"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet - Gestore ricette"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organizza ricette, crea liste della spesa, calcola informazioni nutrizionali "
-"e molto altro ancora"
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Cerca nelle ricette"
@@ -4070,7 +3898,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Seleziona la ricerca per Categoria, Cucina, ecc..."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Principale"
@@ -4083,38 +3910,6 @@ msgstr "Ceca le ricette doppioni"
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr "Una utility cerca e rimuove o unisce le ricette doppioni"
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Invia a Email"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Invia le ricette via email da Gourmet"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Supporto Zip, Gzip, and Tarball"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Importa ricette da un archivio zip o tar"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Importatore/Esportatore"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4124,6 +3919,18 @@ msgstr "Esporta in PDF"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Crea pagina web dalla ricetta"
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Importatore/Esportatore"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4136,14 +3943,6 @@ msgid ""
 msgstr ""
 "Importa ed Esporta le ricette come file XML di Gourmet, adatti per backup o "
 "per lo scambio con altri utenti Gourmet."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "Esporta HTML"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Crea pagina web dalla ricetta"
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4205,22 +4004,6 @@ msgid ""
 msgstr ""
 "Aiuta l'utente ad annotare e importare del testo semplice. Prevede anche "
 "l'esportazione di testo."
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Importa pagina web"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Importa ricette dal web"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Importatori da Sito Web"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Importatori per about.com, foodnetwork.com e altri"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4289,6 +4072,196 @@ msgstr ""
 "modo pulito in Gourmet. Disattivare questa opzione se non si utilizzano mai "
 "l'UTF16 e si è continuamente infastiditi dalla finestra di dialogo "
 "'Codifica' quando si importano i file."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Invia ricetta selezionata per e-mail"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "Invia ricetta via _e-mail"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (assistenza in porting su Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (installatore Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (migliorie all'interfaccia di Unit Converter)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (migliorie all'esportazione Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo e schermata d'avvio)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr ""
+#~ "Yula Zubritsky (icone nutrizione ed aggiungi-alla-lista-della-spesa)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (miglioramenti "
+#~ "all'internazionalizzazione, correzioni varie)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Manutenzione della versione per "
+#~ "windows e re-progettazzione sito web)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Aggiornamento database in corso"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "A seconda della dimensione del tuo database, questo potrebbe essere un "
+#~ "processo lungo e richiedere del tempo. E' stato effettuato "
+#~ "automaticamente un back-up dei tuoi dati nel caso in cui qualcosa andasse "
+#~ "storto."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Incolla ingredienti"
+
+#~ msgid "Import from file"
+#~ msgstr "Importa da file"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Seleziona un file contenente la tua lista ingredienti."
+
+#~ msgid "No file selected"
+#~ msgstr "Nessun file selezionato"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Nessun file è stato selezionato. Azione cancellata"
+
+#~ msgid "_Import file"
+#~ msgstr "_Importa file"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Importa _pagina web"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Importa ricetta da pagina web"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Apri il _Cestino"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Archivio (zip, tarball)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Carcamento archivio zip"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Unzipping archivio zip"
+
+#~ msgid "Webpage"
+#~ msgstr "Pagina web"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Download di %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Lista della spesa per %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Ricezione %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Ricezione file"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Inserisci l'URL di un archivio di ricette o di un sito di ricette."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Inserisci l'URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Non è possibile importare l'URL"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet non ha un plugin capace di importare l'URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Impossibile importare %(url)s di tipo MIME %(type)s. File salvato "
+#~ "temporaneamente in %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Non comprendo questa pagina web. Uso un importatore generico..."
+
+#~ msgid "Import complete."
+#~ msgstr "Import completato."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Importazione della ricetta"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Elaborazione degli ingredienti"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Elaborazione degli ingredienti."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML File"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet - Gestore ricette"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organizza ricette, crea liste della spesa, calcola informazioni "
+#~ "nutrizionali e molto altro ancora"
+
+#~ msgid "Send to Email"
+#~ msgstr "Invia a Email"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Invia le ricette via email da Gourmet"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Supporto Zip, Gzip, and Tarball"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Importa ricette da un archivio zip o tar"
+
+#~ msgid "HTML Export"
+#~ msgstr "Esporta HTML"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Crea pagina web dalla ricetta"
+
+#~ msgid "Webpage import"
+#~ msgstr "Importa pagina web"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Importa ricette dal web"
+
+#~ msgid "Website Importers"
+#~ msgstr "Importatori da Sito Web"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Importatori per about.com, foodnetwork.com e altri"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4423,9 +4396,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "_Porzioni"
-
-#~ msgid "Select File_type"
-#~ msgstr "Seleziona il _tipo di File"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Un file chiamato %s esiste già."

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-06-20 00:33+0000\n"
 "Last-Translator: Vincent Lhote <Unknown>\n"
 "Language-Team: Japanese <ja@li.org>\n"
@@ -19,506 +19,508 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "新しいレシピ(_N)"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "買い物リストに追加(_S)"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "カテゴリ(_C):"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "ホスト(_H):"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "パスワード(_P)："
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "ファイル(_F)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "レシピ"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "詳細(_D)"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "買い物リスト"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "レシピを削除(_D)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "選択された(複数の)レシピを削除"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "レシピ"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -526,31 +528,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -559,285 +561,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "単位"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -852,651 +855,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "買い物リスト(_S)"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "編集(_E)"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "ヘルプ(_H)"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "買い物リストに追加(_S)"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1508,446 +1462,429 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "パスワード(_P)："
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Tetsuya https://launchpad.net/~dr.hornet\n"
 "  Vincent Lhote https://launchpad.net/~vincent.lhote"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "選択された(複数の)レシピを削除"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "印刷"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "レシピ"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "レシピを削除(_D)"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "レシピ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "終了(_Q)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "操作(_A)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "情報(_A)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "ツール(_T)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "タイマ (_T)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1955,12 +1892,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1968,78 +1905,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2048,386 +1985,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "単位変換器(_U)"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2435,81 +2360,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2518,881 +2416,898 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "ファイル(_F)"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3406,288 +3321,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3696,102 +3565,96 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3800,7 +3663,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3812,69 +3675,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3884,7 +3708,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3897,44 +3720,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3945,14 +3748,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4006,22 +3801,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-05-18 10:46+0000\n"
 "Last-Translator: Algimantas Margevičius <Margevicius.Algimantas@gmail.com>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
@@ -15,218 +15,221 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
-"%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Receptų rodyklė"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Naujas receptas"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Įtraukti į Pirkinių _Sąrašą"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Rodyti Re_ceptą"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Ieškoti:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Ieškoti receptų taip kaip jus parašėte"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_į"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Ieškoti pagal naują kriterijų, praleidžiant surastus rezultatus"
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Pri_dėti paieškos kriterijų"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Riboti paiešką iki:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "_R Paieškos rezultatai"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Įdėti nuotrauką"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "Pašalinti Nuot_rauką"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "_o Šaltinis"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "Įve_rtinimas:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Kategorija:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "_Paruošimo Laikas"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Pagaminymo lai_kas"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_WWW puslapis"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Nuotrauka:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Kiekis:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Kiekis vnt."
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (reikia prisijungimo prie duomenų bazės)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Pasirinkti duomenų bazę"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Kompiuteris:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Naudotojo vardas:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Slaptažodis:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Duomenu Bazės _Vardas"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Byla"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "_Išsaugoti slaptažodį"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -234,296 +237,296 @@ msgstr ""
 "Duomenų bazė kurioje Gourmet saugos jūsų informaciją. Gourmet pamėgins "
 "sukurti duomenų bazę, jei ji neegzistuoja."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "receptas"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Jūsų prisijungimo vardas duomenų bazėje"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Naršyti"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detaliau"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Gourmet Receptų Menedžerio Nuostatos"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Receptai per visą puslapį:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Peržiūrėti Pagrindinį puslapį"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Prekių sąrašo nuostatos</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "_Išvalyti  pasirenkamus ingredientus"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "_Visada pridėti pasirenkamus ingredientus"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Niekad nepridėti pasirenkamus ingredientus"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Pirkinių sąrašas"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "porcijos"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Pavadinimas"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Pavadinimas:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategorija"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "įvertinimas"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Kiekis"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Kiekis vnt."
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Parduotuvė"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Redaguoti _aprašymą"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Gaminimo Laikas:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Paruošimo laikas:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Kategorijos:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>WWW puslapis:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Kiekis:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Šaltinis:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Įvertinimas:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Instrukcijos</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Redaguoti _instrukcijas"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Pastabos</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Receptas"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Ingredientai</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Redaguoti _ingredientus"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Pridėti _ingredientą:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredientai"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Pridėti receptą į pirkinių sąrašą"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Pridėti į _pirkinių sarašą"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Ištrinti pažymėtą receptą"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Trinti receptą"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Redaguoti pažymėtų receptų atributus"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Pažymėtą receptą siųsti el. paštu"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Ištrinti pažymėtą receptą"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "receptas"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -531,31 +534,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Paieškos Parametrai</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategorija"
 
@@ -564,285 +567,287 @@ msgstr "Kategorija"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Išplėstinė paieška"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Kiekis:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Vienetas:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gurmanų Receptų Manedžeris"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -857,651 +862,603 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Duomenu Bazės _Vardas"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Pirkinių _sąrašas"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "K_eisti"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Pagalba"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Įtraukti į Pirkinių _Sąrašą"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1513,113 +1470,112 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Naudotojo vardas:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Slaptažodis:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1627,335 +1583,319 @@ msgstr ""
 "  Mariukenas https://launchpad.net/~mariukenas\n"
 "  ebabytux https://launchpad.net/~gimimas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "receptas"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "_Trinti receptą"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "receptas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Veiksmai"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Apie"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "Įran_kiai"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Receptų rodyklė"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1963,12 +1903,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1976,78 +1916,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2056,386 +1996,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Joks"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Vienetų konvertavimas"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Iš</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "Produk_tai:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Į</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Resultatas:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2443,81 +2371,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2526,881 +2427,898 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "porcijos"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Byla"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3414,288 +3332,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3704,104 +3576,98 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3810,7 +3676,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3822,70 +3688,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gurmanų Receptų Manedžeris"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3895,7 +3721,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3908,44 +3733,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3956,14 +3761,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4017,22 +3814,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4091,6 +3872,13 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Pažymėtą receptą siųsti el. paštu"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gurmanų Receptų Manedžeris"
 
 #~ msgid "_Label"
 #~ msgstr "_Pavadinimas"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2010-06-23 08:52+0000\n"
 "Last-Translator: Jelena <Unknown>\n"
 "Language-Team: Latvian <lv@li.org>\n"
@@ -19,506 +19,507 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Pievienot _Iepirkšanās Sarakstam"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Dzēst izvēlētās receptes"
+
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
-
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -526,31 +527,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -559,285 +560,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -852,651 +854,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Pievienot _Iepirkšanās Sarakstam"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1508,445 +1461,425 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Jelena https://launchpad.net/~ilingua\n"
 "  Raivis Dejus https://launchpad.net/~orvils"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Dzēst izvēlētās receptes"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+msgid "_Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1954,12 +1887,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1967,78 +1900,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2047,386 +1980,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2434,81 +2355,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2517,880 +2411,897 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3404,288 +3315,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3694,104 +3559,98 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3800,7 +3659,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3812,69 +3671,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3884,7 +3704,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3897,44 +3716,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3945,14 +3744,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4006,22 +3797,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/mk.po
+++ b/po/mk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2011-10-01 22:43+0000\n"
 "Last-Translator: pyropingvin <pyropingvin@yahoo.com>\n"
 "Language-Team: Macedonian <mk@li.org>\n"
@@ -19,506 +19,507 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:53+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gourmet менаџер на рецепти"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+msgid "Copy selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -526,31 +527,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -559,285 +560,287 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet менаџер на рецепти"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -852,651 +855,603 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Оди"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "шопинг _листа"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Веб-локација"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr ""
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Одберете _тип на датотека"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1508,445 +1463,427 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Увозот на податоци е паузиран"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Индекс на рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "шопинг _листа"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  pyropingvin https://launchpad.net/~pyropingvin"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Зачувано!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Зачувајте ги вашите промени во %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Отпадоци"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Увозот на податоци е паузиран"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr ""
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Отпадоци"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "_Индекс на рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1954,12 +1891,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1967,78 +1904,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2047,386 +1984,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2434,81 +2359,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2517,880 +2415,897 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3404,288 +3319,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3694,103 +3563,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3799,7 +3662,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3811,70 +3674,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet менаџер на рецепти"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3884,7 +3707,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3897,44 +3719,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3945,14 +3747,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4006,22 +3800,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4081,8 +3859,9 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
-#~ msgid "Select File_type"
-#~ msgstr "Одберете _тип на датотека"
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet менаџер на рецепти"
 
 #~ msgid ""
 #~ "Importing recipe data from a previous version of Gourmet into new "

--- a/po/ms.po
+++ b/po/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-13 22:11+0000\n"
 "Last-Translator: Shaiffulnizam Mohamad <Unknown>\n"
 "Language-Team: Malay <ms@li.org>\n"
@@ -19,506 +19,508 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "Resipi _Baru"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Tambah ke _Senarai Pembelian"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Fail"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "resipi"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Keterangan"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Hapus Resipi"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Hapus Resipi yang Dipilih"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "resipi"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -526,31 +528,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -559,285 +561,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -852,651 +855,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Senarai Pembelian"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Edit"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Bantuan"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Tambah ke _Senarai Pembelian"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1508,444 +1462,427 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Shaiffulnizam Mohamad https://launchpad.net/~shaifful-md"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Hapus Resipi yang Dipilih"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Cetak"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "resipi"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "_Hapus Resipi"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "resipi"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Tindakan"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Perihal"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Alatan"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Pemasa"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1953,12 +1890,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1966,78 +1903,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2046,386 +1983,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Tiada"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Penukar _Unit"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2433,81 +2358,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2516,881 +2414,898 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Fail"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3404,288 +3319,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3694,103 +3563,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3799,7 +3662,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3811,69 +3674,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3883,7 +3707,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3896,44 +3719,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3944,14 +3747,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4005,22 +3800,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/nb.po
+++ b/po/nb.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nb\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2014-02-19 15:24+0000\n"
 "Last-Translator: John Andre Gjerde <Unknown>\n"
 "Language-Team: <en@li.org>\n"
@@ -21,64 +21,64 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Oppskrifts Liste"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "Ny Oppskrift"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Legg til Handleliste"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Se oppskrift"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "Søk etter:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Søk etter oppskrifter når du skriver"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "i"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Søk med andre søkeord i søkeresultatet"
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Legg til Søkekriterie"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Begrens søk til:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Søke Resultater"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Sett Felt for Valgte Oppskrifter"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -86,129 +86,132 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Setter Opprkiftsfelt for Valgte "
 "oppskrifter</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "Legg til bilde"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "Fjern Bilde"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "Kilde:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "Vurdering:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "Kjøkken"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "Kategori:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "Forberedelsestid"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Koketid"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "Nettside"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Bilde:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "Utbytte:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Utbytteenhet"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "Sett kun verdier der felt er foreløpig tomt"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Sett alle verdier for _alle de valgte oppskriftene"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metasett (standard, lagret i en lokal fil)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (Lagret på lokal fil)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (krever kontakt med database)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Velg Database"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Velg Database System for Gourmet </b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "Database System"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "Vert:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "Brukernavn:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "Passord:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Passord for dit brukernavn på databasen."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Databasenavn:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "Fil"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -216,11 +219,11 @@ msgstr ""
 "Vertsnavn på systemet som kjører din databaseserver. Dersom databaseserveren "
 "kjører lokalt bruker du \"localhost\"."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -228,11 +231,11 @@ msgstr ""
 "Lagre passord til neste gang. Passord blir lagret usikkert i din "
 "konfigurasjons-fil."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "Lagre Passord"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -240,299 +243,300 @@ msgstr ""
 "Navn på database hvor Gourmet skal lagre data. Gourmet forsøker å opprette "
 "denne dersom den ikke eksisterer fra før."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "oppskrift"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Brukernavnet ditt på databasen."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "Bla gjennom"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "Detaljer"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Gourmet Recipe Manager Preferanser"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Innstillinger for kartotekvisning</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Vis Alternativer"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "Oppskrifter per side"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr "<i>Konfigurer hvilke kolonner som er inkludert i kartotekvisning.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Kartotekvisning"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Innstillinger for kortvisning</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "Tillat at enheter forandres ved multiplikasjon"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "Bruk brøker"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Bruk brøker til visning når mulig"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr "<i>Fjerne elementer som du ikke bruker fra kortvinduet.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Kortvisning"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Instillinger for handleliste</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Hva skal Gourmet gjøre med valgfrie ingredienser når en oppskrift blir "
 "lagt til i handlelisten?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "Spør om å inkludere valgfrie ingredienser"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "Husk brukervalg som standard"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "Nullstill huskede valgfrie ingredienser"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "Alltid legg til valgfrie ingredienser"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "Aldri legg til valgfrie ingredienser"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Handleliste"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "porsjoner"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Tittel"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "Tittel:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Tilberedningstid"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategori"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "Vurdering"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Utbytte"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Utbytteenhet"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "Handle"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Rediger_beskrivelse"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Tilberedningstid:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Tilberedningstid</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Kjøkken:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Kategori</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Nettside:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Utbytte:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Nettadresse</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Kilde</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Vurdering:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Multipliser med:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Instruksjoner</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Rediger_instruksjoner"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Notater</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Rediger_notater"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Oppskrift"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Ingredienser</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Rediger_ingrediens"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Legg til ingrediens:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredienser"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Legg oppskrift til i handleliste"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Legg til Handleliste"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Hopp til oppskrift i Kortvisning"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Slett valgt oppskrift"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "Slett oppskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Rediger egenskaper for valgt oppskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "Satsvis redigere oppskrifter"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Send valgt oppskrift som e-post"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Åpne valgt oppskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "Send oppskrift som e-post"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Velg oppskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Skriv ut valgt oppskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "Skriv ut oppskrift"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -544,31 +548,31 @@ msgstr ""
 "Den vil ikke bli inkludert når du lagrer eller skriver ut listen med mindre "
 "du forteller meg at du behøver å kjøpe den."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Legg til i _Spiskammer"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Vis Alternativer"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Søk i"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "Bruk vanlige uttrykk (avansert søking)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Søk mens du skriver"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Søkealternativer</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategori"
 
@@ -577,291 +581,293 @@ msgstr "Kategori"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Nøkkel"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Kategoriredigering"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Søk etter"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Søk mens du skriver"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Bruk vanlige uttrykk"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Avansert søk"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Legg til kategori: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Tidtaker"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Stoppeklokke</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Stoppeklokke ferdig!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Stoppeklokken vil fortsette til du lukker dette vinduet eller nullstiller "
 "stoppeklokken."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Sett_Stoppeklokke: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "Nullstill"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "Start"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "Lyd"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "Notat"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Gjenta alarm til jeg skrur den av"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "Innstillinger"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Redigere felt gjennom databasen</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Felt å Redigere:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "For hver valgte verdi:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "La verdi være uendret"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>Ny verdi vil bli lagt til i slutten av eksisterende tekst</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Ny verdi vil erstatte eksisterende verdi</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "Felt:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "Verdi:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Forandre annet felt:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "Forandre verdi til: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "Slett verdi"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Velg tilsvarende for</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>fra USDA database</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "Forandre ingrediens"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>eller</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "Søk i USDA ingrediensdatabase"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Søk mens du skriver"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Vis kun mat i gruppe:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Søkeresultater:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>Fra:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "Mengde:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Enhet:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "enhet"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "Forandre enhet"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "Lagre ny enhet"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>Til:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "Enhet:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Skriv inn ernæringsinformasjon for </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Velg en tetthet</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Ingrediensnøkkel: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>USDA vare: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "Rediger USDA-assosiasjon"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Næringsinformasjon</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "Rediger informasjon"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "Ernæringsinformasjon"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Tetthet:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "USDA tilsvarende:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Egendefinerte tilsvarende:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "Tetthetsinformasjon"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Kjent næringsinformasjon</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "Avansert Søk"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Næringsinformasjon"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "Ignorer"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet Recipe Manager"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Copyright (c) 2004,2005,2006,2007,2008,2009,2010,2011 Thomas M. Hinkle. GNU "
 "GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -884,216 +890,168 @@ msgstr ""
 "brukere. Gourmet lar deg lenke bilder til oppskriftene. Gourmet kan også "
 "kalkulerere næringsinformasjon for oppskrifter basert på ingrediensene."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Windows porting assistance)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-"Richard Ferguson (forbedringer av brukergrensesnitt til enhetskalkualtoren)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (forbedringer av MealMaster-eksport)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo og splash screen)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (næring- and legg-til-handleliste-ikoner)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (forbedringer av "
-"internasjonalisering, bugfiksing)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Windows-versjon vedlikehold og "
-"nettstedutvikler)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Velg Databasefil"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Oppgraderer database"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Ny oppskrift"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Databasenavn:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"Avhengig av størrelsen på databasen din, kan dette være en omfattende "
-"prossess og kan ta noe tid. Databasen din er sikkerhetskopiert i tilfelle "
-"noe går galt."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Detaljer"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "En sikkerhetskopi har blitt laget i %s i tilfelle noe går galt. Hvis denne "
 "oppgraderingen feiler, kan du manuellt gi sikkerhetskopien recipies.db nytt "
 "navn for å bruke den med en eldre versjon av Gourmet."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Ny oppskrift"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Endre kategori"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Lag ny kategori"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Forandre kategorien for det valgte elementet"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Spiskammer"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Flytt til handleli_sten"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Flytt til spiskammer"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Fjern fra handleliste"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Flytt valgt element til %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Handleliste"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Har Allerede (varer spiskammer)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Skriv inn Kategori"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Kategori å legge %s til"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategori:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "Oppskrifter"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "Legg til element:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Fjern oppskrifter"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Fjern oppskrifter fra handlelisten"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "Rediger"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "Hjelp"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Legg til element"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Legg vilkårlige varer til i handlelisten"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Ingen oppskrift er valgt. Vil du slette hele listen?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Lagre handleliste som..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Velg valgfrie ingredienser"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1102,57 +1060,59 @@ msgstr ""
 "handlelisten."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "Oppskrift"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "Gå"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Eksporter oppskrift"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Eksporter valgt oppskrift (lagre til fil)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "Slett oppskrift"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Slett denne oppskriften"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Juster enheter ved multiplisering"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Endre enheter for å gjøre dem enklere å lese, der det er mulig, når det "
 "multipliseres."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Skriv ut oppskrift"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Legg til Handleliste"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Glem huskede valgfrie ingredienser"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1160,150 +1120,144 @@ msgstr ""
 "Før det blir lagt til i handleliste, spør om alle valgfrie ingredienser, "
 "selv de du tidligere ville ha husket"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Eksporter oppskrift"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Du har ulagrede endringer"
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Lagre endringer før utskrift?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Lagre endringer før utskrift?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Valgfri)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Finner ikke oppskrift %s i databasen"
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Endre oppskrift:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Lagre endringer i databasen"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Vis oppskrifskort"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Rediger"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Lagre endringer i %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Legg til ingrediens"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Legg til gruppe"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Lim inn ingredienser"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importer fra fil"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Legg til oppskrift"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Legg til en annen oppskrift som ingrediens i denne oppskriften"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Slett"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Opp"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Ned"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Velg en fil som inneholder ingredienslisten din."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instruksjoner"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notater"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Mengde"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Enhet"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Vare"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Valgfritt"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Oppskriften %s (ID %s) er ikke i databasen vår."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Konvertert: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Ikke Konvertert: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Endret enhet."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1312,233 +1266,232 @@ msgstr ""
 "Du har forandret enheten for %(item)s fra %(old)s til %(new)s. Ønsker du "
 "mengden konvertert, eller ikke?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Konvertert %(old_amt)s %(old_unit)s til %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Klarte ikke konvertere fra %(old_unit)s til %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Legger til Ingrediensgruppe"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Legg til et navn for ny undergruppe av ingredienser"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Navn på gruppe:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Velg oppskrift"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Oppskrift kan ikke kreve seg selv som en oppskrift!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Uendelig rekursjon er ikke tillatt i oppskrifter!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Du har ikke valgt noen oppskrifter!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Hvor mye av %(title)s krever oppskriften din?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Oppskrifter"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Ringelyd"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Alarmlyd"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Feilmeldingslyd"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Stoppe stoppeklokke?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Stopp stoppeklokke"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "Fortsett nedtelling"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Programmtillegg"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Programmtillegg legger til ekstra funksjonalitet i Gourmet"
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Programtillegget kreves av andre tillegg. Deaktivere tillegget allikevel?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Det følgende programmtillegget krever %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Deaktiver allikevel"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Beholdt programmtillegg aktivt"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "eller"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "En feil skjedde under aktivering av programmtillegget."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "En feil skjedde under deaktivering av programmtillegget."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Kjøkken"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Vurdering"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Kilde"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Nettsted"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Tilberedningstid"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Tilberedningstid"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Endringer"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Ugyldig data."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Ikke et tall."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "Pause"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "Stopp"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Ikke spør om dette igjen."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Er du sikker på at du vil gjøre dette"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "utmerket"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "flott"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "god"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "grei"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "dårlig"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Konverter vurderinger til femstjerners-skala."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Konverter vurderinger."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Vennligst gi hver vurdering en ekvivalent verdi på en skala fra 1 til 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Nåværende vurdering"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Vurdering ut fra 5 stjerner"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Ingen fil valgt"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Velg fil_type"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Ingen fil ble valgt så handlingen har blitt avbrutt"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1547,13 +1500,13 @@ msgstr ""
 "Beklager, men jeg kan ikke forstå\n"
 "mengden \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Mengder må være tall (brøker eller desimaler), et intervall eller blankt."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1573,86 +1526,86 @@ msgstr ""
 "For å skrive inn et intervall, bruk \"-\" for å separere tallene.\n"
 "For eksempel kan du skrive \"2-4\" eller \"1 1/2-3 1/2\".\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "Brukernavn:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "Passord:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "Hvetemel, siktet"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "sukker"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "salt"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "sort pepper, malt"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "is"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "vann"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "olje, vegetabilsk"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "olje, oliven"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Ukjent"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Oppskriften krever seg selv som en ingrediens."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Ingrediens %s vil bli ignorert."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Handleliste for %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "For de følgende oppskriftene:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "For de følgende oppskriftene:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Velg encoding"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1660,29 +1613,28 @@ msgstr ""
 "Kan ikke finne passende enconding. Vennligst velg korrekt encoding fra "
 "listen under."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Se encoded _fil"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importering satt på vent"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Stopp importering"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Oppskriftsoversikt"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Handleliste"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1697,337 +1649,324 @@ msgstr ""
 "  Tor Egil Hoftun Kvæstad https://launchpad.net/~toregilhk\n"
 "  raskall https://launchpad.net/~rolfas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Lagret!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Lagre dine endringer til %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Importering pågår."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "En eksport pågår."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "En sletting pågår."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Avslutt programmet likevel?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Ikke avslutt!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Permanent slettet %s fra %s oppskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Søppelbøtte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Bla gjennom, permanent slette eller gjenopprett slettede oppskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Gjenopprettede oppskrifter "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Anntall %(unit)s av %(title)s å handle"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multipliser %s med:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Sett %(attributes)s for %(num)s valgt oppskrift?"
 msgstr[1] "Sett %(attributes)s for %(num)s valgte oppskrifter?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Enhver eksisterende verdi vil ikke bli endret."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "De nye verdiene vil overskrive alle eksisterende verdier."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Denne endringen kan ikke angres."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Sett verdier for valgte oppskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Søk i oppskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Åpne oppskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Åpne valgt oppskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Slett oppskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Slett merkede oppskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Rediger oppskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Åpne valgte oppskrifter i redigeringsvisning"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "Eksporter valgte oppskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Eksporter valgte oppskrifter til fil"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "Skriv ut"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "oppskrifter"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Satsvis redigere oppskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "Ny"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "Importer fil"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Importer oppskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Importer oppskrift fra fil"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Importer nettside"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s oppskrift"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Importer oppskrift fra nettside"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Eksporter alle oppskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Eksporter alle oppskrifter til fil"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "Avslutt"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "Handlinger"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Åpne Søppelbøtte"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Søppelbøtte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "Preferanser"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "Programmtillegg"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 "Administrere programmtillegg som legger til ekstra funksjonalitet til i "
 "Gourmet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Innstillinger"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "Om"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "Verktøy"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "Stoppeklokke"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Vis stoppeklokke"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Søkbar indeks av oppskrifter i databasen."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Vil du slette %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Du har ulagrede endringer for %s. Er du sikker på at du vil slette?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Slettet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Uten tittel"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Slett oppskrifter permanent?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Slett oppskriften permanent?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Er du sikker på at du vil slette oppskriften <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Er du sikker på at du vil slette de følgende oppskriftene?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Er du sikker på at du vil slette de %s valgte oppskriftene?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Se oppskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Slette Oppskrifter"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Oppskrifts Liste"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Slett oppskrift %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Ferdig!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importerer..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Ingrediensnøkkel redigering"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Masseredigering av ingrediensnøkler"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "nøkkel"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "vare"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Felt"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Verdi"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Antall"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Endre alle nøkler \"%s\" til \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2037,12 +1976,12 @@ msgstr ""
 "Du vil ikke kunne angre dette valget. Hvis det allerede finnes ingredienser "
 "med nøkkelen \"%s\" vil du ikke kunne skille disse fra de du endrer nå."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Endre alle varer \"%s\" til \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2052,12 +1991,12 @@ msgstr ""
 "Du vil ikke kunne angre dette valget. Hvis det allerede finnes ingredienser "
 "med objektet \"%s\" vil du ikke kunne skille disse fra de du endrer nå."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Endre _alle forekomster av \"%(unit)s\" til \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2066,13 +2005,13 @@ msgstr ""
 "Endre \"%(unit)s\" til \"%(text)s\" kun for _ingredienser \"%(item)s\" med "
 "nøkkel \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Endre _alle forekomster av \"%(amount)s\" %(unit)s til %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2081,7 +2020,7 @@ msgstr ""
 "Endre \"%(amount)s\" %(unit)s til \"%(text)s\" %(unit)s kun der hvor "
 "ingrediensnøkkelen er %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2090,11 +2029,11 @@ msgstr ""
 "Endre \"%(amount)s\" %(unit)s til \"%(text)s\" %(unit)s kun der hvor "
 "ingrediensnøkkelen er %(key)s og der hvor objektet er %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Endre alle valgte rader?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2103,7 +2042,7 @@ msgstr ""
 "Du vil ikke kunne angre dette valget. Er du sikker på at du vil gi alle de "
 "%s valgte radene følgende verdier:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2112,7 +2051,7 @@ msgstr ""
 "\n"
 "Nøkkel til %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2121,7 +2060,7 @@ msgstr ""
 "\n"
 "Vare til %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2130,7 +2069,7 @@ msgstr ""
 "\n"
 "Enhet til %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2139,8 +2078,8 @@ msgstr ""
 "\n"
 "Mengde av %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2149,23 +2088,23 @@ msgstr[1] "%s ingredienser"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Vis ingredienser %(bottom)s til %(top)s av %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Mengde"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Ingrediensnøkler"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2173,11 +2112,11 @@ msgstr ""
 "Ingrediensnøkler er normaliserte ingrediensnavn som blir brukt for "
 "handlelister og kalkulasjoner"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Gjett nøkler"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2185,56 +2124,56 @@ msgstr ""
 "Gjett beste verdier for alle ingrediensnøkler basert på verdier allerede i "
 "din database"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Rediger nøkkelassosiasjoner"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Redigere assosiasjoner med nøkkel og andre egenskaper i databasen"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Nøkkelredigering"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "Element:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "Nøkkel:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>Endre valgte ingredienser</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Innkjøpskategori"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Vis enheter som skrevet for hver oppskrift (ingen endring)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Vis alltid imperiske enheter"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Vis alltid metriske enheter"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Juster enheter automatisk"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Sett preferanser for enhetsvisning"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2242,42 +2181,42 @@ msgstr ""
 "Automatisk konvertere enheter til foretrukket system (metrisk, imerisk, "
 "osv.) når mulig."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Stjerner"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s siden"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Auto-flett oppskrifter"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Bruk alltid den nyeste oppskriften"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Bruk alltid den eldste oppskriften"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Ingen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2285,97 +2224,97 @@ msgstr ""
 "Noen av de importerte oppskriftene virker som å være duplikater. Du kan "
 "flette dem her, eller lukke dette vinduet og la dem være som de er."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Finn duplikate oppskrifter"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Finn og fjern duplikate oppskrifter"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Oppskrifter med lignende oppskriftsinformasjon"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Oppskrifter med lignende ingredienser"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Oppskrifter med lignende oppskriftsinformasjon og ingredienser"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Duplikate oppskrifter</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "Inkludere oppskrifter i søppelbøtten"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>Viser:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Slå sammen alle duplikater"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Slå sammen oppskrifter</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "Slå sammen automatisk"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "For hver valgte verdi"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Hvor %(field)s er %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Endring vil påvirke %s oppskrift"
 msgstr[1] "Endring vil påvirke %s oppskrifter"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Slette %s hvor den er %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Endre %s fra %s til \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Denne endringen kan ikke angres.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Feltredigering"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Endre felt på tvers av flere oppskrifter på en gang."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Sende oppskrifter som e-post"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Send alle valgte oppskrifter som e-post (eller alle oppskrifter hvis ingen "
@@ -2384,162 +2323,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Ønsker du virkelig å sende alle %s valgte oppskrifter som e-post?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Ja, send dem"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Kan ikke konvertere %s til %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Trenger tetthetsinformasjon."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Enhetskalkulator"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Kalkuler enhetskonverteringer"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Enhetskonverterer"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Fra</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "Vare"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "Tetthet"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Tetthetsinformasjon"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Til</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "Resultat"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Komprimert fil (zip, tarball)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Laster ziparkiv"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Pakker ut ziparkiv"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML-side"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Eksporterer webside"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Eksporterer oppskrifter til HTML-filer i mappen %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Oppskrift lagret som HTML-fil %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Ogrinal Side fra %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "valgfri"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Eksporterer webside"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Eksporterer oppskrifter til HTML-filer i mappen %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Oppskrift lagret som HTML-fil %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Ren tekstfil"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Teksteksport"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Eksporterer oppskrifter til tekstfil %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Oppskrift lagret som ren tekstfil %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Stor Fil"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Filen %s er for stor for å importere"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2551,81 +2478,54 @@ msgstr ""
 "bruk et tekstredigeringsprogram for å dele den i mindre filer og prøv å "
 "importere igjen."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Nettside"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Laster ned %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Handleliste for %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Henter %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML-fil"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML-eksport"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Eksporterer oppskrifter til Gourmet XML-fil %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Oppskrift lagret i Gourmet XML-filen %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML-fil (Utgått)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML-fil"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook Tekstfil"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Mastercook-importering fullført"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Rydder opp XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML-fil"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2634,274 +2534,295 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Sideoppsett"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Skriv ut oppskrifter"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF-eksport"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Eksporterer oppskrifter til PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Oppskrift lagret som PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Brev"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Stående"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Enkel"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "poeng"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Kartotekkort (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Kartotekkort (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Kartotekkort (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Kartotekkort (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Brev"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Kartotekkort (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Kartotekkort (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Kartotekkort (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Liggende"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Enkel"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s kolonne"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s kolonne"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s kolonne"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s kolonne"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s kolonne"
 msgstr[1] "%s kolonner"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Stående"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Liggende"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Papir_Størrelse"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "Orientering"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Skriftstørrelse"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Utforming"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Skriftstørrelse"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Venstre marg"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Høyre marg"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Toppmarg"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Bunnmarg"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "PDF-innstillinger"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster-fil"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster-eksport"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Eksporterer oppskrifter til MealMaster-fil %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Oppskrift lagret som MealMaster-fil %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "porsjon"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Stor Fil"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "HTML Eksport"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Eksporterer oppskrifter til Gourmet XML-fil %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Oppskrift lagret i Gourmet XML-filen %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Handlelistelagrer"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Lagre Liste som Oppskrift"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Lagre gjeldende handleliste som oppskrift for fremtidig bruk"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Meny for %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Meny"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Ernæringsinformasjon reflekterer mengde per %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Ernæringsinformasjon reflekterer mengde for hele oppskriften"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Ernæringsinformasjon mangler for %s ingredienser: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Alle matgrupper"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "utvalg"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Konverter enhet for %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "For å kunne beregne næringsinforsjon trenger Gourmet at du endrer \"%s\" til "
 "en enhet den forstår."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Endre ingrediensnøkkel"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2910,27 +2831,27 @@ msgstr ""
 "Endre ingrediensnøkkel fra %(old_key)s til %(new_key)s overalt eller kun i "
 "oppskriften %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Endre overalt"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "Kun i oppskriften %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Endre ingrediensnøkkel fra %(old_key)s til %(new_key)s over alt?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Endre enhet"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2939,210 +2860,212 @@ msgstr ""
 "Endre enhet fra %(old_unit)s til %(new_unit)s for alle ingredienser "
 "%(ingkey)s eller kun i oppskriften %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
-"For å kunne beregne næringsinformasjon for \"%(amount)s %(unit)s %(ingkey)s"
-"\" trenger Gourmet å vite tettheten. Næringsdatabasen har flere beskrivelser "
-"av denne matvaren med forskjellige tettheter. Vennligst velg korrekt under."
+"For å kunne beregne næringsinformasjon for \"%(amount)s %(unit)s "
+"%(ingkey)s\" trenger Gourmet å vite tettheten. Næringsdatabasen har flere "
+"beskrivelser av denne matvaren med forskjellige tettheter. Vennligst velg "
+"korrekt under."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "For å legge til ernæringsinformasjon, trenger Gourmet en gyldig verdi og "
 "enhet."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Ernæring"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingrediens"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Tilsvarende i USDA database"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gram"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalorier"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Total mengde fett"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Mettet fett"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Kolesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Natrium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Total mengde karbohydrat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Kostfiber"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Sukker"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Protein"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfakaroten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Askeinnhold"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Betakaroten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta cryptoxantin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Kalsium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Kobber"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Folat Total"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Folatsyre"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Matfolat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Dietetiske folatekvivalenter"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Jern"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Lycopen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Lutein+Zeazantin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Pantotensyre (Vitamin B5)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Kalium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamin A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamin A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamin A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamin C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Sink"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitaminer og mineraler"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3151,11 +3074,11 @@ msgstr ""
 "Mangler ernæringsinformasjon\n"
 " for %(missing)s av %(total)s ingredienser."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Daglig inntak"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3164,367 +3087,367 @@ msgstr ""
 "Prosent av anbefalt daglig inntak basert på %i kalorier per dag. Klikk for å "
 "redigere anntall kalorier per dag."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Mengde per %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Mengde per oppskrift"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Laster næringsinformasjon"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Ernæringsdatabase import fullført!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Henter næringsinformasjon fra arkivet %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Pakker ut %s fra zip-arkiv."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Bearbeider næringsinformasjon..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Leser næringsinformasjon: importert %s av %s."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Bearbeider vektdata..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr "Leser vektdata for ernæringsvarer: importert %s av %s"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Vann"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalorier"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g protein"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipid"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g aske"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g karbohydrater"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g fiber"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g sukker"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg kalsium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg jern"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg kalium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg natrium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg sink"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg kobber"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mikrogram selen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamin c"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg tiamin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niacin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg pantotenisk syre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "mikrogram Folat Total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "mikrogram Folsyre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "mikrogram Matfolat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "mikrogram dietetiske folatekvivalenter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Kolin, Total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mikrogram Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamin A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamin A (mikrogram retinal aktivitet ekvivalenter)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "mikrogram retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "mikrogram alfakaroten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "mikrogram betakaroten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "mikrogram Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "mikrogram Lycopene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "mikrogram Lutein+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g mettet fettsyre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g Enumettede Fettsyrer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g Flerumettede Fettsyrer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Kolesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Prosent avfall"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Meieri- og eggprodukter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Krydder & Urter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Babymat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Fett og olje"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Fjærfe"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Supper og saus"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Pølser og enkle kjøttretter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Frokostblandinger"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Frukt & Fruktjuicer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Svinekjøtt"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Grønnsaker"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Nøtter & Frø"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Storfe"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Drikke"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Fisk og skalldyr"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Belgfrukter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Lam, kalv og vilt"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Bakevarer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Søtsaker"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Korn og pasta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Hurtigmat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Måltider, Hovedretter og Tilbehør"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Småretter"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Etnisk mat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "hele databasen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Ingrediensnøkkel"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "USDA ID-nummer"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA varebeskrivelse"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Tilsvarende tetthet"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3538,59 +3461,59 @@ msgstr "Verktøy"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Hent ernæringsinformasjon for gjeldende liste"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Mengde for Handleliste"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "Rediger_næringsinformasjon"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "stjerner"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Eksportert %(number)s av %(total)s oppskrifter"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Eksportering fullført."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Inkluder oppskrift i e-postens brødtekst (en god idé uansett)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Send oppskrift via e-post som HTML-vedlegg"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Send oppskrift via e-post som PDF-vedlegg"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "E-post-valg"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Ikke spør før sending av e-post."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-post ikke sendt"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3598,232 +3521,186 @@ msgstr ""
 "Du har ikke valgt å inkludere oppskriften i meldingens brødtekst eller som "
 "et vedlegg."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Lagre oppskrift som..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet kan ikke eksportere filer av type \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Eksporter oppskrifter"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "oppskrifter"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Kan ikke eksportere: ukjent filtype \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "Vennligst velg filtype i nedtrekksliste under lagring."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Eksporter"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Kan ikke skrive ut: ingen programmtillegg for utskrift er aktive!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Skriv ut %s oppskrift"
 msgstr[1] "Skriv ut %s oppskrifter"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Henter fil"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "utbytte"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Skriv inn URL'en til et oppskriftsarkiv eller webside."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Skriv inn nettadresse"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Skriv inn URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Skriv inn adressen for et nettsted eller oppskriftsarkiv."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Kunne ikke importere URL"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet har ikke et programmtillegg som kan importere URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Kan ikke importere URL %(url)s av mimetype %(type)s. Filen er lagret i "
-"midlertidig plassering %(fn)s."
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Åpne oppskrift..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Skriv inn nettadresse"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Endringer"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Skriv inn adressen for et nettsted eller oppskriftsarkiv."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Import"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Alle importerbare filer"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Importert %s oppskrifter."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "porsjon"
 msgstr[1] "porsjoner"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Importert %s av %s oppskrifter."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "OK"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Gjenkjenner ikke denne websiden. Bruker generisk importering..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Importerer fullført."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Importerer oppskrift"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Behandler ingredienser"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Behandler ingredienser."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Porsjoner"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Ingrediens Undergruppe"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Skjul"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Tekst"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Handlinger"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importer oppskrift"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Slett Merkelapper"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Importer oppskrift"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "hvor som helst"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "tittel"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrediens"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instruksjoner"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "notater"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "kjøkken"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "kilde"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Bruk vanlige uttrykk i søk"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr "Bruk vanlige uttrykk (et avansert søkespråk) i tekstsøk"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Søk mens du skriver (skru av dette hvis søk går sakte)"
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Vis søkealternativer"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Vis avanserte søkealternativer"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3832,104 +3709,98 @@ msgstr[1] "%s oppskrifter"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Viser oppskrifter %(bottom)s til %(top)s av %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s i %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Pauset"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "KRecipe import"
 msgstr[1] "KRecipe import"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pause"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Ferdig"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Feil: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Feil"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Feil %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Tilbakesporing"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "sekund"
 msgstr[1] "sekunder"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minutt"
 msgstr[1] "minutter"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "t."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "time"
 msgstr[1] "timer"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
 msgstr[1] "dager"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "uke"
 msgstr[1] "uker"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "måned"
@@ -3938,7 +3809,7 @@ msgstr[1] "måneder"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "år"
@@ -3950,73 +3821,30 @@ msgstr[1] "år"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " og "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "og"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "til"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML-fil"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet Recipe Manager"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organiser oppskrifter, lage handlelister, kalkulere næringsinformasjon og "
-"mer."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Bla Gjennom Oppskrifter"
@@ -4026,7 +3854,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Valg av oppskrifter ved å bla gjennom kategorier, kjøkken osv."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Hoved"
@@ -4039,38 +3866,6 @@ msgstr "Finn duplikate oppskrifter"
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr "En veiviser for å finne og fjerne eller flette duplikate oppskrifter."
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Send til e-post"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Send oppskrifter fra Gourmet som e-post"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Zip, Gzip, og Tarball-støtte"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Importer oppskrifter fra zip og tar-arkiv"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Importerer/Eksporterer"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4080,6 +3875,18 @@ msgstr "PDF-eksport"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Lag nettside fra oppskrifter."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Importerer/Eksporterer"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4092,14 +3899,6 @@ msgid ""
 msgstr ""
 "Importere og eksportere oppskrifter som Gourmet XML-fil, egnet som "
 "sikkerhetskopi og utveksling med andre Gourmet-brukere."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "HTML Eksport"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Lag nettside fra oppskrifter."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4159,22 +3958,6 @@ msgstr "Ren tekst veiledet import"
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
 msgstr "Hjelp bruker"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Importer fra nettside"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Importerer oppskrifter fra nettet."
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Nettsted importeringsverktøy"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Importeringsverktøy for about.com, foodnetwork.com og andre"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4242,6 +4025,196 @@ msgstr ""
 "Aktiver dette hvis dine utf-16 tekstfiler ikke importerer skikkelig inn til "
 "Gourmet. Deaktiver denne hvis du aldri bruker utf-16 og du blir irritert av "
 "\"Koder\"-dialogen når du importerer filer."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Send valgt oppskrift som e-post"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "Send oppskrift som e-post"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Windows porting assistance)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr ""
+#~ "Richard Ferguson (forbedringer av brukergrensesnitt til "
+#~ "enhetskalkualtoren)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (forbedringer av MealMaster-eksport)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo og splash screen)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (næring- and legg-til-handleliste-ikoner)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (forbedringer av "
+#~ "internasjonalisering, bugfiksing)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Windows-versjon vedlikehold og "
+#~ "nettstedutvikler)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Oppgraderer database"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Avhengig av størrelsen på databasen din, kan dette være en omfattende "
+#~ "prossess og kan ta noe tid. Databasen din er sikkerhetskopiert i tilfelle "
+#~ "noe går galt."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Lim inn ingredienser"
+
+#~ msgid "Import from file"
+#~ msgstr "Importer fra fil"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Velg en fil som inneholder ingredienslisten din."
+
+#~ msgid "No file selected"
+#~ msgstr "Ingen fil valgt"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Ingen fil ble valgt så handlingen har blitt avbrutt"
+
+#~ msgid "_Import file"
+#~ msgstr "Importer fil"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Importer nettside"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Importer oppskrift fra nettside"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Åpne Søppelbøtte"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Komprimert fil (zip, tarball)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Laster ziparkiv"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Pakker ut ziparkiv"
+
+#~ msgid "Webpage"
+#~ msgstr "Nettside"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Laster ned %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Handleliste for %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Henter %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Henter fil"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Skriv inn URL'en til et oppskriftsarkiv eller webside."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Skriv inn URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Kunne ikke importere URL"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet har ikke et programmtillegg som kan importere URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Kan ikke importere URL %(url)s av mimetype %(type)s. Filen er lagret i "
+#~ "midlertidig plassering %(fn)s."
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Gjenkjenner ikke denne websiden. Bruker generisk importering..."
+
+#~ msgid "Import complete."
+#~ msgstr "Importerer fullført."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Importerer oppskrift"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Behandler ingredienser"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Behandler ingredienser."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML-fil"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet Recipe Manager"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organiser oppskrifter, lage handlelister, kalkulere næringsinformasjon og "
+#~ "mer."
+
+#~ msgid "Send to Email"
+#~ msgstr "Send til e-post"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Send oppskrifter fra Gourmet som e-post"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Zip, Gzip, og Tarball-støtte"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Importer oppskrifter fra zip og tar-arkiv"
+
+#~ msgid "HTML Export"
+#~ msgstr "HTML Eksport"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Lag nettside fra oppskrifter."
+
+#~ msgid "Webpage import"
+#~ msgstr "Importer fra nettside"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Importerer oppskrifter fra nettet."
+
+#~ msgid "Website Importers"
+#~ msgstr "Nettsted importeringsverktøy"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Importeringsverktøy for about.com, foodnetwork.com og andre"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4373,9 +4346,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "Porsjoner"
-
-#~ msgid "Select File_type"
-#~ msgstr "Velg fil_type"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "En fil med navnet %s eksisterer allerede."

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gourmet Recipe Manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-04-03 08:29+0000\n"
 "Last-Translator: rob <linuxned@gmail.com>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -20,64 +20,64 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Receptenindex"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nieuw recept"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Toevoegen aan _boodschappenlijst"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Re_cept bekijken"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Zoeken naar:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Zoeken naar recepten terwijl u typt"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_in"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Zoeken op andere critera binnen de huidige zoekresultaten."
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Zoekcriteria _toevoegen"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Zoeken beperken tot:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Zoek_resultaten"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Velden instellen voor geselecteerde recepten"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -85,129 +85,132 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Receptvelden voor geselecteerde "
 "recepten instellen</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "Afbeelding _toevoegen"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "Afbeelding _verwijderen"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "Br_on:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Waardering:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "Ke_uken:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Categorie:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "_Voorbereidingstijd:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "_Kooktijd:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Website:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Afbeelding:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Aantal:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Eenheid"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "_Alleen waarden instellen waarvan het veld momenteel leeg is"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Alle waarden instellen voor _alle geselecteerde recepten"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (wordt standaard opgeslagen in een lokaal bestand)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (wordt standaard opgeslagen in een lokaal bestand)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (vereist een databank)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Databank selecteren"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Selecteer databanksysteem om te gebruiken door Gourmet</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "_Databanksysteem"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Computernaam:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Gebruikersnaam:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "Wa_chtwoord:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Wachtwoord voor gebruikersnaam voor databank."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Databank_naam:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Bestand"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -215,11 +218,11 @@ msgstr ""
 "Computernaam van het systeem waarop uw databankserver draait. Indien uw "
 "databankserver op uw lokale systeem draait, gebruik dan ´lokaal´."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "lokaal"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -227,11 +230,11 @@ msgstr ""
 "Dit wachtwoord opslaan voor de volgende keer. Dit betekent dat uw wachtwoord "
 "onveilig opgeslagen zal worden in uw configuratiebestand"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "Wachtwoord op_slaan"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -239,302 +242,303 @@ msgstr ""
 "Naam van de databank waarin Gourmet informatie moet opslaan. Gourmet zal "
 "proberen om deze databank aan te maken indien deze nog niet bestaat."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recept"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Uw gebruikersnaam voor de databank."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Bladeren"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Details"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Voorkeuren Gourmet-receptbeheer"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Indexweergavevoorkeuren</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "_Opties tonen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Recepten per pagina:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 "<i>Instellen welke kolommen weergegeven worden in de receptenindexweergave.</"
 "i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Indexweergave"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Kaartweergavevoorkeuren</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "Maten _toestaan te veranderen tijdens het vermenigvuldigen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "Breuken gebr_uiken"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Indien mogelijk breuken gebruiken voor weergave"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 "<i>Verwijder items die u niet langer gebruikt in de receptkaartinterface.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Kaartweergave"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Boodschappenlijstvoorkeuren</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Wat moet Gourmet doen met optionele ingrediënten wanneer er recepten "
 "toegevoegd worden aan de boodschappenlijst?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "_Vragen of de optionele ingrediënten ook toegevoegd moeten worden"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "Gebruikerskeuzes standaard _onthouden"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "Onthouden optionele ingrediënten _wissen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "_Altijd optionele ingrediënten toevoegen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Nooit optionele ingrediënten toevoegen"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Boodschappenlijst"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "personen"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Titel"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Titel:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "_Voorbereidingstijd:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "categorie"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "waardering"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Aantal"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Eenheid"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "Boodschappenlijst maken"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Omschrijving be_werken"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Kooktijd:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Voorbereidingstijd:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Keuken:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Categorie:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Website:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Aantallen:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"enkele\" kleur=\"blauw\">Link</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Bron:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Waardering:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Vermenigvuldigen met:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Instructies</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "_Instructies bewerken"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Notities</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "_Notities bewerken"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recept"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Ingrediënten</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "_Ingrediënten bewerken"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "_Ingrediënt toevoegen:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingrediënten"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Recept aan boodschappenlijst toevoegen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Aan _boodschappenlijst toevoegen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Ga naar recept in receptkaartweergave"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Geselecteerde recept verwijderen"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "Recept _verwijderen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Attributen van geselecteerd recept bewerken"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "Recepten in _bulk bewerken"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Geselecteerd recept e-mailen"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Geselecteerd recept openen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "Recept _e-mailen"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Selecteer recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Geselecteerd recept afdrukken"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "Recept af_drukken"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -546,31 +550,31 @@ msgstr ""
 "dat u het nodig heeft. Het zal echter niet in de lijst opgenomen worden "
 "wanneer u deze afdrukt of opslaat, tenzij u mij vertelt dat u het moet kopen."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Aan _voorraadkast toevoegen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "_Opties tonen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Zoeken _in"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "Normale uitdrukkingen gebr_uiken (geavanceerd zoeken)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Zoeken terwijl u _typt"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Zoekopties</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Categorie"
 
@@ -579,293 +583,295 @@ msgstr "Categorie"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Sleutel"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Categoriebeheer"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Zoeken op"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Zoeken terwijl u typt"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Normale uitdrukkingen gebruiken"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Geavanceerd zoeken"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Categorie toevoegen: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Kookwekker"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Kookwekker</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Kookwekker afgelopen!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Alarm zal herhaald worden totdat u deze dialoog sluit of de kookwekker "
 "terugzet."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "_Kookwekker instellen: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Terugzetten"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Starten"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "_Geluid"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Notitie"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Alarm _herhalen totdat ik het uitzet"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Instellingen"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Velden door gehele databank bewerken</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Veld om te be_werken:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Voor elke geselecteerde waarde:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "Waarde _laten zoals deze is"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 "<i>Nieuwe waarde zal toegevoegd worden aan het einde van een bestaande "
 "tekst</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Nieuwe waarde zal bestaande waarde vervangen</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Veld:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Waarde:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Veld _ander veranderen:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "Waarde _veranderen in: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "_Waarde verwijderen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Selecteer equivalent van</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>uit USDA-databank</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "Ingrediënt _veranderen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>of</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "USDA-ingrediëntendatabank door_zoeken:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Zoeken terwijl u t_ypt"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Alleen voedsel uit de volgende _groep tonen:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Zoek_resultaten:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>van:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Hoeveelheid:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Maat:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "maat"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "Maat _veranderen"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "Nieuwe maat op_slaan"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>naar:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Maat:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Voedingswaarde invoeren voor </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Selecteer een dichtheid</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Ingrediëntsleutel: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>USDA-item: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "_USDA-associatie bewerken"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Voedingswaarde</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "_Informatie bewerken"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "_Voedingswaarde"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Dichtheid:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "USDA-equivalenten"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Aangepaste equivalenten:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "_Dichtheidsinformatie"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Bekende voedingswaarde</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "_Geavanceerd zoeken"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Voedingswaarde"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "Ne_geren"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet-receptbeheer"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Copyright (c) 2004,2005,2006,2007,2008,2009,2010,2011 Thomas M. Hinkle. GNU "
 "GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -889,217 +895,168 @@ msgstr ""
 "Gourmet ondersteunt het toevoegen van afbeeldingen aan recepten, en kan de "
 "voedingswaarde berekenen op basis van de ingrediënten."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (assistentie bij het poorten naar Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (verbeteringen aan maatomrekeninterface)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (verbeteringen aan MealMaster export)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo en welkomstscherm)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-"Yula Zubritsky (voedingswaarde en ´Toevoegen aan boodschappenlijst´-"
-"pictogrammen)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (verbeteringen aan "
-"internationalisatie, verschillende bugfixes)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Windows-versie onderhoud en website "
-"redesign)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Selecteer databankbestand"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Databank bijwerken"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Nieuw recept"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Databank_naam:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"Afhankelijk van de grootte van uw databank kan dit een langdurig proces "
-"zijn. Er wordt automatisch een back-up van uw data gemaakt, voor als er iets "
-"fout mocht gaan."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Details"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Er is een back-up gemaakt in %s voor als er iets fout mocht gaan. Wanneer "
 "het bijwerken mislukt, dan kunt u het back-upbestand recipes.db handmatig "
 "hernoemen om het terug te zetten voor het gebruik met de oudere Gourmet"
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Nieuw recept"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "_Categorie veranderen"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Nieuwe categorie aanmaken"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Categorie van momenteel geselecteerd item veranderen"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Voorraadkast"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Naar _boodschappenlijst verplaatsen"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Naar _voorraadkast verplaatsen"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Van boodschappenlijst verwijderen"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Geselecteerde items verplaatsen naar %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Bood_schappenlijst"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Reeds aanwezig (_voorraadkastitems)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Categorie invoeren"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Categorie om %s aan toe te voegen"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Categorie:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recepten"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "Items _toevoegen:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Recepten verwijderen"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Recepten verwijderen van boodschappenlijst"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Bewerken"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Help"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Items toevoegen"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Willekeurige items aan boodschappenlijst toevoegen"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Geen recepten geselecteerd. Wilt u de volledige lijst wissen?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Boodschappenlijst opslaan als..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Optionele ingrediënten selecteren"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1108,57 +1065,59 @@ msgstr ""
 "plaatsen."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recept"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Bekijken"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Recept exporteren"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Geselecteerd recept exporteren (opslaan naar bestand)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "Recept _verwijderen"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Dit recept verwijderen"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Maten aanpassen tijdens het vermenigvuldigen"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Verander, waar mogelijk, de maten om ze makkelijker leesbaar te maken bij "
 "het vermenigvuldigen."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Recept afdrukken"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Toevoegen aan _boodschappenlijst"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Onthouden optionele ingrediënten vergeten"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1166,150 +1125,144 @@ msgstr ""
 "Vraag naar alle optionele ingrediënten, zelfs diegene die u voorheen "
 "onthouden wilde hebben, voordat u ze toevoegt aan een boodschappenlijst"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Recept exporteren"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "U heeft niet opgeslagen veranderingen."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Veranderingen toepassen voordat u afdrukt?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Veranderingen toepassen voordat u afdrukt?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Optioneel)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Kon recept %s niet vinden in databank."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Recept bewerken:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Veranderingen opslaan naar databank"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Receptkaart bekijken"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Bewerken"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Veranderingen opslaan naar %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Ingrediënt toevoegen"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Groep toevoegen"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Ingrediënten plakken"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importeren vanaf bestand"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "_Recept toevoegen"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Een ander recept als een ingrediënt toevoegen aan dit recept"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Omhoog"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Omlaag"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Selecteer een bestand dat uw ingrediëntenlijst bevat."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Omschrijving"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Bereiding"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notities"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Aantal"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Maat"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Item"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Optioneel"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Het recept %s (ID %s) bevindt zich niet in onze databank."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Omgerekend: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Niet omgerekend: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Veranderde maat."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1318,232 +1271,231 @@ msgstr ""
 "U heeft de maat van %(item)s van %(old)s naar %(new)s veranderd. Wilt u de "
 "hoeveelheid ook omzetten?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "%(old_amt)s %(old_unit)s omgerekend naar %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Kan niet van %(old_unit)s naar %(new_unit)s omrekenen"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Ingrediëntengroep toevoegen"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Voer een naam in voor de nieuwe subgroep van ingrediënten"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Groepsnaam:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Selecteer recept"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Recept kan niet bij zichzelf als een ingrediënt gebruikt worden!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Oneindige recursie is niet toegestaan in recepten!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "U heeft geen recepten geselecteerd!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Hoeveel %(title)s heeft uw recept nodig?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recepten"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Belgeluid"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Waarschuwingsgeluid"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Foutgeluid"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Kookwekker stoppen?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "_Kookwekker stoppen"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Kookwekker niet stoppen"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Plug-ins voegen extra functionaliteit toe aan Gourmet."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Plug-in wordt gebruikt door andere plug-ins. Plug-in toch uitschakelen?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "De volgende plug-ins gebruiken %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Toch uitschakelen"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Plug-in ingeschakeld laten"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "of"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Er is een fout opgetreden bij het inschakelen van de plug-in."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Er is een fout opgetreden bij het uitschakelen van de plug-in."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Keuken"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Waardering"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Bron"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Website"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Voorbereidingstijd"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Kooktijd"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Wijzigingen"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Onjuiste invoer."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Geen getal."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pauzeren"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stoppen"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Vraag me dit niet opnieuw."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Weet u zeker dat u dit wilt doen"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "voortreffelijk"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "uitstekend"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "goed"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "redelijk"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "onvoldoende"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Waardering omzetten in 5-sterrenschaal."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Waardering omzetten."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Geef de waardering op een schaal van 1 tot 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Huidige waardering"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Waardering op een 5-sterrenschaal"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Geen bestand geselecteerd"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Selecteer bestands_type"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Er werd geen bestand geselecteerd, de actie is geannuleerd"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1552,14 +1504,14 @@ msgstr ""
 "Het spijt me, ik begrijp de \n"
 "hoeveelheid \"%s\" niet."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Hoeveelheden moeten getallen zijn (breuken of decimalen), een getallenreeks, "
 "of leeg."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1580,86 +1532,86 @@ msgstr ""
 "om ze te scheiden. U kunt bijvoorbeeld '2-4' of '1 1/2 - 3 1/2'\n"
 "invullen.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Gebruikersnaam:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "Wa_chtwoord:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "bloem, alle doeleinden"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "suiker"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "zout"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "zwarte peper, gemalen"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "ijs"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "water"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "plantaardige olie"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "olijfolie"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Recept wil zichzelf als een ingrediënt gebruiken."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Ingrediënt %s zal genegeerd worden."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Boodschappenlijst voor %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Voor de volgende recepten:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Voor de volgende recepten:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Kies een codering"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1667,29 +1619,28 @@ msgstr ""
 "Kan de juiste codering niet bepalen. Selecteer de juiste codering uit de "
 "volgende lijst."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "_Bestand met codering bekijken"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importeren gepauzeerd"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Stop importeren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Recepten_index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Boodschappen_lijst"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "vertalers\n"
@@ -1710,340 +1661,327 @@ msgstr ""
 "  raboof https://launchpad.net/~launchpad-bzzt\n"
 "  rob https://launchpad.net/~rvdb"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Opgeslagen!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Uw veranderingen opslaan naar %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Een import is bezig."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Een export is bezig."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Een verwijdering is bezig."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Het programma toch afsluiten?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Niet afsluiten!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "%s van %s recepten zijn permanent verwijderd"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Prullenbak"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 "Doorbladeren, recepten permanent verwijderen of verwijderde recepten "
 "terugzetten"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Teruggeplaatste recepten "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Aantal %(unit)s van %(title)s om boodschappen voor te gaan doen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "%s vermenigvuldigen met:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "%(attributes)s voor %(num)s geselecteerd recept instellen?"
 msgstr[1] "%(attributes)s voor %(num)s geselecteerde recepten instellen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Reeds bestaande waarden zullen niet worden veranderd."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 "Alle bestaande waarden zullen vervangen worden door de nieuwe waarden.."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Deze verandering kan niet ongedaan gemaakt worden."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Waarden instellen voor geselecteerde recepten"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Recepten zoeken"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Recept openen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Geselecteerd recept openen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Recept verwijderen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Geselecteerde recepten verwijderen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Recept bewerken"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Geselecteerde recepten openen in bewerkingsvenster"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "Geselecteerd recepten e_xporteren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Recepten exporteren naar bestand"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "Af_drukken"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "recepten"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Recepten in bulk be_werken"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nieuw"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "Bestand _importeren"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Recept importeren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Recept importeren vanaf bestand"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "_Website importeren"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Recept importeren vanaf website"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "_Alle recepten exporteren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Alle recepten exporteren naar bestand"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Afsluiten"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Acties"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "_Prullenbak openen"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Prullenbak"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Voorkeuren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Plug-ins"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Plug-ins beheren die extra functionaliteit toevoegen aan Gourmet."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "I_nstellingen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "I_nfo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Gereedschappen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Kookwekker"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Kookwekker tonen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Doorzoekbare index van recepten in de database"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "%s verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "Er zijn niet opgeslagen veranderingen gemaakt aan %s. Weet u zeker dat u "
 "door wilt gaan met verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Verwijderd"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Naamloos"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Recepten definitief verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Recept definitief verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Weet u zeker dat u het recept <i>%s</i> wilt verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Weet u zeker dat u de volgende recepten wilt verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Weet u zeker dat u de %s geselecteerde recepten wilt verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Recepten bekijken"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Recepten verwijderen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Receptenindex"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Recept %s is verwijderd"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr "Prullenbak openen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Klaar!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importeren…"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Ingrediëntsleutelbeheer"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Ingrediëntsleutel in bulk bewerken"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "sleutel"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "item"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Veld"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Waarde"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Aantal"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Alle sleutels veranderen van \"%s\" in \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2054,12 +1992,12 @@ msgstr ""
 "sleutel \"%s\" zijn, dan zult u deze niet meer kunnen onderscheiden van de "
 "ingrediënten die u nu verandert."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Alle items veranderen van \"%s\" in \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2070,27 +2008,27 @@ msgstr ""
 "item \"%s\" zijn, dan zult u deze niet meer kunnen onderscheiden van de "
 "ingrediënten die u nu verandert."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "_Alle voorkomens van \"%(unit)s\" veranderen in \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
-"\"%(unit)s\" veranderen in \"%(text)s\" alleen voor _ingredienten \"%(item)s"
-"\" met sleutel \"%(key)s\""
+"\"%(unit)s\" veranderen in \"%(text)s\" alleen voor _ingredienten "
+"\"%(item)s\" met sleutel \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "_Alle voorkomens van \"%(amount)s\" %(unit)s veranderen in %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2099,7 +2037,7 @@ msgstr ""
 "Verander \"%(amount)s\" %(unit)s in \"%(text)s\" %(unit)s alleen daar _waar "
 "de ingredientsleutel %(key)s is"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2108,11 +2046,11 @@ msgstr ""
 "Verander \"%(amount)s\" %(unit)s in \"%(text)s\" %(unit)s _alleen daar waar "
 "de ingredientsleutel %(key)s en het item %(item)s is."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Alle geselecteerde rijen veranderen?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2121,7 +2059,7 @@ msgstr ""
 "Deze actie kan niet ongedaan gemaakt worden. Weet u zeker dat u voor alle %s "
 "geselecteerde rijen de volgende waarden wilt instellen:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2130,7 +2068,7 @@ msgstr ""
 "\n"
 "Sleutel naar %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2139,7 +2077,7 @@ msgstr ""
 "\n"
 "Item naar %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2148,7 +2086,7 @@ msgstr ""
 "\n"
 "Maat naar %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2157,8 +2095,8 @@ msgstr ""
 "\n"
 "Hoeveelheid naar %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2167,23 +2105,23 @@ msgstr[1] "%s ingrediënten"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Ingrediënten %(bottom)s tot %(top)s van %(total)s worden getoond"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Hoeveelheid"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Ingrediëntsleutels"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2191,11 +2129,11 @@ msgstr ""
 "Ingrediëntsleutels zijn genormaliseerde ingrediëntnamen die worden gebruikt "
 "voor boodschappenlijsten en berekeningen."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Geschatte sleutels"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2203,56 +2141,56 @@ msgstr ""
 "Beste waarden schatten voor alle ingrediëntsleutels, gebaseerd op reeds "
 "aanwezige waarden in uw databank"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Sleutelassociaties bewerken"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Associaties bewerken met sleutel en andere attributen in databank"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Sleutelbeheer"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "_Item:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Sleutel:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>Geselecteerde ingrediënten _veranderen</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Boodschappencategorie"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Maten weergeven zoals geschreven voor elk recept (geen veranderingen)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Altijd U.S.-maten weergeven"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Altijd metrische maten weergeven"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Maten automatisch aanpassen"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Voorkeuren _maatweergave instellen"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2260,42 +2198,42 @@ msgstr ""
 "Maten automatisch omrekenen naar gewenst systeem (metrisch, imperaial, enz.) "
 "indien mogelijk."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Sterren"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s geleden"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Recepten auto-samenvoegen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Gebruik altijd het nieuwste recept"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Gebruik altijd het oudste recept"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Geen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2303,97 +2241,97 @@ msgstr ""
 "Sommige geimporteerde recepten schijnen duplicaten te zijn. U kunt ze hier "
 "samenvoegen, of deze dialoog sluiten en ze laten."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "_Duplicaatrecepten zoeken"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Duplicaatrecepten zoeken en verwijderen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Recepten met gelijksoortige receptinformatie"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Recepten met gelijksoortige ingrediënten"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Recepten met gelijksoortige receptinformatie en ingrediënten"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Duplicaatrecepten</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "_Inclusief de recepten in de prullenbak"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Tonen:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "_Alle duplicaatrecepten samenvoegen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Recepten samenvoegen</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "_Auto-samenvoegen"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Voor elke geselecteerde waarde"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Waar %(field)s is %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Veranderingen zullen effect hebben op %s recept"
 msgstr[1] "Veranderingen zullen effect hebben op %s recepten"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "%s verwijderen waar het %s is?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "%s van %s naar \"%s\" veranderen?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Deze verandering kan niet teruggedraaid worden.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Veldbeheer"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Velden tegelijkertijd bewerken in meerdere recepten."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Recepten e-mailen"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Alle geselecteerde recepten e-mailen (of alle recepten indien er geen "
@@ -2402,162 +2340,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Wilt u echt alle %s geselecteerde recepten e-mailen?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Ja, _e-mail ze"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Kan %s niet omrekenen naar %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Dichtheidsinformatie nodig."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Maten omrekenen"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Maten omrekenen"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Maten omrekenen"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>van</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "I_tem:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Dichtheid:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Dichtheids_informatie"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>naar</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Resultaat:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Archief (zip, tarball)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Zip-archief laden"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Zip-archief uitpakken"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML webpagina"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Bezig met exporteren van webpagina"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Bezig met exporteren van recepten naar HTML-bestanden in map %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Recept als HTML-bestand %(file)s opgeslagen"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Originele pagina van %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "optioneel"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Bezig met exporteren van webpagina"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Bezig met exporteren van recepten naar HTML-bestanden in map %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Recept als HTML-bestand %(file)s opgeslagen"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Platte tekstbestand"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Tekst export"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Recepten exporteren naar tekstbestand %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Recepten opgeslagen als tekstbestand %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Groot bestand"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Bestand %s is te groot om te importeren"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2569,81 +2495,54 @@ msgstr ""
 "tekstverwerker om het te splitsen in kleinere delen, probeer het daarna "
 "opnieuw te importeren."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Website"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Bezig met downloaden van %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Boodschappenlijst voor %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "%s wordt opgehaald"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML-bestand"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML-export"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Recepten exporteren naar Gourmet XML-bestand %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Recept opgeslagen in Gourmet XML-bestand %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML-bestand (verouderd)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML-bestand"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook-tekstbestand"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "MasterCook-import voltooid."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "XML schoonmaken"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML-bestand"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2652,275 +2551,296 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Pagina-opmaak"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Recepten afdrukken"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF-export"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Recepten exporteren naar PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Recept opgeslagen als PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Rechtop"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Liggend"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Normaal"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "punten"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Indexkaart (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Indexkaart (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Indexkaart (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Indexkaart (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Rechtop"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Indexkaarten (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Indexkaarten (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Index-kaarten (A7"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Liggend"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Normaal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Kolom"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Kolom"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Kolom"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Kolom"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s Kolom"
 msgstr[1] "%s Kolommen"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Liggend"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Liggend"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Papier_formaat"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Oriëntatie"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Grootte _Lettertype"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Pagina-inde_ling"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Grootte _Lettertype"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Linkermarge"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Rechtermarge"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Bovenmarge"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Ondermarge"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "PDF-opties"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster-bestand"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster export"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Bezig met exporteren van recepten naar MealMaster-bestand %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Recept opgeslagen als MealMaster-bestand %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "persoon"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Groot bestand"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "HTML-export"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Recepten exporteren naar Gourmet XML-bestand %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Recept opgeslagen in Gourmet XML-bestand %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Opslaan boodschappenlijst"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Boodschappenlijst opslaan als recept"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 "Huidige boodschappenlijst opslaan als een recept voor toekomstig gebruik"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Menu voor %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Voedingswaarde is hoeveelheid per %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Voedingswaarde is hoeveelheid voor gehele recept"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Voedingswaarde ontbreekt voor %s ingrediënten: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Iedere groep"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "Selectie"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Maat omrekenen voor %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Om de voedingswaarde te berekenen heeft Gourmet uw hulp nodig om \"%s\" om "
 "te rekenen naar een bekende maat."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Ingrediëntsleutel veranderen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2929,27 +2849,27 @@ msgstr ""
 "Ingrediëntsleutel overal veranderen van %(old_key)s in %(new_key)s of alleen "
 "in recept %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Ov_eral veranderen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "Alleen in recept %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Ingrediëntsleutel overal van %(old_key)s naar %(new_key)s veranderen?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Maat veranderen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2958,11 +2878,11 @@ msgstr ""
 "Maat van %(old_unit)s in %(new_unit)s veranderen voor alle ingrediënten "
 "%(ingkey)s of alleen in recept %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2971,198 +2891,199 @@ msgstr ""
 "verschillende beschrijvingen van dit voedingsmiddel met verschillende "
 "dichtheden. Selecteer de juiste hieronder:"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Om de voedingswaarde te berekenen heeft Gourmet een bekende hoeveelheid en "
 "maat nodig."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Voeding"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingrediënt"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Equivalent USDA-databank"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gram"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Calorieën"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Totale vetgehalte"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Verzadigd vet"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Cholesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Zout"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Totale hoeveelheid koolhydraten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Voedingsvezels"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Suikers"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteïne"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alpha-caroteen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "As"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-caroteen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta-cryptoxanthine"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Calcium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Koper"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Totale hoeveelheid foliumzuur"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Foliumzuur"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Foliumzuur in voeding"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Foliumzuurequivalenten in dieet"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "IJzer"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "lycopeen (natuurlijk geel)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Luteïne+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangaan"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacine"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Vitamine B5"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Kalium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamine A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selenium"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Thiamine (vitamine B1)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamine A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamine A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamine B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamine B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamine C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamine E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamine K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zink"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitaminen en mineralen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3171,11 +3092,11 @@ msgstr ""
 "Voedingswaarde onbekend van \n"
 "%(missing)s van de %(total)s ingrediënten."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Dagelijkse hoeveelheid"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3184,370 +3105,370 @@ msgstr ""
 "Het percentage van de aanbevolen dagelijkse hoeveelheid is gebaseerd op %i "
 "calorieën per dag. Klik om het aantal calorieën per dag aan te passen."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Hoeveelheid per %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Hoeveelheid per recept"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Gegevens voedingswaarde laden"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Importeren voedingswaarde-databank voltooid!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Voedingswaardedatabank uit zip-archief %s halen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "%s wordt uit zip-archief gehaald"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Gegevens voedingswaarde worden verwerkt..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 "Gegevens voedingswaarde worden gelezen: %s van de %s regels geïmporteerd."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Gegevens gewicht worden verwerkt..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Gegevens gewicht voor voedingswaarde worden gelezen: %s van de %s regels "
 "geïmporteerd."
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Water"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilocalorieën"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g proteïnen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipiden (vetten)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g as"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g koolhydraten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g vezels"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g suiker"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg calcium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg ijzer"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnesium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg kalium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg zout"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg zink"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg koper"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg mangaan"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "microgram seleen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamine C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg thiamine"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg riboflavine (vitamine B2)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niacine"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg pantotheenzuur"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamine B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "microgram Folium in totaal"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "microgram Foliumzuur"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "microgram Voedingsfolium"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "microgram foliumzuurequivalenten in dieet"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Totale hoeveelheid choline"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "microgram Vitamine B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamine A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamine A (microgram 'Netvlies activiteiten equivalenten'"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "microgram Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "microgram Alpha-caroteen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "microgram Beta-caroteen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "microgram Beta-cryptoxanthine"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "microgram lycopeen (natuurlijk geel)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "microgram Luteïne+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamine E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamine K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g Verzadigde Vetzuren"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g Enkelvoudig Onverzadigde Vetzuren"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g Meervoudig Onverzadigde Vetzuren"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Cholesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Percenten afval"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Zuivel- & Eierproducten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Kruiden & Specerijen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Babyvoeding"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Vetten & Oliën"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Gevogelte"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Soepen & Sauzen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Worst & Fijne vleeswaren"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Ontbijtgranen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Fruit en Fruitsappen"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Varkensvlees"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Groenten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Noten & Zaden"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Rundvlees"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Dranken"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Vis & Schaaldieren"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Peulvruchten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Lam, Kalf & Wild"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Gebakken producten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Snoep"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Rijst & Pasta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Fastfood"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Hoofdgerechten, Voorgerechten & Bijgerechten"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Snacks"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Uitheems Eten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "Gehele databank"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Ingrediëntsleutel"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "USDA-ID-nummer"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA-itemomschrijving"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Dichtheidsequivalent"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA-ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3561,61 +3482,61 @@ msgstr "Hulpmiddelen"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Voedingswaarde voor huidige lijst verkrijgen"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Hoeveelheid voor boodschappenlijst"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "_Voedingswaarde bewerken"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "sterren"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "%(number)s van %(total) recepten geëxporteerd"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Exporteren voltooid"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 "Recept aan de tekst van het e-mailbericht toevoegen (in alle gevallen een "
 "goed idee)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Recept e-mailen als HTML-bijlage."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Recept e-mailen als PDF-bijlage"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "E-mailopties"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Niet vragen voor het verzenden van e-mail."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-mail niet verzonden"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3623,235 +3544,188 @@ msgstr ""
 "U heeft niet gekozen om het recept aan de tekst van het bericht toe te "
 "voegen of als bijlage aan het bericht toe te voegen."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Recept opslaan als..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet kan geen bestand van het type \"%s\" exporteren"
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Recepten exporteren"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recepten"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Kon niet exporteren: onbekend bestandstype \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "Selecteer a.u.b. een bestandstype uit het keuzemenu bij het opslaan."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Exporteren"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Kon niet afdrukken: er zijn geen afdrukplug-ins ingeschakeld!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "%s recept afdrukken"
 msgstr[1] "%s recepten afdrukken"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Bestand ophalen"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "aantal"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "De URL van een receptenarchief of receptenwebsite invoeren."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Voer website-adres in"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "URL invoeren:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Voer website-adres of receptenarchief in."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Kon URL niet importeren"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Er is geen plug-in beschikbaar voor het importeren van de URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Kon URL %(url)s met mimetype %(type)s niet importeren. Bestand opgeslagen "
-"naar tijdelijke locatie %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Recept openen..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Voer website-adres in"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Wijzigingen"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Voer website-adres of receptenarchief in."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importeren"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Alle bestanden die geïmporteerd kunnen worden"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "%s recepten geïmporteerd."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "persoon"
 msgstr[1] "personen"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "%s van %s recepten geïmporteerd."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "ok"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-"Deze webpagina wordt niet herkend. De generieke importeur wordt gebruikt..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Importeren voltooid"
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Recept importeren"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Ingrediënten worden verwerkt"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Ingrediënten worden verwerkt."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Personen"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Ingrediëntensubgroup"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Verbergen"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Tekst"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Acties"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Recept importeren"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "_Labels verwijderen"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Recept importeren"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "Overal"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "titel"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrediënt"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "aanwijzingen"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "notities"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "keuken"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "bron"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Normale uitdrukkingen gebruiken voor het zoeken"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Normale uitdrukkingen gebruiken (een geavanceerde zoektaal) om tekst te "
 "zoeken"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Zoeken terwijl u typt (schakel dit uit als zoeken langzaam gaat)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Zoek_opties tonen"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Geavanceerde zoekopties tonen"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3860,104 +3734,98 @@ msgstr[1] "%s recepten"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Recepten %(bottom)s t/m %(top)s van %(total)s worden getoond"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s in %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Gepauzeerd"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "KRecipe-import"
 msgstr[1] "KRecipe-import"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pauze"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Klaar"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Fout: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Fout"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Fout %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Herleiden"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "seconde"
 msgstr[1] "seconden"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min."
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuut"
 msgstr[1] "minuten"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "uur"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "uur"
 msgstr[1] "uren"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
 msgstr[1] "dagen"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
 msgstr[1] "weken"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -3966,7 +3834,7 @@ msgstr[1] "maanden"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"
@@ -3978,73 +3846,30 @@ msgstr[1] "jaren"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " en "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "en"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "tot"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML-bestand"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet-receptbeheer"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Recepten organiseren, boodschappenlijsten maken, voedingswaarden berekenen "
-"en meer."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Recepten doorbladeren"
@@ -4055,7 +3880,6 @@ msgstr ""
 "Recepten selecteren d.m.v. het doorbladeren van categorie, keuken, enz."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Algemeen"
@@ -4069,38 +3893,6 @@ msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 "Een assistent om duplicaatrecepten te zoeken verwijderen of samen te voegen"
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Verzenden naar e-mail"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Recepten e-mailen met Gourmet"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Ondersteuning voor Zip, Gzip, en Tarball"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Recepten importeren uit zip- en tar-archieven"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Importeren/Exporteren"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4110,6 +3902,18 @@ msgstr "PDF-export"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Receptwebsites van recepten aanmaken."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Importeren/Exporteren"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4122,14 +3926,6 @@ msgid ""
 msgstr ""
 "Recepten importeren en exporten als Gourmet XML-bestanden, toepasbaar voor "
 "back-up of uitwisseling met andere Gourmet-gebruikers."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "HTML-export"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Receptwebsites van recepten aanmaken."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4191,22 +3987,6 @@ msgid ""
 msgstr ""
 "Helpt gebruiker bij markeren en importeren van platte tekst. Geeft ook de "
 "mogelijkheid voor het exporteren als platte tekst."
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Webpagina importeren"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Recepten importeren vanaf het web."
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Website-importeerders"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Importeerders voor about.com, www.foodnetwork.com, en andere"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4275,6 +4055,198 @@ msgstr ""
 "geïmporteerd worden. Schakel dit uit wanneer u nooit UTF16 gebruikt en u "
 "voortdurend de 'Coderingsdialoog' te zien krijgt bij het importeren van "
 "bestanden."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Geselecteerd recept e-mailen"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "Recept _e-mailen"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (assistentie bij het poorten naar Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (verbeteringen aan maatomrekeninterface)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (verbeteringen aan MealMaster export)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo en welkomstscherm)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr ""
+#~ "Yula Zubritsky (voedingswaarde en ´Toevoegen aan boodschappenlijst´-"
+#~ "pictogrammen)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (verbeteringen aan "
+#~ "internationalisatie, verschillende bugfixes)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Windows-versie onderhoud en website "
+#~ "redesign)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Databank bijwerken"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Afhankelijk van de grootte van uw databank kan dit een langdurig proces "
+#~ "zijn. Er wordt automatisch een back-up van uw data gemaakt, voor als er "
+#~ "iets fout mocht gaan."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Ingrediënten plakken"
+
+#~ msgid "Import from file"
+#~ msgstr "Importeren vanaf bestand"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Selecteer een bestand dat uw ingrediëntenlijst bevat."
+
+#~ msgid "No file selected"
+#~ msgstr "Geen bestand geselecteerd"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Er werd geen bestand geselecteerd, de actie is geannuleerd"
+
+#~ msgid "_Import file"
+#~ msgstr "Bestand _importeren"
+
+#~ msgid "Import _webpage"
+#~ msgstr "_Website importeren"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Recept importeren vanaf website"
+
+#~ msgid "Open _Trash"
+#~ msgstr "_Prullenbak openen"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Archief (zip, tarball)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Zip-archief laden"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Zip-archief uitpakken"
+
+#~ msgid "Webpage"
+#~ msgstr "Website"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Bezig met downloaden van %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Boodschappenlijst voor %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "%s wordt opgehaald"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Bestand ophalen"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "De URL van een receptenarchief of receptenwebsite invoeren."
+
+#~ msgid "Enter URL:"
+#~ msgstr "URL invoeren:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Kon URL niet importeren"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Er is geen plug-in beschikbaar voor het importeren van de URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Kon URL %(url)s met mimetype %(type)s niet importeren. Bestand opgeslagen "
+#~ "naar tijdelijke locatie %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr ""
+#~ "Deze webpagina wordt niet herkend. De generieke importeur wordt "
+#~ "gebruikt..."
+
+#~ msgid "Import complete."
+#~ msgstr "Importeren voltooid"
+
+#~ msgid "Importing recipe"
+#~ msgstr "Recept importeren"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Ingrediënten worden verwerkt"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Ingrediënten worden verwerkt."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML-bestand"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet-receptbeheer"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Recepten organiseren, boodschappenlijsten maken, voedingswaarden "
+#~ "berekenen en meer."
+
+#~ msgid "Send to Email"
+#~ msgstr "Verzenden naar e-mail"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Recepten e-mailen met Gourmet"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Ondersteuning voor Zip, Gzip, en Tarball"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Recepten importeren uit zip- en tar-archieven"
+
+#~ msgid "HTML Export"
+#~ msgstr "HTML-export"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Receptwebsites van recepten aanmaken."
+
+#~ msgid "Webpage import"
+#~ msgstr "Webpagina importeren"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Recepten importeren vanaf het web."
+
+#~ msgid "Website Importers"
+#~ msgstr "Website-importeerders"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Importeerders voor about.com, www.foodnetwork.com, en andere"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4409,9 +4381,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "Per_sonen"
-
-#~ msgid "Select File_type"
-#~ msgstr "Selecteer bestands_type"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Er bestaat al een bestand met de naam %s."

--- a/po/nl_BE.po
+++ b/po/nl_BE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gourmet Recipe Manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2007-04-01 15:19+0000\n"
 "Last-Translator: Desikn <Unknown>\n"
 "Language-Team: Dutch (Belgium) <nl_BE@li.org>\n"
@@ -20,506 +20,509 @@ msgstr ""
 "X-Generator: Launchpad (build 16514)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nieuw recept"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Aan _boodschappenlijstje toevoegen"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Bestand"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recept"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Details"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gourmet Receptenbeheerder"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Boodschappenlijstje"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Titel"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "categorie"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recept"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingrediënten"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Recept verwijderen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Geselecteerde recepten verwijderen"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +530,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Categorie"
 
@@ -560,285 +563,287 @@ msgstr "Categorie"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Sleutel"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Kookwekker"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "eenheid"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet Receptenbeheerder"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,204 +858,164 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Windows porting assistentie)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (verbeteringen aan eenhedenomzetter interface)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (verbeteringen aan MealMaster export)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Nieuw recept"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Naar _boodschappenlijstje verplaatsen"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Boodschappenlijstje"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Al reeds in bezit (_Provisiekast items)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Geef categorie in"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Categorie %s toe te voegen aan"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recepten"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Recepten verwijderen"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Recepten van boodschappenlijstje verwijderen"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Bewerk"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Hulp"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Geen recepten geselecteerd. Wilt u de volledige lijst leeg maken?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Sla boodschappenlijstje op als ..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1059,204 +1024,200 @@ msgstr ""
 "plaatsen."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Recept afdrukken"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Aan _boodschappenlijstje toevoegen"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "U heeft niet opgeslagen veranderingen."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Pas veranderingen toe voordat u afdrukt?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Pas veranderingen toe voordat u afdrukt?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Optioneel)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Receptenkaart bekijken"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Kies een bestand die uw ingrediëntenlijst bevat."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instructies"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notities"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Aantal"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Eenheid"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Item"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Optioneel"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Het recept %s (ID %s) bevindt zich niet in onze databank."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Omgezet: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Niet omgezet: %(amt)s % (unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Veranderde eenheid."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1265,243 +1226,241 @@ msgstr ""
 "U heeft de eenheid van %(item)s van %(old)s naar %(new)s veranderd. Wilt u "
 "het aantal omzetten of niet?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "%(old_amt)s %(old_unit)s omgezet naar %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Kan niet van %(old_unit)s naar %(new_unit)s omzetten"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Bezig met ingrediëntengroep aan het toevoegen"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Geef een nieuwe naam in voor subgroep van ingrediënten"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Recept kan zichzelf niet als een ingrediënt aanroepen!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Oneindige recursie is niet toegestaan in recepten!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "U heeft geen recepten geselecteerd!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recepten"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Keuken"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Waardering"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Bron"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Tijd om klaar te maken"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Kooktijd"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Wijzigingen"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Gepauzeerd"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stop"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Me dit niet meer vragen."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Wilt u dit echt doen"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "fair"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "arm"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Waarderingen omzetten in 5-sterrenschaal"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Waarderingen omzetten."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Geef iedere waardering een getal op een schaal van 1 tot 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Geen bestand geselecteerd"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Selecteer bestands_type"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Geen bestand was geselecteerd, dus de actie werd afgebroken."
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr "Het spijt me, ik begrijp het aantal \"%s\" niet."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1513,84 +1472,84 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "bloem, alle doeleinden"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "suiker"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "zout"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "zwarte peper, gemaald"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "ijs"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "water"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "olie, plantaardig"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "olie, olijf"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Recept roept zichzelf aan als ingrediënt."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Ingrediënten %s zullen genegeerd worden."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Boodschappenlijstje voor %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Voor de volgende recepten:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Voor de volgende recepten:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Selecteer encodering"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1598,29 +1557,28 @@ msgstr ""
 "Kan de correcte encodering niet bepalen. Selecteer de correcte encodering "
 "uit de volgende lijst."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Bekijk _bestand met encodering"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importeren gepauzeerd"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Stop importeren"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Recepten_index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Boodschappen_lijstje"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Gregory Deseck\n"
@@ -1629,337 +1587,321 @@ msgstr ""
 "  Desikn https://launchpad.net/~desikn\n"
 "  Jan Dante Meulemeester https://launchpad.net/~jandante"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Opgeslagen!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Sla uw bewerkingen op %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Een import is bezig."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Een export is bezig."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Een verwijdering is bezig."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Toch programma sluiten?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Niet sluiten!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Teruggezette recepten "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Geselecteerde recepten verwijderen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Afdrukken"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "recepten"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Exporteer recepten"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "Recept afdrukken"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Acties"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Info"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Extra"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "%s verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "Er zijn niet opgeslagen veranderingen gemaakt aan %s. Weet u zeker dat u "
 "deze wilt verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Verwijder recepten definitief?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Verwijder het recept definitief?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Bent u zeker dat u het recept <i>%s</i> wilt verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Bent u zeker dat u de volgende recepten wilt verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Bent u zeker dat u de %s geselecteerde recepten wilt verwijderen?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Zie recepten"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Recepten_index"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Verwijder recept %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Gedaan!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Bezig aan het importeren ..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "sleutel"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "item"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Tel"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1967,12 +1909,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1980,78 +1922,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2060,387 +2002,375 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Aantal"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Boodschappencategorie"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Geen"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Kan %s niet omzetten naar %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Densiteitsinformatie nodig."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Eenhedenomzetter"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML Webpagina"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Bezig webpagina aan het exporteren"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Recepten naar HTML-bestanden in map %(file)s aan het exporteren"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Recept als HTML-bestand %(file)s opgeslagen"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "optioneel"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Bezig webpagina aan het exporteren"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Recepten naar HTML-bestanden in map %(file)s aan het exporteren"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Recept als HTML-bestand %(file)s opgeslagen"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Tekst export"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2448,81 +2378,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Boodschappenlijstje voor %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML-bestand"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML export"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Recepten naar Gourmet XML-bestand %(file)s aan het exporteren."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Recept opgeslagen in Gourmet XML-bestand %(bestand)en."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "MasterCook import beëindigd."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "XML schoonmaken"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2531,882 +2434,899 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Druk recepten af"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster bestand"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster export"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Bezig recepten naar MealMaster-bestand %(file)s aan het exporteren."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Recept als MealMaster-bestand %(file)s opgeslaan"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "Porties"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Bestand"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Tekst export"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Recepten naar Gourmet XML-bestand %(file)s aan het exporteren."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Recept opgeslagen in Gourmet XML-bestand %(bestand)en."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3420,59 +3340,59 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Geëxporteerd %(number)s van %(total) recepten"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Export compleet."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Plaats recept in de kern van de e-mail (een goed idee)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "E-mail recept als HTML bijlage"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "E-mail opties"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Vraag niet voor het zenden van e-mail."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-mail niet verzonden"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3480,230 +3400,186 @@ msgstr ""
 "U heeft niet gekozen om het recept in de body van het bericht te plaatsen of "
 "als een bijlage bij het bericht te voegen."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Sla recept op als ..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet kan geen bestand van het type \"%s\" exporteren"
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Exporteer recepten"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recepten"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Druk %s recept af"
 msgstr[1] "Druk %s recepten af"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Vul de URL van een receptenarchief of receptenwebsite in"
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "URL invullen:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Vul de URL van een receptenarchief of receptenwebsite in"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Wijzigingen"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Alle bestanden die geïmporteerd kunnen worden"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "%s van %s recepten geïmporteerd."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Porties"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "titel"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrediënt"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instructies"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "notities"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "keuken"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "bron"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3712,103 +3588,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "seconden"
 msgstr[1] "seconden"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuten"
 msgstr[1] "minuten"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "u."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "uren"
 msgstr[1] "uren"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dagen"
 msgstr[1] "dagen"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3817,7 +3687,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaren"
@@ -3829,71 +3699,30 @@ msgstr[1] "jaren"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML-bestand"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet Receptenbeheerder"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3903,7 +3732,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3916,38 +3744,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -3955,6 +3751,18 @@ msgstr "Tekst export"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3965,14 +3773,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4026,22 +3826,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4101,6 +3885,39 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Windows porting assistentie)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (verbeteringen aan eenhedenomzetter interface)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (verbeteringen aan MealMaster export)"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Kies een bestand die uw ingrediëntenlijst bevat."
+
+#~ msgid "No file selected"
+#~ msgstr "Geen bestand geselecteerd"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Geen bestand was geselecteerd, dus de actie werd afgebroken."
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Boodschappenlijstje voor %s"
+
+#~ msgid "Enter URL:"
+#~ msgstr "URL invullen:"
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML-bestand"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet Receptenbeheerder"
+
 #~ msgid "Gourmet Recipe Manager starting up..."
 #~ msgstr "Opstarten Gourmet Receptenbeheerder ..."
 
@@ -4137,9 +3954,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Bezig receptgegevens van een vorige versie van Gourmet in de nieuwe "
 #~ "databank te importeren."
-
-#~ msgid "Select File_type"
-#~ msgstr "Selecteer bestands_type"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Een bestand met naam %s bestaat reeds."

--- a/po/oc.po
+++ b/po/oc.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: po_gourmet-oc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2013-12-03 10:33+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (lengadocian) <ubuntu-l10n-oci@lists.ubuntu.com>\n"
@@ -21,508 +21,511 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Indèx de las recèptas"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "Recèpta _novèla"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Apondre a la lista de _crompas"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Veire la recèpta"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Recercar :"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_dins"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Apondre un critèri de recèrca"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Limitar la recèrca a :"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Resultats de la recèrca"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Apondre un imatge"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Suprimir l'imatge"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "_Font :"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Nòta :"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "Cosina"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Categoria :"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "_Temps de preparacion"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Temps de coseson :"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Pagina Internet"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Imatge :"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Part :"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Rendament unitari"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Causir la banca de donadas"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "_Sistèma de banca de donadas"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Òste :"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "Nom d'_utilizaire :"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "Se_nhal :"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Nom de la banca de donadas"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Fichièr"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "_Enregistra lo senhal"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recèpta"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Percórrer"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detalhs"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gestionari de recèptas Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Preferéncias de la vista per indèx</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Afichar las _opcions"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Recèptas per pagina :"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Vista per lista"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Preferéncias de la vista per ficha</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Utilizar de fraccions"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Afichatge de la carta"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Preferéncias de la lista de crompas</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Lista de crompas"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "porcions"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Títol"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Títol :"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "_Temps de preparacion :"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "categoria"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "nòta"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Rendament"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Rendament unitari"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Apondre a las crompas"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Modificar _la descripcion"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Temps de coseson :</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Temps de preparacion :</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Cosina :</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Categoria :</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Pagina internet :</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Parts :</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Ligam</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Font :</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Nòta :</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Multiplicar per :</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Instruccions</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Modificar _las instruccions"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Nòtas</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Modificar _las nòtas"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recèpta"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Ingredients</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Modificar _los ingredients"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Apondre _un ingredient :"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredients"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Suprimir la recèpta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Suprimir las recèptas seleccionadas"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Causir una recèpta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "_Imprimir la recèpta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -530,31 +533,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Afichar las _opcions"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Recercar _dins"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Opcions de recèrca</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Categoria"
 
@@ -563,288 +566,290 @@ msgstr "Categoria"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Clau"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Cercar per"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Recercar al moment de la picada"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Utilizar las expressions racionalas"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Recèrca avançada"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Apondre una categoria : "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Cronomètre"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Minutador</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Temps passat !</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Programar lo minu_tador : "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Reïnicializar"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Aviar"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "S_on"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Nòta"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Paramètres"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Camp a _modificar :"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Per cada valor seleccionada :"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Camp :"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Valor :"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "_Suprimir la valor"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Seleccionar l’equivalent de</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>dempuèi la banca de donadas USDA</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "_Cambiar l’ingredient"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>o</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Resultats de la recèrca :</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>De :</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Quantitat :"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Unitat :"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "unitat"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>A :</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Unitat :"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>Element USDA : </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "Modificar l’associacion _USDA"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "Modificar las _informacions"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Densitat :"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "Equivalents USDA"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Equivalents personalizats"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "I_gnorar"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gestionari de recèptas Gourmet"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Copyright (c) 2004,2005,2006,2007,2008,2009,2010,2011 Thomas M. Hinkle. GNU "
 "GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -859,651 +864,604 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (assisténcia de portatge Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (lògo e vidèo d'aviada)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr "Detalhs"
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Nom de la banca de donadas"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr "Detalhs"
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Cambiar la _categoria"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Lista de las cr_ompas"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Entrar una categoria"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Categoria :"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recèptas"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Apondre d'elements :"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Suprimir las recèptas"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Edicion"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Ajuda"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Apondre d'elements"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recèpta"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Anar"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Exportar la recèpta"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Suprimir la recèpta"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Suprimir aquesta recèpta"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Estampar la recèpta"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Apondre a la lista de _crompas"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Exportar la recèpta"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Falcutatiu)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Modificar la recèpta :"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Veire la ficha recèpta"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Editar"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Apondre un ingredient"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Apondre un grop"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Pegar los ingredients"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importar dempuèi un fichièr"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Apondre una _recèpta"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Suprimir"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Montar"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Davalar"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Descripcion"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instruccions"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Nòtas"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Qtat"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Unitat"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Element"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Opcional"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Convertit : %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Unitat cambiada."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "%(old_amt)s %(old_unit)s convertit en %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Impossible de convertir de %(old_unit)s en %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Nom del grop :"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Causir una recèpta"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recèptas"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Sonariá"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Son d’avertiment"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Son d’error"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Arrestar lo minutador ?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Arrestar lo minutador"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Conservar lo minutatge"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Empeutons"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "o"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Classificacion"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Font"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Site web"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Temps de preparacion"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Modificacions"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pausa"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Arrestar"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Me pausar pas pus la question"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "corrècte"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Pas de fichièr seleccionat"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Seleccionar lo tipe de fichièr"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1515,114 +1473,113 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "Nom d'_utilizaire :"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "Se_nhal :"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "farina, totes tipes"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "sucre"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sal"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "pebre negre, molut"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "glaç"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "aiga"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "òli vegetal"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "òli d'oliva"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "L’ingredient %s serà ignorat."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Lista de crompas per %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Per las recèptas seguentas :"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Per las recèptas seguentas :"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importacion en pausa"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Arrestar l'importacion"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Indèx de las recèptas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Lista de crompas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Yannig Marchegay (Kokoyaya) <yannig@marchegay.org>\n"
@@ -1631,335 +1588,321 @@ msgstr ""
 "  Cédric VALMARY (Tot en òc) https://launchpad.net/~cvalmary\n"
 "  Yannig MARCHEGAY (Kokoyaya) https://launchpad.net/~yannick-marchegay"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Salvat !"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Importacion en cors."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Exportacion en cors."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Supression en cors."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Quitar l'aplicacion malgrat tot ?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Quitar pas !"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Escobilhièr"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Nombre de %(unit)s de %(title)s de crompar"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multiplicar %s per :"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Cercar de recèptas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Dobrir una recèpta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Suprimir la recèpta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Suprimir las recèptas seleccionadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Imprimir"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "recèptas"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Novèl"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Importar un fichièr"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Exportar la recèpta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Importar una pagina _web"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Importer une recette depuis une page web"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s recèpta"
+
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Quitar"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Accions"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr ""
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Escobilhièr"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Preferéncias"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "Em_peutons"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Preferé_ncias"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_A prepaus"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Aisinas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "Minu_tador"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Suprimir %s ?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Suprimit"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Sens títol"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Indèx de las recèptas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Acabat !"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importacion..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "clau"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "element"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Zòna"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Comptar"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1967,12 +1910,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1980,78 +1923,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2060,387 +2003,375 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Quantitat"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Clau :"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Categoria de crompas"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Estelas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "i a %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Pas cap"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Impossible de convertir %s en %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Convertidor d’_unitat"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Convertidor d'unitats"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Dempuèi</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "Element"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Densitat :"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Informacion sus la densitat"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Cap a</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Resultat :"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "Pagina HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Expòrt de la pagina"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Pagina originala de %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "opcional"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Expòrt de la pagina"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2448,81 +2379,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Pagina Web"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Telecargament de %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Lista de crompas per %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Fichièr XML Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Exportar al format XML Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Fichièr XML Gourmet (obsolet)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2531,882 +2435,903 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Organizacion de la pagina"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Exportar al format PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Letra"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Retrach"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Simpla"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "punts"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Letra"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Informacions legalas"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Païsatge"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Simpla"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s colomna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s colomna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s colomna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s colomna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s colomna"
 msgstr[1] "%s colomnas"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Retrach"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Païsatge"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientacion"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Marge d'esquèrra"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Marge de drecha"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "Opcions PDF"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "porcions"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Fichièr"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Exportacion HTML"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menú"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "seleccion"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Nutricion"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingredient"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 grames"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Calorias"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Matèria grassa totala"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Grais saturat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Colesteròl"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sòdi"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Total d’idrats de carbòni"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Fibras alimentàrias"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Sucres"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteïna"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfacarotèn"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Ash"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Bètacarotèn"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Bètacriptoxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Calci"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Coire"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Acid folic total"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Acid folic"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Folacina alimentària"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Equivalents dietetics de folacina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Fèrre"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Licopèn"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Luteïna+Zeazantina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnèsi"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Manganès"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Vitamina B3"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Acid pantotenic"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfòr"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potassi"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamina A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinòl"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selèni"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamina A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamina A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zinc"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitaminas e minerals"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Valor jornalièra"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Quantitat per %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Quantitat per recèpta"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Aiga"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Quilocalorias"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g de proteïnas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g de lipids"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g de cendre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g d’idrats de carbòni"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g de fibras"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g de sucre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg de calci"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg de fèrre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg de magnèsi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg de fosfòr"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg de potassi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg de sòdi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg de zinc"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg de coire"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg de manganès"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "µg de Seleni"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg de vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg de tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg de riboflavina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg de vitamina B3"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg d’acid pantotenic"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg de vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "µg de folacina al total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "µg d’acid folic"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "µg de folacina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "µg d’equivalents dietetics folacina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Total colina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "µg de vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamina A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamina A (micrograma de retinòl-equivalent)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "micrograma de Retinòl"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "micrograma d’alfacarotèn"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "micrograma de bètacarotèn"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "micrograma de bètacriptoxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "micrograma de Licopèn"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "micrograma Luteïna+Zeazantina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg de Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg de Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g d’acids grasses saturats"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g d’acids grasses monoinsaturats"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g d’acids grasses insaturats"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg de colesteròl"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Percentatge de descais"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Uòus e produches lachièrs"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Espècias e èrbas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Aliments per nenon"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Graisses e òlis"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Polalha"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Sopas e sauças"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Carns e saucissas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Cerealas de dejunar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Frucha e chucs de frucha"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Pòrc"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Legums"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Noses e granas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Buòu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Bevendas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Peisses e cauquilhatges"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Leguminoses"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Anhèl, vedèl e salvatgina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Plats cosinats"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Sucrariás"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Cerealas e pastas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Restauracion rapida"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Repais, plats principals, e acompanhament"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Snacks"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Cosinas del mond"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Clau d’ingredient"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "Identificant USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "Descripcion d’element USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Equivalent de densitat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "Numèro USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3420,288 +3345,243 @@ msgstr "Aisinas"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Obténer las informacions nutricionalas per aquesta lista"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Quantitat per la lista de crompas"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "estelas"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Exportacion acabada."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recèptas"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Exportar"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Estampar %s recèpta"
 msgstr[1] "Estampar %s recèptas"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Modificacions"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importar"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Cobèrts"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Amagar"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Tèxte"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Accions"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "títol"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingredient"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instruccions"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "nòtas"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "cosina"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "font"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3710,103 +3590,97 @@ msgstr[1] "%s recèptas"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s dins %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "En pausa"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pausa"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Acabat"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Error : %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Error"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Error %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "segonda"
 msgstr[1] "segondas"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuta"
 msgstr[1] "minutas"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "oras"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ora"
 msgstr[1] "oras"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jorn"
 msgstr[1] "jorns"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "setmana"
 msgstr[1] "setmanas"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -3815,7 +3689,7 @@ msgstr[1] "meses"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "annada"
@@ -3827,73 +3701,30 @@ msgstr[1] "annadas"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " e "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "e"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "cap a"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Fichièr XML Gourmet"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gestionari de recèptas Gourmet"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organizar de recèptas, crear de listas de corsas, calcular de "
-"caracteristicas nutricionalas, e plan mai de causas encara."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3903,7 +3734,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Principal"
@@ -3916,38 +3746,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -3955,6 +3753,18 @@ msgstr "Exportar al format PDF"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3965,14 +3775,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "Exportacion HTML"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4026,22 +3828,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4101,6 +3887,62 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (assisténcia de portatge Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (lògo e vidèo d'aviada)"
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Pegar los ingredients"
+
+#~ msgid "Import from file"
+#~ msgstr "Importar dempuèi un fichièr"
+
+#~ msgid "No file selected"
+#~ msgstr "Pas de fichièr seleccionat"
+
+#~ msgid "_Import file"
+#~ msgstr "_Importar un fichièr"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Importar una pagina _web"
+
+#~ msgid "Webpage"
+#~ msgstr "Pagina Web"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Telecargament de %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Lista de crompas per %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Fichièr XML Gourmet"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gestionari de recèptas Gourmet"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organizar de recèptas, crear de listas de corsas, calcular de "
+#~ "caracteristicas nutricionalas, e plan mai de causas encara."
+
+#~ msgid "HTML Export"
+#~ msgstr "Exportacion HTML"
+
 #~ msgid "_Raw recipe:"
 #~ msgstr "_Recèpta bruta :"
 
@@ -4130,9 +3972,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "_Porcions"
-
-#~ msgid "Select File_type"
-#~ msgstr "Seleccionar lo tipe de fichièr"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Un fichièr nomenat %s existís ja."

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gourmet Recipe Manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2013-07-18 10:17+0000\n"
 "Last-Translator: wir3k <wir1990@gmail.com>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -21,64 +21,64 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Lista Przepisów"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nowy Przepis"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Dodaj do li_sty zakupów"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Zobacz Prze_pis"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "Wy_szukiwanie:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Szukaj przepisów w trakcie pisania"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_w"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Szukaj poprzez inne kryteria w obecnych wynikach wyszukiwania."
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "_Dodaj Kryterium Wyszukiwania"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Ogranicz wyszukiwanie do:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Wyniki _Wyszukiwania"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Ustaw pola dla wybranych przepisów"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -86,129 +86,132 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Ustaw pola receptur do wybranych "
 "przepisów</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Dodaj obraz"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "Usuń Ob_razek"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "Źródł_o:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Ocena:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "K_uchnia"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Kategoria:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "Czas _Przygotowania"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Czas Go_towania:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "Strona interneto_wa"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Grafika:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "W_ydajność:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Jednostka wydajności"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "Tylko określone wartości, gdzie pole jest obecnie pustye"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Ustaw wszystkie wartości dla wszystkich wybranych przepisów"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (domyślne, zapisane w lokalnym pliku)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQL (przechowuje w lokalnym pliku)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (wymaga połączenia z bazą danych)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Wybierz Bazę Danych"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Wybierz System Bazodanowy dla użycia przez Gourmet</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "System Baz _Danych"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Gospodarz"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "Nazwa _użytkownika:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Hasło:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Hasło dla nazwy użytkownika w bazie danych."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "_Nazwa Bazy Danych:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Plik"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -217,11 +220,11 @@ msgstr ""
 "serwer bazy danych jest uruchomiony w systemie lokalnym, należy użyć "
 "localhost."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -229,11 +232,11 @@ msgstr ""
 "Zapisz hasło do użycia ponownie. Oznacza to że hasło będzie przechowane "
 "niezabezpieczone w lokalnym pliku konfiguracyjnym."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "Zapisz Ha_sło"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -241,300 +244,301 @@ msgstr ""
 "Nazwa bazy danych, w której Gourmet powinien przechowywać swoje informacje. "
 "Gourmet spróbuje stworzyć bazę danych, jeśli nie istnieje."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "przepis"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Nazwa użytkownika w bazie danych."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Przeglądaj"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Szczegóły"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Preferencje Menedżera Receptur Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Preferencje Widoku Indeksu</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Pokaż _Opcje"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "Przepisów na st_ronię:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr "<i>Skonfiguruj kolumny, które są zawarte w indeksie przepisu.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Widok Indeksu"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Preferencje Widoku Karty</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "Pozwól jednostkom zmienić się, gdy są mnożone"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Użyj ułamków"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Użyj ułamków, jeśli to możliwe na ekranie"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 "<i>Usuń elementy, które nie korzystają z interfejsu karty przepisu.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Widok karty"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Preferencje Widoku Listy Zakupów</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Co powinienem Gourmet zrobić z opcjonalnymi składnikami podczas dodawania "
 "przepisów do listy zakupów?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "Zap_ytaj, czy uwzględnić ewentualne składniki"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "Zapamiętaj wybó_r użytkownika domyślnie"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "Wyczyść zapamiętane składniki opcjonalne"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "Zawsze dodawaj dodatkowe składniki"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Nigdy nie dodawaj opcjonalnych składników"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Lista Zakupów"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "porcji"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Tytuł"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Tytuł:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Czas _Przygotowania:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategoria"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "ocena"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Wydajność"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Jednostka wydajności"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Sklep"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "E_dytuj opis"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Czas Gotowania:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Czas Przygotowania:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Kuchia:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Kategoria:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Strona internetowa:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>W_ydajność</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Link</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Źródło:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Ocena:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>Po_mnuż przez:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Instrukcje:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Edytuj _instrukcje"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Notatki</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Edytuj _notatki"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Przepis"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Składniki</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Edytuj składn_iki"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Dodaj składn_iki:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Składniki"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Dodaj przepis do listy zakupów"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Dodaj do li_sty zakupów"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Skocz do przepisu w widoku Karty Receptur"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Usuń wybrany przepis"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Usuń Przepis"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Edycja atrybutów wybranych przepisów"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "_Wsadowa edycja przepisów"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "E-mail wybrany przepis"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Otwórz wybrany przepis"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "_E-Mail przepis"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Wybierz przepis"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Drukuj wybrany przepis"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "_Drukuj przepis"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -546,31 +550,31 @@ msgstr ""
 "uwzględnione podczas zapisywania lub drukowania listy, jeżeli nie powiesz "
 "mi, że trzeba to kupić."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Dodaj do s_piżarni"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Pokaż _Opcje"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Szukaj _w"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "Użyj wyrażeń regularnych (wyszukiwanie zaawansowane)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Szu_kaj podczas wpisywania"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Opcje Wyszukiwania</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategoria"
 
@@ -579,288 +583,290 @@ msgstr "Kategoria"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Klucz"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Edytor kategorii"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Szukaj za pomocą"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Szukaj w trakcie wpisywania"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Użyj wyrażeń regularnych"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Zaawansowane Wyszukiwanie"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Dodaj Kategorię: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Minutnik"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Minutnik</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Czas się skończył!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Minutnik będzie kontynuował odliczanie do momentu zamknięcia tego okna lub "
 "wyzerowania stopera."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Us_taw Minutnik "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Resetuj"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Uruchom"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "_Dźwięk"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Notatka"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "_Powtarzaj alarm dopóki go nie wyłączę"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Ustawienia"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Edycja pól w całej bazie danych</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Pole do _edycji:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Dla każdej wybranej wartości:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "Z_ostaw wartość tak jak"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>Nowa wartość będzie dodana na końcu aktualnego tekstu</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Nowa wartość zastąpi każdą wartość aktualną</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Pole:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Wartość:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Zmień _inne pola:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "Z_mień wartość na: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "_Usuń wartość"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>wybierz odpowiednik</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>z bazy USDA</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>lub</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Wyszukuj podczas w_pisywania"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>Wyszukaj_wyniki:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>Od:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "K_wota:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "jednostka"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>Do:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Jednostka:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Wpisz informacje odżywcze dla </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Wybierz gęstość</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Składnik kluczowy: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>Składniki USDA: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Informacje o wartości odżywczej</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Wiadome informacje odżywcze</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "_Zaawansowane wyszukiwanie"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Wartości odżywcze"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet - menedżer szefa kuchni"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -883,218 +889,169 @@ msgstr ""
 "Gourmet. Gourmet obsługuje dołączanie zdjęć do przepisów, potrafi także na "
 "podstawie składników obliczyć wartość odżywczą przepisów."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (pomoc przy przenoszeniu na platoformę Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-"Daniel Folkinshteyn <nanotube@gmail.com>\n"
-"(instalator dla systemu Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Fergusin (ulepszenie interfejsu Konwertera Jednostek)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (ulepszenie eksportu z Mealmastera)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo i splash screen)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (dietetyka i ikony dodawania do listy zakupów)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (udoskonalenia w "
-"umiędzynarodowieniu, różnego rodzaju poprawki)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Windows version maintenance and website "
-"re-design)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Wybierz plik bazy danych"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Aktualizacja bazy danych"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Nowy Przepis"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "_Nazwa Bazy Danych:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"W zależności od rozmiarów twojej bazy danych, może to być intensywny proces  "
-"i może zająć trochę czasu. Dla twoich danych została automatycznie utworzona "
-"kopia zapasowa w przypadku, gdyby coś poszło nie tak."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Szczegóły"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Kopia bezpieczeństwa została utworzona w %s w przypadku gdyby coś poszło "
 "źle. Jeżeli aktualizacja się nie powiedzie, możesz ręcznie zmienić nazwę "
 "pliku kopii bezpieczeństwa - recipes.db aby przywrócić dane, lub aby użyć go "
 "ze starszą wersją programu Gourmet."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Nowy Przepis"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Zmień _kategorię"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Utwórz nową kategorię"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Zmień kategorię aktualnie zaznaczonej pozycji"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Spiżarnia"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Przenieś do Li_sty Zakupów"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Przenieś do _spiżarni"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Usuń z listy zakupów"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Przenieś zaznaczone pozycje do %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Lista zakupów"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Już masz (Pozycje S_piżarni)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Wprowadź Kategorię"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Katagoria do której chcesz dodać %s"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategoria:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "P_rzepisy"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Dodaj pozycje:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Usunięte przepisy"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Usuń przepisy z listy zakupów"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Edycja"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "Po_moc"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Dodaj pozycje"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Dodaj dowolne pozycje do listy zakupów"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Nie wybrano żadnych przepisów. Czy chcesz wymazać całą listę?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Zapisz Listę Zakupów Jako..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Wybierz składniki dodatkowe"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1103,57 +1060,59 @@ msgstr ""
 "dołączyć do listy zakupów."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Przepis"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Idź"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Eksportuj przepis"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Eksportuj zaznaczony przepis (zapis do pliku)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Usuń przepis"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Usuń ten przepis"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Dostosuj jednostki podczas przemnażania"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Zmień jednostki (gdzie możliwe) podczas przemnażania, by były bardziej "
 "czytelne."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Drukuj przepis"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Dodaj do li_sty zakupów"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Zapomnij zapamiętane składniki dodatkowe"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1161,150 +1120,144 @@ msgstr ""
 "Przed dodawaniem do listy zakupów, pytaj o wszystkie składniki dodatkowe, "
 "nawet te, które poprzednio chciałeś by były zapamiętane"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Eksportuj przepis"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Nie zapisałeś zmian."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Zachować zmiany nim przystąpisz do wydruku?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Zachować zmiany nim przystąpisz do wydruku?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Opcjonalne)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Nie można znaleźć przepisu %s w bazie."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Edytuj przepis:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Zapisz zmiany do bazy"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Zobacz kartę przepisu"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Edycja"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Zapisz zmiany w %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Dodaj składnik"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Dodaj grupę"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Wklej składniki"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importuj z pliku"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Dodaj p_rzepis"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Dodaj kolejny przepis jako składnik w tym przepisie"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "W górę"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "W dół"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Wybierz plik zawierający twoją listę składników."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Opis"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instrukcje"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notatki"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Il."
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Jednostka"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Pozycja"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Opcjonalne"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Przepisu %s (ID %s) nie ma w naszej bazie danych."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Skonwertowane: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Nie skonwertowane: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Zmienione jednostki."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1313,246 +1266,245 @@ msgstr ""
 "Zmieniłeś jednostkę %(item)s z %(old)s na %(new)s. Czy chcesz również "
 "przekonwertować ilość?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Przekonwertowano %(old_amt)s %(old_unit)s na %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Nie można przekonwertować z %(old_unit)s na %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Dodaję Grupę Składników"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Podaj nazwę nowej podgrupy składników"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Nazwa grupy"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Wybierz przepis"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Przepis nie może odwoływać się do siebie jako składnika!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Nieskończona rekurencja jest nie dozwolona w przepisach!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Nie wybrałeż żadnych przepisów!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Przepis"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Dźwięk dzwonka"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Dźwięk ostrzegawczy"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Dźwięk błędu"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Zatrzymać minutnik?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "_Zatrzymaj minutnik"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Odliczaj dalej"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Wtyczki"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Pluginy dodają ekstra funkcjonalność do Groumet."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Wtyczka jest potrzebna dla innych wtyczek. Dezaktywować wtyczkę mimo to?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Następujące wtyczki wymagają %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Dezaktywuj mimo wszystko"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Zostaw wtyczkę aktywną"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "lub"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Pojawił się błąd podczas aktywowania wtyczki"
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Wystąpił błąd podczas dezaktywacji wtyczki."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Kuchnia"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Ocena"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Źródło"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Strona Internetowa"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Czas Przygotowania"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Czas Gotowania"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Modyfikacje"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Nieprawidłowe dane wejściowe."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "To nie jest liczba"
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pauza"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stop"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Nie pytaj mnie o to ponownie."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Czy naprawdę chcesz to zrobić"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "doskonały"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "znakomity"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "dobry"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "zadawalający"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "słaby"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Konwertuj rankingi do skali 5 gwiazdek."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Konwertuj rankingi."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Proszą podaj dla każdej oceny jej odpowiednik w skali od 1 do 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Obecna Ocena"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Ocena w skali pięciogwiazdkowej"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Nie wybrano plików"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Wybierz Typ_Pliku"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Nie wybrano plików, dlatego akcja została wstrzymana"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr "Przepraszam, ale nie mogę zrozumieć ilości \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Ilości muszą być liczbami (ułamki zwykłe lub dziesiętne), zakresami liczb, "
 "lub puste."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1572,86 +1524,86 @@ msgstr ""
 "Aby wprowadzić zakres licz, używaj \"-\" aby je oddzielić.\n"
 "Na przykład, możesz wprowadzić 2-4 lub 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "Nazwa _użytkownika:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Hasło:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "mąka, wszystkie zastosowania"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "cukier"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sól"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "czarny pieprz, zmielony"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "lód"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "woda"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "olej, warzywa"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "oliwa"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Przepis wywołuje sam siebie jako składnik."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Składnik %s zostanie zignorowany."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Lista zakupów dla %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Dla następujących przepisów:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Dla następujących przepisów:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Wybierz kodowanie"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1659,29 +1611,28 @@ msgstr ""
 "Nie można ustalić odpowiedniego kodowania. Proszę wybrać odpowiednie "
 "kodowanie z poniższej listy."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Obejrzyj _plik z kodowaniem"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Import wstrzymany"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Zatrzymaj import"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Indeks Przepisów"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Lista Zakupów"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "tłumacze\n"
@@ -1711,82 +1662,63 @@ msgstr ""
 "  Łukasz Daniel https://launchpad.net/~lukasz-daniel\n"
 "  Łukasz Nowak https://launchpad.net/~shufla"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Zapisane!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Zapisz swoje zmiany do %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Import w trakcie."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Eksport w trakcie."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Usuwanie w trakcie."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Czy na pewno wyjść z progamu?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Nie wychodź!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Trwale usunięto %s z %s przepisów"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Kosz"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Przeglądaj, usuń trwale lub przywróć usunięte przepisy"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Nieusunięte przepisy "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Ilość %(unit)s  %(title)s do zakupienia"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Pomnóż %s przez:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
@@ -1794,253 +1726,259 @@ msgstr[0] "Ustawić %(attributes)s dla %(num)s wybranego przepisu?"
 msgstr[1] "Ustawić %(attributes)s dla %(num)s wybranych przepisów?"
 msgstr[2] "Ustawić %(attributes)s dla %(num)s wybranych przepisów?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Wszelkie istniejące wartości nie zostaną zmienione."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Nowe wartości nadpiszą wszystkie uprzednio istniejące wartości."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Ta zmiana nie może być cofnięta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Ustaw wartości dla wybranych przepisów"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Szukaj przepisów"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Otwórz przepis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Otwórz wybrany przepis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Usuń przepis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Usuń zaznaczone przepisy"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Edytuj przepis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Otwórz wybrany przepis w widoku edytora przepisów"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_ksportuj wybrane przepisy"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Eksportuj wybrane przepisy do pliku"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Drukuj"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "przepisy"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "_Grupowa edycja przepisów"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nowy"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Importuj plik"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Importuj przepis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Importuj przepis z pliku"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Importuj _stronę www"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s przepis"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Importuj przepis ze strony www"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Eksportuj _wszystkie przepisy"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Eksportuj wszystkie przepisy do pliku"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Wyjdź"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Akcje"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Otwórz _kosz"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Kosz"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Preferencje"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Wtyczki"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Zarządzaj wtyczkami, które dodają ekstra funkcjonalności do Gourmet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Ustawie_nia"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_O programie"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Narzędzia"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Minutnik"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Pokaż zegar"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Indeks przepisów w bazie"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Usunąć %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Masz niezapisane zmiany w %s. Czy na pewno usunąć?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Usunięto"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Bez tytułu"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Czy usunąć trwale przpisy?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Czy usunąć trwale przepis?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Czy jesteś pewien, że chcesz usunąć przepis <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Czy jesteś pewien, że chcesz usunąć następujące przepisy?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Czy jesteś pewien, że chcesz usunąć %s wybrane przepisy?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Zobacz przepisy"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Usuń przepisy"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Lista Przepisów"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Usunięty przepis %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Wykonane!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importuję..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Edytor składników"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Grupowo edytuj składniki"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "klucz"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "pozycja"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Pole"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Wartość"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Oblicz"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Zmienić wszystkie klawisze \"%s\" na \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2051,12 +1989,12 @@ msgstr ""
 "\"%s\", nie będzie możliwości odróżnienia ich od elementów, które są właśnie "
 "zmieniane."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Zmienić wszystkie elementy \"%s\" na \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2067,12 +2005,12 @@ msgstr ""
 "\"%s\", nie będzie możliwości odróżnienia ich od elementów, które są właśnie "
 "zmieniane."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Zmień wszystkie wystąpieni_a \"%(unit)s\" na \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2081,13 +2019,13 @@ msgstr ""
 "Zamień \"%(unit)s\" na \"%(text)s\" tylko dla składn_ików \"%(item)s\" o "
 "kluczu \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Zmień wszystkie wystąpieni_a \"%(amount)s\" %(unit)s na %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2096,7 +2034,7 @@ msgstr ""
 "Zmień \"%(amount)s\" %(unit)s na \"%(text)s\" %(unit)s tylko gdy kluczem "
 "składnika jest %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2105,11 +2043,11 @@ msgstr ""
 "Zmień \"%(amount)s\" %(unit)s na \"%(text)s\" %(unit)s tylko gdy kluczem "
 "składnika jest %(key)s _a elementem jest %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Zmienić wszystkie wybrane rzędy?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2118,7 +2056,7 @@ msgstr ""
 "Tej akcji nie da się cofnąć. Czy jesteś pewny, że dla wszystkich %s "
 "wybranych wierszy chcesz ustawić następujące wartości:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2127,7 +2065,7 @@ msgstr ""
 "\n"
 "Klucz do %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2136,7 +2074,7 @@ msgstr ""
 "\n"
 "Element na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2145,7 +2083,7 @@ msgstr ""
 "\n"
 "Jednostka na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2154,8 +2092,8 @@ msgstr ""
 "\n"
 "Ilość na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2165,23 +2103,23 @@ msgstr[2] "%s składników"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Wyświetlono skłądników od %(bottom)s do %(top)s z %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Ilość"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Składniki"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2189,11 +2127,11 @@ msgstr ""
 "Składnikami kluczowymi są znormalizowane składniki używane do listy zakupów "
 "i do obliczeń"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Odgadnij wartości"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2201,56 +2139,56 @@ msgstr ""
 "Odgadnij najlepsze wartości dla wszystkich składnków bazując na danych "
 "pobranych z Twojej bazy"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Zmień skojarzenia"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Edytuj skojarzenia z kluczem i innymi atrybytami w bazie"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Edycja klawiszy"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "_Rzecz"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Klawisz:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>_Zmień zaznaczone składniki</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Kategoria Zakupów"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Wyświetl jednostki takie jakie są dla każdego przepisu (bez zmian)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Zawsze wyświetla jednostki U.S."
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Zawsze wyświetlaj jednostki metryczne"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Automatycznie dostosuj jednostki"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "_Ustaw preferowane jednostki"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2258,42 +2196,42 @@ msgstr ""
 "Automatycznie konwertuj jednostki do preferowanego systemu (metryczny, "
 "angielski, etc.) gdzie tylko możliwe."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Gwiazdki"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s temu"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Automatyczne łączenie przepisów"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Zawsze używaj najnowszego przepisu"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Zawsze używaj najstarszego przepisu"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Nic"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2301,61 +2239,61 @@ msgstr ""
 "Niektóre z zaimportowanych przepisów mogą być duplikatami. Możesz je scalić "
 "tutaj, albo zamknąć to okno aby pozostawić je w takiej postaci."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Znajdź _powtarzające się przepisy"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Znajdź i usuń powtarzające się przepisy"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Receptury z podobnymi informacjami o przepisie"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Receptury z podobnymi składnikami"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Receptury z podobnymi informacjami o przepisie oraz składnikami"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Duplikaty receptur</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "_Razem z recepturami z kosza"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Pokazuj</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Połącz _wszystkie duplikaty"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Scalanie receptur</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "_Auto-połącz"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Dla każdej zaznaczonej wartości"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Gdzie %(field)s to %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
@@ -2363,36 +2301,36 @@ msgstr[0] "Zmiana będzie dotyczyć %s przepisu"
 msgstr[1] "Zmiana będzie dotyczyć %s przepisów"
 msgstr[2] "Zmiana będzie dotyczyć %s przepisów"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Usunąć %s, gdzie podane jest %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Zmienić %s z %s na \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Ta zmiana jest nieodwracalna.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Edytor pól"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Edycja pól w wielu przepisach na raz"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Wyślij przepisy poprzez e-mail"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Wyślij wszystkie zaznaczone przepisy emailem (lub wszystkie przepisy jeśli "
@@ -2401,164 +2339,152 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 "Czy naprawdę chcesz wysłać poprzez e-mail wszystkie %s zaznaczonych "
 "przepisów?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Tak, wyślij je poprzez e_mail"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Nie można skonwertować %s do %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Potrzebna informacja o gęstości."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Konwerter _Jednostek"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Przelicz konwersję jednostek"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Przelicznik jednostek"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Z</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "Po_zycja:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Gęstość:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "_Informacje o gęstość"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Do</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Wynik:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Archiwum (zip, tarbal)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Ładowanie archiwum zip"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Rozpakowywanie archizum zip"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "Strona HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Eksportowanie strony."
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Eksportowanie przepisów do pliku HTML w katalogi %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Przepis zapisany jako plik HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Oryginalna strona z %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "opcjonalne"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Eksportowanie strony."
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Eksportowanie przepisów do pliku HTML w katalogi %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Przepis zapisany jako plik HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Płaski plik tekstowy"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Eksport tekstowy"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Eksportowanie przepisów do pliku tekstowego %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Przepis zapisany jako płaski plik tekstowy %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Duży plik"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Plik %s jest zbyt duży by go zaimportować"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2570,81 +2496,54 @@ msgstr ""
 "jakiegoś edytora tekstowego, by rozdzielić plik na mniejsze części i spróbuj "
 "ponownie."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Strona www"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Pobieranie %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Lista zakupów dla %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Pobieranie %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Plik XML Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Eksport Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Eksportowanie przepisów do pliku Gourmet XML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Przepis zapisany w pliku Gourmet XML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet plik XML (przestarzałe)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Plik XML Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Plik tekstowy Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Import pliku Mastercook zakończony."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Czyszczenie pliku XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "Plik XML KRecipe"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2653,106 +2552,119 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Układ strony"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Drukuj Przepisy"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Export PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Eksport przepisów do PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Przepis zapisany jako PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "List"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Pionowo"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Zwykły"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "punkty"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17''"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Strona indeksu (3.5x5'')"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Strona indeksu (4x6'')"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Strona indeksu (5x8'')"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Strona indeksu (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "List"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Prawne"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Strona indeksu (3,5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Strona indeksu (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Strona indeksu (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Orientacja pozioma"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Zwykły"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Kolumna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Kolumna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Kolumna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Kolumna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
@@ -2760,168 +2672,176 @@ msgstr[0] "%s Kolumna"
 msgstr[1] "%s Kolumny"
 msgstr[2] "%s Kolumn"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Pionowo"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Orientacja pozioma"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "_Rozmiar papieru"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientacja"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Rozmiar _Czcionki"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "_Układ Strony"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Rozmiar _Czcionki"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Lewy Margines"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Prawy Margines"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Margines Górny"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Margines Dolny"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "Ustawienia PDF"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "Plik MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Eksport MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Eksportowanie przepisów do pliku MealMaster (tm) %(file)s"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Przepis zapisany jako plik MealMaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "porcja"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Duży plik"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Eksport HTML"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Eksportowanie przepisów do pliku Gourmet XML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Przepis zapisany w pliku Gourmet XML %(file)s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Zapisywanie Listy Zakupów"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Zapisz listę jako przepis"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Zapisz bieżącą listę zakupów jako przepis dla przyszłego użytku"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Menu dla %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Informacja o wartości odżywczej uwzględnia ilość na %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Informacja o wartości odżywczej uwzględnia ilość dla całego przepisu."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Brakuje informacja o wartościach odżywczych dla %s składników: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Każda grupa żywności"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "zaznaczenie"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Konwertuj jednostkę dla %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Aby przeliczyć informacje o składnikach odżywczych, musisz pomóc zamienić "
 "\"%s\" na jednostkę którą Gourmet rozumie."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Zmień składnik"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2930,27 +2850,27 @@ msgstr ""
 "Zmienić klucz składnika z %(old_key)s na %(new_key)s wszędzie, czy tylko w "
 "przepisie %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Zmień _wszędzie"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "Tylko w przepisie %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Zmień jednostkę"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2959,11 +2879,11 @@ msgstr ""
 "Zmienić jednostkę z %(old_unit)s na %(new_unit)s dla wszystkich składników "
 "%(ingkey)s, czy tylko w przepisie %(title)s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2972,198 +2892,199 @@ msgstr ""
 "dotyczacych tego składnika z podaną różną gestościa. Prosze wybrać poniżej "
 "włąściwą gęstość."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Żeby zastosować informacje dietetyczne, Gourmet musi dysponować poprawną "
 "ilością i jednostką miary."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Wartości odżywcze"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Składnik"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Odpowiednik bazy USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gramów"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalorie"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Całkowity tłuszcz"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Tłuszcze Nasyconw"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Cholesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sód"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Ogółem Węglowadanów"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Błonnik pokarmowy"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Cukry"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Białka"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-karoten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Jesion"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-karoten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta-karoten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Wapń"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Miedź"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Ogółem Kwasu Foliowego"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Kwas foliowy"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Kwas foliowy"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Żywieniowe Odpowiedniki Kwasu Foliowego"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Żelazo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Likopen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Luteina+Zeaksantyna"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnez"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacyna"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Kwas pantotenowy"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potas"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Witamina A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Ryboflawina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Witamina A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Witamina A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "WItamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Witamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Witamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Witamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Witamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Cynk"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Witaminy i minerały"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3172,11 +3093,11 @@ msgstr ""
 "Brakuje informacji dietetycznych\n"
 "dla %(missing)s z %(total)s składników."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Dzienna dawka"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3185,369 +3106,369 @@ msgstr ""
 "Procent rekomendowanej dziennej dawki oparty o %i kalorii dziennie. Kliknij "
 "aby zmienić ilość dziennej dawki kalorii."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Ilość na %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Ilość na przepis"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Ładowanie danych dietetycznych"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Import bazy dietetycznej zakończony!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Pobieranie bazy dietetycznej z archiwum zip %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Rozpakowywanie %s z archwium zip."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Analizowanie danych dietetycznych"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Odczytywanie danych dietetycznych: zaimportowano %s z %s wpisów."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Analizowanie danych o wadze..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Odczyt informacji wagowych dla elementów dietetycznych: zaimportowano %s z "
 "%s pozycji"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Woda"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalorie"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g białka"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipidów"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g popiołu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g węglowodorów"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g błonnika"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g cukrów"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg wapnia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg żelaza"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnezu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosforu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg potasu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg sodu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg cynku"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg miedzi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg manganu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mikrogram selenu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg witaminy C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg tiaminy"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg ryboflawiny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niecyny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg kwasu pantotenowego"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg witaminy B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "mikrogramy kwasu foliowego sumarycznie"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "mikrogram kwasu foliowego"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "mikrogramy kwasu foliowego"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "Odpowiedniki kwasu foliowego w mikrogramach"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mikrogram witaminy B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Witamina A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Witamina A (odpowiedniki witaminy A w mikrogramach)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "mikrogram witaminy A"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "mikrogram Alfa-karotenu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "mikrogram Beta-karotenu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "mikrogram Beta-karotenu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "mikrogram likopenu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "mikrogram luteiny z zeaksantyną"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Witaminy E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg witaminy K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g nasyconych kwasów tłuszczowych"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g jednonienasyconych kwasów tłuszczowych"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g wielonienasyconych kwasów tłuszczowych"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg cholesterolu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Procent odrzucony"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Produkty Nabiałowe i Jaja"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Przyprawy & Zioła"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Jedzenie Dziecięce"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Tłuszcze i oleje"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Drób"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Zupy i sosy"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Kiełbasy i wędliny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Płatki Śniadaniowe"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Owoce & Soki owocowe"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Wieprzowina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Warzywa"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Orzechy i nasiona"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Wołowina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Napoje"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Ryby & Skorupiaki"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Warzywa strączkowe"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Jagnięcina, Cielęcina i Dziczyzna"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Produkty Wypiekane"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Słodycze"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Zboża i makarony"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Fast Food"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Potrawy, Przystawki i Przekąski"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Przekąski"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Potrawy etniczne"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "cała baza danych"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Składnik"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "Numer ID USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Odpowiednik gęstości"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3561,108 +3482,108 @@ msgstr "Narzędzia"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Pobierz wartości odżywcze dla aktualnej listy"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Ilość pozycji Listy zakupów"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "Edytuj info wartości od_żywczych"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "gwiazdki"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Wyeksportowano %(number)s z %(total)s przepisów"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Eksport zakończony"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 "Załącz Przepis w Treści E-maile (Bardzo dobry pomysł bez różnicy na wszystko)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Wyślij Przepis E-mailem jako załącznik HTML"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Wyślij przepis w formacie PDF poprzez e-mail."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Opcje E-mail"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Nie pytaj przed wysyłaniem e-maili."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-mail nie wysłany"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 "Nie wybrałeś aby dołączyć przepis jako treść wiadomości lub jako załącznik"
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Zapisz przepis jako..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet nie może eksportować plików typu \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Eksportuj przepisy"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "przepisy"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Nie można eksportować: nieznany format pliku \"%s\"."
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "Upewnij się, że zaznaczyłeś format pliku z listy podczas zapisu."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Eksport"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Nie można drukować: brak aktywnych wtyczek druku!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
@@ -3670,188 +3591,142 @@ msgstr[0] "Wydrukuj %s przepis"
 msgstr[1] "Wydrukuj %s przepisy"
 msgstr[2] "Wydrukuj %s przepisów"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Pobieranie pliku"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "wydajność"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Wprowadź URL archiwum przepisów lub strony z przepisami."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Wpisz adres strony www"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Wprowadź URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Wpisz adres strony www lub archiwum przepisów"
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Nie można zaimportować adresu URL"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet nie posiada wtyczki umożliwiającej importowanie adresów URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Nie można zaimportować %(type)s z URL%(url)s. Plik został zapisany w "
-"położeniu %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Otwórz przepis..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Wpisz adres strony www"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Modyfikacje"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Wpisz adres strony www lub archiwum przepisów"
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Import"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Wszystkie importowalne pliki"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Przepis %s został pobrany"
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "porcja"
 msgstr[1] "porcje"
 msgstr[2] "porcje"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Zaimportowano %s z %s przepisów."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "OK"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Strona nie została rozpoznana. Zostanie użyty ogólny importer..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Import zakończony."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Importowanie przepisu"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Przetwarzanie składników"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Przetwarzanie składników."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Serwowanie"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Podgrupa składników"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Ukryj"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Tekst"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Czynności"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importuj przepis"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Wyczyść _znaczniki"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Importuj przepis"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "gdziekolwiek"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "tytuł"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "składnik"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instrukcje"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "notatki"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "kuchnia"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "źródło"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Użyj wyrażeń regularnych podczas wyszukiwania"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Użyj wyrażeń regularnych (zaawansowany język wyszukiwania) w wyszukiwaniu "
 "tekstu"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 "Wyszukuj podczas wpisywania (wyłącz, jeśli wyszukiwanie jest zbyt wolne)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Pokaż _opcje wyszukiwania"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Pokaż zaawansowane opcje wyszukiwania"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3861,21 +3736,21 @@ msgstr[2] "%s przepisów"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Pokazuję przepisy %(bottom)s do %(top)s z %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s w %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Wstrzymano"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
@@ -3883,43 +3758,37 @@ msgstr[0] "Import KRecipe"
 msgstr[1] "Import KRecipe"
 msgstr[2] "Import KRecipe"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Wstrzymaj"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Wykonano"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Błąd: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Błąd"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Błąd %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Prześledź"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "sekunda"
@@ -3927,11 +3796,11 @@ msgstr[1] "sekundy"
 msgstr[2] "sekund"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuta"
@@ -3939,32 +3808,32 @@ msgstr[1] "minuty"
 msgstr[2] "minut"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "godz."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "godzina"
 msgstr[1] "godziny"
 msgstr[2] "godzin"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dzień"
 msgstr[1] "dni"
 msgstr[2] "dni"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tydzień"
 msgstr[1] "tygodnie"
 msgstr[2] "tygodni"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "miesiąc"
@@ -3974,7 +3843,7 @@ msgstr[2] "miesięcy"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"
@@ -3987,73 +3856,30 @@ msgstr[2] "lat"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " i "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "i"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "do"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Plik XML Gourmet"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet - menedżer szefa kuchni"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Porządkuj przepisy, twórz listy zakupów, obliczaj informacje odżywcze i dużo "
-"więcej."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Przeglądaj Przepisy"
@@ -4063,7 +3889,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Wybierz przepisy przeglądając kategorie, kuchnie, itd."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Główny"
@@ -4076,38 +3901,6 @@ msgstr "Znajdź duplikaty przepisów"
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr "Kreatorna znajdzie  i usunie lub scali duplikaty przepisów."
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Wyślij email"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Wyślij receptury z Gourmet"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Wsparcie Zip, Gzip, oraz Tarball"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Importuj przepisy z archiwum zip oraz tar"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Importer/Exporter"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4117,6 +3910,18 @@ msgstr "Export PDF"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Stwórz stronę przepisu z receptury"
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Importer/Exporter"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4129,14 +3934,6 @@ msgid ""
 msgstr ""
 "Import oraz Export przepisów Gourmet jako plik XML,  odpowiednie do "
 "tworzenia kopii zapasowych lub wymiany z innymi użytkownikami Gourmet."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "Eksport HTML"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Stwórz stronę przepisu z receptury"
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4199,22 +3996,6 @@ msgstr ""
 "Pomoże użytkownikowi oznaczyć i zaimportować zwykły tekst. Pozwala również "
 "wyeksportować zwykły tekst."
 
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Import strony internetowej"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Importuj receptury z internetu."
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Importowanie z sieci"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Importuje dla about.com, www.foodnetwork.com, i innych"
-
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
 "Assign and edit ingredient keys (unique identifiers for ingredients, used "
@@ -4273,6 +4054,197 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "E-mail wybrany przepis"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "_E-Mail przepis"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (pomoc przy przenoszeniu na platoformę Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr ""
+#~ "Daniel Folkinshteyn <nanotube@gmail.com>\n"
+#~ "(instalator dla systemu Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Fergusin (ulepszenie interfejsu Konwertera Jednostek)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (ulepszenie eksportu z Mealmastera)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo i splash screen)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (dietetyka i ikony dodawania do listy zakupów)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (udoskonalenia w "
+#~ "umiędzynarodowieniu, różnego rodzaju poprawki)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Windows version maintenance and "
+#~ "website re-design)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Aktualizacja bazy danych"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "W zależności od rozmiarów twojej bazy danych, może to być intensywny "
+#~ "proces  i może zająć trochę czasu. Dla twoich danych została "
+#~ "automatycznie utworzona kopia zapasowa w przypadku, gdyby coś poszło nie "
+#~ "tak."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Wklej składniki"
+
+#~ msgid "Import from file"
+#~ msgstr "Importuj z pliku"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Wybierz plik zawierający twoją listę składników."
+
+#~ msgid "No file selected"
+#~ msgstr "Nie wybrano plików"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Nie wybrano plików, dlatego akcja została wstrzymana"
+
+#~ msgid "_Import file"
+#~ msgstr "_Importuj plik"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Importuj _stronę www"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Importuj przepis ze strony www"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Otwórz _kosz"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Archiwum (zip, tarbal)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Ładowanie archiwum zip"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Rozpakowywanie archizum zip"
+
+#~ msgid "Webpage"
+#~ msgstr "Strona www"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Pobieranie %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Lista zakupów dla %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Pobieranie %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Pobieranie pliku"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Wprowadź URL archiwum przepisów lub strony z przepisami."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Wprowadź URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Nie można zaimportować adresu URL"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet nie posiada wtyczki umożliwiającej importowanie adresów URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Nie można zaimportować %(type)s z URL%(url)s. Plik został zapisany w "
+#~ "położeniu %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Strona nie została rozpoznana. Zostanie użyty ogólny importer..."
+
+#~ msgid "Import complete."
+#~ msgstr "Import zakończony."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Importowanie przepisu"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Przetwarzanie składników"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Przetwarzanie składników."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Plik XML Gourmet"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet - menedżer szefa kuchni"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Porządkuj przepisy, twórz listy zakupów, obliczaj informacje odżywcze i "
+#~ "dużo więcej."
+
+#~ msgid "Send to Email"
+#~ msgstr "Wyślij email"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Wyślij receptury z Gourmet"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Wsparcie Zip, Gzip, oraz Tarball"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Importuj przepisy z archiwum zip oraz tar"
+
+#~ msgid "HTML Export"
+#~ msgstr "Eksport HTML"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Stwórz stronę przepisu z receptury"
+
+#~ msgid "Webpage import"
+#~ msgstr "Import strony internetowej"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Importuj receptury z internetu."
+
+#~ msgid "Website Importers"
+#~ msgstr "Importowanie z sieci"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Importuje dla about.com, www.foodnetwork.com, i innych"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4399,9 +4371,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "_Porcje"
-
-#~ msgid "Select File_type"
-#~ msgstr "Wybierz Typ_Pliku"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Plik o nazwie %s już istnieje."

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2011-06-24 21:55+0000\n"
 "Last-Translator: Nuno Rodrigues <Unknown>\n"
 "Language-Team: Portuguese <pt@li.org>\n"
@@ -20,506 +20,509 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nova Receita"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Adicionar à _Lista de Compras"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Ficheiro"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "receita"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detalhes"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gestor de Receitas Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Lista de Compras"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Título"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "categoria"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Receita"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredientes"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Apagar Receita"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Abrir receita seleccionada"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Abrir receita"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +530,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Categoria"
 
@@ -560,286 +563,288 @@ msgstr "Categoria"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Chave"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Temporizador"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "unidade"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gestor de Receitas Gourmet"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -862,206 +867,164 @@ msgstr ""
 "linkagem de imgens com receitas. O Gourmet pode também calcular a informação "
 "nutricional para as receitas baseando-se nos seus ingredientes"
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (assistência ao porte para MS Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Instalador para Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (melhorias à interface do Conversor de Unidades)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "RS Born (melhorias à exportação para Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logótipo e ecrã de entrada)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (nutritição e ícones da lista de compras )"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (melhorias a internacionalização,"
-"algumas correcções)"
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr "Detalhes"
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Nova Receita"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr "Detalhes"
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Mover para lista de _Compras"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Li_sta de Compras"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Já possui (_Itens de Despensa)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Entre Categoria"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Categoria onde acrescentar %s"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Categoria:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Receitas"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Remover Receitas"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Remover receitas da lista de compras"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Editar"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Ajuda"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "×"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Nenhuma receita selecionada.  Você quer limpar toda a lista?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Salvar Lista de Compras Como"
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1070,437 +1033,431 @@ msgstr ""
 "incluir em sua lista de compras."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Receita"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Imprimir receita"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Adicionar à _Lista de Compras"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Você tem mudanças a salvar."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Aplicar mudanças antes de imprimir?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Aplicar mudanças antes de imprimir?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Opcional)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Incapaz de encontrar receita %s na base de dados."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Editar Receita:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Ver Cartão de Receitas"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Escolha um arquivo contendo sua lista de ingredientes."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instruções"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notas"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Qtd"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Unidade"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Item"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Opcional"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "A receita %s (ID %s) não está em nossa base de dados."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Converter: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Não Convertido: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Unidade alterada."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr "Você alterou a unidade para %(item)s de %(old)s para %(new)s."
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "%(old_amt)s %(old_unit)s convertidos para %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Incapaz de converter de %(old_unit)s para %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Acrescentar Grupo de Ingredientes"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Entrar um nome para o novo subgrupo de ingredientes"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Nome do grupo:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "A própria receita não pode incluir-se como um ingrediente!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Recursão infinita é proibida em receitas!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Você não selecionou nenhuma receita!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Receitas"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Som de Toque"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Som de Aviso"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Som de Erro"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Parar temporizador?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Parar _temporizador"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Manter temporizador"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "ou"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Cozinha"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Classificação"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Fonte"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Tempo de Preparação"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Tempo de Cocção"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Alterações"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Entrada inválida."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Não é um número."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Suspender"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Parar"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Não me pergunte isto novamente."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Você realmente quer fazer isto"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "excelente"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "muito bom"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "bom"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "mais ou menos"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "mau"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Converter classificação para a escala de 5 estrelas"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Converter classificações."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Por favor, atribua a cada uma das classicações um equivalente na escala de 1 "
 "a 5."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Classficação Actual"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Classificação"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Nenhum arquivo selecionado"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Selecionar _Tipo de Arquivo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Nenhum arquivo foi selecionado, portanto a ação foi cancelada"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1509,14 +1466,14 @@ msgstr ""
 "Sinto muito, não consigo entender\n"
 "a quantidade \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Quantidades devem ser números (frações ou decimais), faixas de números, ou "
 "ficar em branco."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1536,84 +1493,84 @@ msgstr ""
 "Para entrar uma faixa de números, use um \"-\"para separá-los.\n"
 "Por exemplo, você pode digitar 2-4 ou 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "farinha branca"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "açúcar"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sal"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "pimenta preta moída"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "gelo"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "água"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "óleo vegetal"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "azeite"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "A receita pede a si mesma como um ingrediente"
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "O ingrediente %s será ignorado."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Lista de compras para %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Para as seguintes receitas:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " ×%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Para as seguintes receitas:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Selecionar codificação"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1621,29 +1578,28 @@ msgstr ""
 "Não pude determinar a codificação correta.  Por favor, selecione a "
 "codificação correta da lista a seguir."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Ver _arquivo com codificação"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importação pausada"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Parar importação"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Índice de Receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Lista de Compras"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "créditos de tradutores\n"
@@ -1662,366 +1618,352 @@ msgstr ""
 "  arkeo_jsf https://launchpad.net/~jerome-sf\n"
 "  iLugo https://launchpad.net/~isra"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Salvo!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Guardar suas edições em %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Uma importação está em curso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Uma exportação está em curso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Uma remoção está em curso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Sair do programa mesmo assim?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Não saia!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Recuperando receitas "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multiplique %s por:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Abrir receita"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Abrir receita seleccionada"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Apagar as receitas seleccionadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_xportar receitas seleccionadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "E_xportar receitas seleccionadas para ficheiro"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Imprimir"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "receitas"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nova"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Importar ficheiro"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Importar receita"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s receita"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Acções"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Preferências"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Acerca"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "Ferramen_tas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Temporizador"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Apagar %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "Existem alterações não guardadas em %s. Tem a certeza que deseja apagar?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Apagado"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Sem título"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Remover permanentemente as receitas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Remover permanentemente a receita?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Tem certeza de querer remover a receita <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Tem certeza de querer remover as seguintes receitas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Tem certeza de querer remover as %s receitas selecionadas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Ver receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Apagar Receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "_Índice de Receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Remover a receita %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Pronto!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importando…"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "chave"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "item"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Campo"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Contagem"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Mudar todas as chaves \"%s\" para \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
 "the key \"%s\", you won't be able to distinguish between those items and the "
 "items you are changing now."
 msgstr ""
-"Você não poderá desfazer esta acção. Se há já ingredientes com a chave \"%s"
-"\", você não poderá distinguir entre esses itens e os itens você muda agora."
+"Você não poderá desfazer esta acção. Se há já ingredientes com a chave "
+"\"%s\", você não poderá distinguir entre esses itens e os itens você muda "
+"agora."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Mudar todos os itens \"%s\" para \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
 "the item \"%s\", you won't be able to distinguish between those items and "
 "the items you are changing now."
 msgstr ""
-"Você não poderá desfazer esta acção. Se há já ingredientes com o item \"%s"
-"\", você não poderá distinguir entre esses itens e os itens você muda agora."
+"Você não poderá desfazer esta acção. Se há já ingredientes com o item "
+"\"%s\", você não poderá distinguir entre esses itens e os itens você muda "
+"agora."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Mude _todas as instâncias de \"%(unit)s\" a \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2030,12 +1972,12 @@ msgstr ""
 "Mude \"%(unit)s\" a \"%(text)s\" só para _ingredientes \"%(item)s\" com "
 "\"%(key)s\" chave"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr "Mude _todos exemplos de \"%(amount)s\" %(unit)s a %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2044,7 +1986,7 @@ msgstr ""
 "Mude \"%(amount)s\" %(unit)s a \"%(text)s\" %(unit)s só _onde a tecla de "
 "ingrediente é %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2053,11 +1995,11 @@ msgstr ""
 "Mude \"%(amount)s\" %(unit)s a \"%(text)s\" %(unit)s só onde a tecla de "
 "ingrediente é %(key)s _e onde o item é %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Mudar todas as colunas selecionadas?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2066,7 +2008,7 @@ msgstr ""
 "Esta ação não será impossível de desfazer. Têm a certeza que  para todas as "
 "%s colunas, você quer pôr os seguintes valores:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2075,7 +2017,7 @@ msgstr ""
 "\n"
 "Chave para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2084,7 +2026,7 @@ msgstr ""
 "\n"
 "Item para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2093,7 +2035,7 @@ msgstr ""
 "\n"
 "Unidade para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2102,8 +2044,8 @@ msgstr ""
 "\n"
 "Quantidade para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2112,387 +2054,375 @@ msgstr[1] "%s ingredientes"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Mostrar ingredients %(bottom)s para %(top)s do %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Quantidade"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Categoria de Compras"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Estrelas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Não pude converter %s para %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Preciso da informação sobre densidade."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Conversor de Unidades"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Carrregando arquivo zip"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Descomprimindo arquivo zip"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "Página HTML para a Teia"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Exportando página para a Teia"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Exportando receitas para arquivos HTML no diretório %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Receita salva como arquivo HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "opcional"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Exportando página para a Teia"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Exportando receitas para arquivos HTML no diretório %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Receita salva como arquivo HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Exportação Texto"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2500,81 +2430,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "A transferir %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Lista de compras para %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Obtendo %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Arquivo XML Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Exportação XML Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Exportando receitas para arquivo XML Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Receita salva em arquivo XML Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Terminada importação do Mastercook."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Limpando XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2583,274 +2486,295 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Imprimir Receitas"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Exportar PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Exportando as receitas para PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Receita salva como PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Carta"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Retrato"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Simples"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Index Card (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Index Card (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Index Card (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Index Card (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Carta"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Index Cards (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Index Cards (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Index Cards (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Paisagem"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Simples"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Coluna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Coluna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Coluna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Coluna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s Coluna"
 msgstr[1] "%s Colunas"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Retrato"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Paisagem"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientação"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Tamanho Fonte"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "_Layout da Página"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Tamanho Fonte"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Margem Esquerda"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Margem Direita"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Margem de Cima"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Margem de Baixo"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "Ficheiro Mealmaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Exportação MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Exportando receitas para ficheiros MealMaster %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Receita salva como ficheiro MealMaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "porção"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Ficheiro"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Exportar"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Exportando receitas para arquivo XML Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Receita salva em arquivo XML Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Qualquer grupo de comida"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Converter unidade para %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "De forma a calcular a informação nutricional, o Gourmet necessita da sua "
 "ajuda para converter \"%s\" para uma unidade perceptível por si."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2859,27 +2783,27 @@ msgstr ""
 "Mudar a chave do ingrediente de %(old_key)s para %(new_key)s em todo o lado "
 "ou só no título da receita %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Mudar _em todo o lado"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Somente na receita %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Mudar unidade"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2888,11 +2812,11 @@ msgstr ""
 "Mudar unidades de %(old_unit)s para %(new_unit)s para todos os ingredientes "
 "%(ingkey)s ou somente no %(title)s da receita?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2901,198 +2825,199 @@ msgstr ""
 "de dados nutricional têm várias descrições desta comida com diferentes "
 "densidades. Por favor seleccione a correcta abaixo."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Para aplicar a informação nutricional, o Gourmet precisa de uma quantidade e "
 "unidade válidas."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingrediente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Base de dados USDA equivalente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gramas"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Calorias"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Gordura Total"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Gordura Saturada"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Colesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sódio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Total de Carbohidratos"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Fibra de Dietas"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Açucares"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteína"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alpha-carotenos"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Cinza"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-caroteno"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta Cryptoxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Cálcio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Cobre"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Total de Fólicos"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Ácido fólico"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Food Folate"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Dietary folate equivalents"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Ferro"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Lycopene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Luteína+Zeazantina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnêsio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Manganêsio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Ácido Pantotênico"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fósforo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potássio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamina A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selénio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamina A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamina A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zinco"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitaminas e minerais"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3101,11 +3026,11 @@ msgstr ""
 "Informação Nutricional em falta\n"
 "para %(missing)s do %(total)s de ingredientes."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Valor Diário"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3114,368 +3039,368 @@ msgstr ""
 "Percentagem do valor diário recomendado baseado nas %i calorias diárias. "
 "Clique para editar o número de calorias diárias."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Quantidade por receita"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Carregando os Dados Nutricionais"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Importação da base de dados nutricional completa!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Obtendo a base de dados nutricional do arquivo zip %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "A extrair %s do arquivo zip."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "A processar dados nutricionais..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "A ler dados nutricionais: %s de %s entradas importadas."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "A processar dados de peso..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "A ler dados de peso para os itens nutricionais: %s de %s entradas importadas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Água"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilocalorias"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g proteínas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipídos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g cinza"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g carbohidratos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g fibras"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g açúcar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg cálcio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg ferro"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnésio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fósforo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg potássio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg sódio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg zinco"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg cobre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg manganêsio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "microgramas de selênio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamina c"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg de tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg de riboflavina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg de niacina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg ácido pantoténico"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg de vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "microgramas de Fólicos Totais"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "microgramas de Ácido Fólico"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "microgramas de Food Folate"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "microgram dietary folate equivalents"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "microgramas de  Vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamina A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamina A (microgramas de Equivalentes Actividade Retinal"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "microgramas de Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "microgramas de Alfa-carotenos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "microgramas Beta-caroteno"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "microgramas de Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "microgramas de Licopene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "microgramas de Luteína+Zeazantina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g de Ácidos Gordos Saturados"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g de Ácidos Gordos Monoinsaturados"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g de Ácidos Gordos Polinsaturados"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Colesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Percentagem de recusa"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Lacticínios e Produtis Diários"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Especiarias"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Comida de Bêbe"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Gorduras e Olêos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Aves"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Sopas & Molhos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Salsichas & Almoço Carnes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Cereais de Pequeno Almoço"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Frutas e Sumos de Fruta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Porco"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Vegetais"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Frutos Secos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Bife"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Bebidas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Peixe & Marisco de Casca"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Legumes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Borrego, Vitela & Game"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Produtos Confecionados"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Doces"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Grãos e Massas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Fast Foods"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Refeições e Entradas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Snacks"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Comidas Etnicas"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3489,290 +3414,246 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "estrelas"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Exportadas %(number)s de %(total)s receitas"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Exportação completa."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Incluir Receita no Corpo do Correio Eletrônica (sempre uma boa idéia)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Envia Receita por Correio Eletrônico como Anexo HTML"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Opções de Correio Eletrônico"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Não me pergunte antes de enviar correio eletrônico."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Correio eletrônico não enviado"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 "Você não pediu para enviar a receita no corpo da mensagem ou como um anexo."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Salvar receita como…"
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet não consegue exportar arquivos do tipo \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Exportar receitas"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "receitas"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Exportar"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Imprimir %s receita"
 msgstr[1] "Imprimir %s receitas"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Obtenfo ficheiro"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-"Introduza o URL de um arquivo de receitas ou de uma página web de receitas."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Insira a URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Abrir receita..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr ""
+"Introduza o URL de um arquivo de receitas ou de uma página web de receitas."
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Alterações"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importar"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Todos os arquivos importáveis"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Importas %s receitas."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "porção"
 msgstr[1] "porções"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Importadas %s de %s receitas."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "okay"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Esta página web não é reconhecível. Utilizando a importação genérica"
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Importação completa."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Importando receita"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Processando ingredientes"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Processando ingredientes."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Porções"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importar receita"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "título"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrediente"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instruções"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "notas"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "cozinha"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "fonte"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3781,103 +3662,97 @@ msgstr[1] "%s receitas"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Mostrar receitas da %(bottom)s to %(top)s do %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "segundo"
 msgstr[1] "segundos"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuto"
 msgstr[1] "minutos"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "hrs."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "hora"
 msgstr[1] "horas"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
 msgstr[1] "dias"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
 msgstr[1] "semanas"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -3886,7 +3761,7 @@ msgstr[1] "meses"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"
@@ -3898,71 +3773,30 @@ msgstr[1] "anos"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " e "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "e"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "para"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Arquivo XML Gourmet"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gestor de Receitas Gourmet"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3972,7 +3806,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3985,38 +3818,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4024,6 +3825,18 @@ msgstr "Exportar PDF"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -4034,14 +3847,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4095,22 +3900,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4170,6 +3959,91 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (assistência ao porte para MS Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Instalador para Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (melhorias à interface do Conversor de Unidades)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "RS Born (melhorias à exportação para Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logótipo e ecrã de entrada)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (nutritição e ícones da lista de compras )"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (melhorias a "
+#~ "internacionalização,algumas correcções)"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Escolha um arquivo contendo sua lista de ingredientes."
+
+#~ msgid "No file selected"
+#~ msgstr "Nenhum arquivo selecionado"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Nenhum arquivo foi selecionado, portanto a ação foi cancelada"
+
+#~ msgid "_Import file"
+#~ msgstr "_Importar ficheiro"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Carrregando arquivo zip"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Descomprimindo arquivo zip"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "A transferir %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Lista de compras para %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Obtendo %s"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Obtenfo ficheiro"
+
+#~ msgid "Enter URL:"
+#~ msgstr "Insira a URL:"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr ""
+#~ "Esta página web não é reconhecível. Utilizando a importação genérica"
+
+#~ msgid "Import complete."
+#~ msgstr "Importação completa."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Importando receita"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Processando ingredientes"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Processando ingredientes."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Arquivo XML Gourmet"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gestor de Receitas Gourmet"
+
 #~ msgid "Select recipe image"
 #~ msgstr "Seleccione imagem para a receita"
 
@@ -4221,9 +4095,6 @@ msgstr ""
 #~ "Pediu o encerramento de uma janela com um temporizador activo. Pode parar "
 #~ "o temporizador ou simplesmente fechar a janela. Se fechar a janela, ela "
 #~ "reaparecerá quando o temporizador terminar."
-
-#~ msgid "Select File_type"
-#~ msgstr "Selecionar _Tipo de Arquivo"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Um arquivo chamado %s já existe."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gourmet Recipe Manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2015-05-15 20:13-0200\n"
 "Last-Translator: Felipe Braga <fbobraga@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
@@ -20,64 +20,64 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Índice de receitas"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nova receita"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Adicionar à _lista de compras"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Ver re_ceita"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Pesquisar por:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Procurar por receitas ao digitar"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_em"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Pesquisar com outros critérios dentro dos resultados."
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Adicionar critério de busca"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Limitar busca a:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "_Resultados da busca"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Configurar Campos para Receitas Selecionadas"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -85,128 +85,131 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Definir atributos de receita para as "
 "receitas selecionadas</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Adicionar imagem"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Remover imagem"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "F_onte:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Avaliação:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "C_ozinha:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Categoria:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "Tempo de _preparo:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Tempo de co_zimento:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Página web:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Imagem:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Rendimento:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr "U_nidade de rendimento:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "_Apenas definir valores que estiverem vazios"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Defina todos os valores para _todas as receitas selecionadas"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Metakit (padrão, armazenado em um arquivo local)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (armazenado em um arquivo local)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (requer conexão a um banco de dados)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Escolha o banco de dados"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Escolha o sistema de banco de dados para o Gourmet usar</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "Sistema de _banco de dados"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Servidor:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "Nome de _usuário:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Senha:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Senha para seu usuário no banco de dados."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "_Nome da base de dados:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Arquivo"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -215,11 +218,11 @@ msgstr ""
 "Se o servidor de banco de dados está sendo executado no sistema local, use "
 "\"localhost\"."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -227,11 +230,11 @@ msgstr ""
 "Salvar a senha para a próxima vez. Isto significa que a senha será "
 "armazenada de forma insegura no seu arquivo de configuração."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "_Salvar Senha"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -239,301 +242,302 @@ msgstr ""
 "Nome do banco de dados no qual o Gourmet deverá armazenar suas informações. "
 "O Gourmet tentará criar este banco de dados se ele já não existir."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "receita"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Seu nome de usuário no banco de dados."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Navegar"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detalhes"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Preferências do gestor de receitas Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Preferências da visão do índice de receitas</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr "Mostrar _barra de ferramentas"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Receitas por página:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 "<i>Configure quais as colunas que aparecem na visão do índice de receitas.</"
 "i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Lista de receitas"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Preferências da visão de cartão das receitas</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "_Permitir que unidades mudem quando multiplicadas"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Usar frações"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Mostrar frações sempre que possível"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 "<i>Remover os itens que você não usa da janela de cartão da receita.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Receita"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Preferências da lista de compras</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>O que o Gourmet deve fazer com ingredientes opcionais quando adicionando "
 "receitas à lista de compras?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "_Perguntar se deve incluir os ingredientes opcionais"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "_Lembrar das escolhas do usuário por padrão"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "Limpar a _memória ingredientes opcionais"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "_Sempre adicionar ingredientes opcionais"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Nunca adicionar ingredientes opcionais"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Lista de compras"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "porções"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Título"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Título:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Tempo de _preparo:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "categoria"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "avaliação"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Rendimento"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Rendimento unitário"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Comprar"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Editar _descrição"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Tempo de cozimento:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Tempo de preparo:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Cozinha:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Categoria:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Página web:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Rende:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Link</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Fonte:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Avaliação:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Multiplicar por:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Modo de preparo</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Editar modo de _preparo"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Notas</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Editar _notas"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Receita"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Ingredientes</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Editar _ingredientes"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Adicionar _ingrediente:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredientes"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Adicionar receita à lista de compras"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Adicionar à _lista de compras"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Ir para a visualização do cartão da receita"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Apagar receita selecionada"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Apagar Receita"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Editar atributos das receitas selecionadas"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "Editar _várias receitas"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Enviar a receita selecionada por e-mail"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Abrir receita selecionada"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "Enviar receita por _e-mail"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Escolha a receita"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Imprimir receita selecionada"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "_Imprimir receita"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -545,31 +549,31 @@ msgstr ""
 "você salvar ou imprimir a lista de compras a menos que você diga que precisa "
 "comprá-lo."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Adicionar à _despensa"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Mostrar _opções"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Procurar _em"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "_Usar expressões regulares (busca avançada)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Pesquisa ao digitar"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Opções de busca</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Categoria"
 
@@ -578,287 +582,290 @@ msgstr "Categoria"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Código"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Editor de categorias"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Procurar por"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Pesquisa ao digitar"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Usar expressões regulares"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Pesquisa avançada"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Adicionar categoria: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Temporizador"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Temporizador</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Tempo alcançado!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "O temporizador continuará a contar até você fechar esta janela ou reiniciá-"
 "lo."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Ajustar _temporizador: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Reiniciar"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Iniciar"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "S_om"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Nota"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Re_petir o alarme até que eu o desligue"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "Confi_gurações"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Editar campos pela base de dados</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Campo para _editar:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "Para cada valor selecionado:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "Deixar o valor _como está"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>O novo valor será adicionado no final do existente</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>O novo valor substituirá o existente</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Campo:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Valor:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Mudar _outro campo:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "_Mudar o valor para: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "_Excluir valor"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Selecione o equivalente de</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>da base de dados da USDA</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "_Alterar ingrediente"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>ou</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "_Procurar na base de dados de ingredientes da USDA:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Pesquisa ao _digitar"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Mostrar apenas alimentos no _grupo:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<i>_Resultados da busca:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>De:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Quantidade:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Unidade:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "unidade"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "_Mudar a unidade"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "_Salvar nova unidade"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>Para:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Unidade:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Entre com a informação nutricional para </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Escolha uma densidade</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Chave do ingrediente: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>Item USDA: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Informação nutricional</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "Editar _informação"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "Informação _nutricional"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Densidade:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "Equivalentes USDA:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "Informação de _densidade"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Informação nutricional conhecida</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "Pesquisa _avançada"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Informação nutricional"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "I_gnorar"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gestor de receitas Gourmet"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
+#, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -881,216 +888,169 @@ msgstr ""
 "suporta vincular imagens às receitas. O Gourmet também pode calcular as "
 "informações nutricionais das receitas com base nos ingredientes.\n"
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Assistência para Converter para Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Instalador Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-"Richard Ferguson (aperfeiçoamentos na interface do conversor de unidades)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (aperfeiçoamentos na exportação para Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (telas de logo e \"splash screen\")"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (ícones de nutrição e adicionar à lista de compras)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (melhorias na "
-"internacionalização, correções diversas)"
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Mantenedor dede a versão 0.16.0, "
-"redesenho do site)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Escolha Arquivo de Banco de Dados"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Atualizando banco de dados"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Nova Receita"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "_Nome da base de dados:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"Dependendo do tamanho do seu banco de dados, este pode ser um processo "
-"intensivo e pode demorar algum tempo. Foi feito backup automático de seus "
-"dados no caso de algo correr errado."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Detalhes"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Uma cópia de segurança foi feita em %s para o caso de ocorrer algum erro. Se "
 "esta atualização falhar, você poderá renomear manualmente sua cópia de "
 "segurança \"recipes.db\" para recuperá-la e usar com a versão antiga do "
 "Gourmet."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Nova Receita"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Alterar _Categoria"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Criar nova categoria"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Alterar a categoria do item selecionado"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Despensa"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Mover para a _lista de compras"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Mover para a _despensa"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Remover da lista de compras"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Mover itens selecionados para %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Lista de compras"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Já possuo (Itens da des_pensa)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Entre a Categoria"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Categoria para adicionar %s para"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Categoria:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Receitas"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Adicione itens:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Remover Receitas"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Remover receitas da lista de compras"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Editar"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Ajuda"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Adicione itens"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Adicionar itens arbitrários a lista de compras"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Nenhuma receita selecionada. Você quer limpar a lista inteira?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Salvar lista de compras Como..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Selecione ingredientes opcionais"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1099,57 +1059,59 @@ msgstr ""
 "em sua lista de compras."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Receita"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Ir"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Exportar receita"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Exporte receitas selecionadas (salvar para arquivo)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Apagar receita"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Apagar esta receita"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Ajustar unidades ao multiplicar"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Alterar as unidades ao multiplicar, sempre que possível, para torná-las mais "
 "legível."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Imprimir receita"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Adicionar à _lista de compras"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Não memorizar ingredientes opcionais"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1157,150 +1119,144 @@ msgstr ""
 "Antes de adicionar à lista de compras, perguntar sobre todos os ingredientes "
 "opcionais, inclusive os anteriormente memorizados"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Exportar receita"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr "Receita exportada com sucesso para <a href=\"file:///%s\">%s</a>"
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Você tem mudanças não salvas."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Aplicar mudanças antes de imprimir?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Aplicar mudanças antes de imprimir?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Opcional)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Não foi possível encontrar a receita %s no banco de dados."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Editar receita:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Salvar alterações no banco de dados"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Ver cartão da receita"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Editar"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Salvar alterações em %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Adicionar ingrediente"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Adicionar grupo"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Colar ingredientes"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importar de um arquivo"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Adicionar _receita"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Adicione uma outra receita como um ingrediente nesta receita"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Excluir"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Subir"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Descer"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Escolher um arquivo contendo sua lista de ingredientes."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Descrição"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Modo de preparo"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notas"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Qtd"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Unidade"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Item"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Opcional"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "A receita %s (ID %s) não está no seu banco de dados."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Convertido: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Não convertido: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Unidade alterada."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1309,233 +1265,232 @@ msgstr ""
 "Você mudou a unidade para %(item)s de %(old)s para %(new)s. Você gostaria da "
 "quantidade convertida ou não?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Convertido %(old_amt)s %(old_unit)s para %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Impossível converter de %(old_unit)s para %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Adicionar Grupo de Ingrediente"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Informe o nome do novo subgrupo de ingredientes"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Nome do grupo:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Escolha a receita"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Uma receita não pode ser seu próprio ingrediente!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Recursão infinita não é permitida em receitas!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Você não selecionou quaisquer receitas!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Quanto de %(title)s sua receita precisa?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Receitas"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Som Soando"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Som de aviso"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Som de erro"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Parar temporizador?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Parar _temporizador"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Manter cronometragem"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Complementos"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Plugins adicionam funcionalidades extras ao Gourmet."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Complemento necessário para outros complementos. Desativar complemento assim "
 "mesmo?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Os seguintes plugins exigem %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Desativar de qualquer maneira"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Manter complemento ativo"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "ou"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Ocorreu um erro na ativando o complemento."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Ocorreu um erro na desativando o complemento."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Cozinha"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Avaliação"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Fonte"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Página Web"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Tempo de preparação"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Tempo de cozimento"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Modificações"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Entrada inválida."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Não numérico."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pausa"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Parar"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Não pergunte novamente."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Você realmente quer fazer isso"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "ótimo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "muito bom"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "bom"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "razoável"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "fraco"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Converte avaliações para escala de 5 estrelas."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Converter avaliações."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Por favor avalie em uma escala de 1 a 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Nota Atual"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Nota até 5 estrelas"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Nenhum arquivo selecionado"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Selecione Tipo de arquivo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Nenhum arquivo selecionado, a ação foi cancelada"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1544,14 +1499,14 @@ msgstr ""
 "Eu sinto muito, eu não entendo\n"
 "o valor \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Valores devem ser números (frações ou decimais), faixas de números, ou "
 "espaço em branco."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1571,85 +1526,85 @@ msgstr ""
 "Para entrar uma faixa de números, use um \"-\" para separa-los.\n"
 "Por exemplo, você poderá entrar 2-4 ou 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "Nome de _usuário:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Senha:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "farinha, todos os propósitos"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "açúcar"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sal"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "pimenta preta, moída"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "gelo"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "água"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "óleo vegetal"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "Azeite"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Receita se pede como um ingrediente."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Ingrediente %s será ignorado."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Lista de compras para %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr "Para as seguintes receitas:\n"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Para as seguintes receitas:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Selecionar codificação"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1657,29 +1612,28 @@ msgstr ""
 "Impossível determinar o tipo de codificação. Por favor selecione a "
 "codificação correta nesta lista."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Ver _arquivo com codificação"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importação em pausa"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Parar importação"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Índice de receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Lista de compras"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1714,337 +1668,321 @@ msgstr ""
 "  tgriffo https://launchpad.net/~tiago-griffo\n"
 "  Felipe Braga https://launchpad.net/~fbobraga-gmail"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-"Por favor, considere fazer uma doação para apoiar o nosso esforço contínuo "
-"para corrigir problemas, implementar recursos e ajudar os usuários!"
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr "Doar via PayPal"
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr "Micro-doar via Flattr"
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-#, fuzzy
-msgid "Donate weekly via Gratipay"
-msgstr "Doe semanalmente via Gittip"
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Salvo!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Salve suas edições para %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Uma importação está em progresso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Uma exportação está em progresso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Uma exclusão está em progresso."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Sair do programa assim mesmo?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Não saia!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Permanentemente excluída %s de %s receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Lixeira"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Navegue, exclua permanentemente ou restaure receitas excluídas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Receitas restauradas "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Quantidade de %(unit)s de %(title)s para comprar"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multiplicar %s por:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Definir %(attributes)s para %(num)s receita selecionada?"
 msgstr[1] "Definir %(attributes)s para %(num)s receitas selecionadas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Nenhum valor já existente será alterado."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Os novos valores vão substituir os valores existentes."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Esta mudança não pode ser desfeita."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Defina os valores de receitas selecionadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Procurar receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Abrir Receita"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Abrir receita selecionada"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Apagar receita"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Apagar receitas selecionadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Editar receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Abra as receitas selecionadas no editor de receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_xportar receitas selecionadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Exportar receitas selecionadas para arquivo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Imprimir"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "receitas"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Editar _várias receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nova"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Importar arquivo"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Importar Receita"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Importar receita a partir do arquivo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Importar _página web"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s receita"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Importar receita de página da web"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Exportar _todas as receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Exportar todas as receitas para arquivo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Sair"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Ações"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Abrir _Lixeira"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Lixeira"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Preferências"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Plugins"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Gerenciar plugins que adicionam funcionalidades extras ao Gourmet."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Confi_gurações"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Sobre"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Ferramentas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Temporizador"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Mostrar Tempo"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "índice pesquisável de receitas na base de dados."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Apagar %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Você tem modificações não salvas em %s. Tem certeza que quer apagar?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Deletado"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Sem título"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Apagar permanentemente as receitas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Apagar permanentemente a receita?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Você tem certeza que quer apagar a receita <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Você tem certeza que quer apagar as seguintes receitas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Você tem certeza que quer apagar as %s receitas selecionadas?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Ver receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Apagar Receitas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr "Receitas apagadas"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Apagar receita %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr "Ver o conteúdo da lixeira agora"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Concluído!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importando..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Editor de Identificadores de Ingrediente"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Editar em série os identificadores de ingredientes"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "chave"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "item"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Campo"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Conta"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Trocar todas chaves \"%s\" por \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2055,28 +1993,28 @@ msgstr ""
 "\"%s\", você não conseguirá distingui-los dos itens que você está "
 "modificando agora."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Trocar todos itens \"%s\" por \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
 "the item \"%s\", you won't be able to distinguish between those items and "
 "the items you are changing now."
 msgstr ""
-"Você não poderá desfazer esta ação. Caso já haja ingredientes com o item \"%s"
-"\", você não conseguirá distingui-los dos itens que você está modificando "
-"agora."
+"Você não poderá desfazer esta ação. Caso já haja ingredientes com o item "
+"\"%s\", você não conseguirá distingui-los dos itens que você está "
+"modificando agora."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Trocar tod_as instâncias de \"%(unit)s\" por \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2085,14 +2023,14 @@ msgstr ""
 "Trocar \"%(unit)s\" por \"%(text)s\" apenas para _ingredientes \"%(item)s\" "
 "com chave \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Alterar _todas as instâncias de \"%(amount)s\" %(unit)s para %(text)s "
 "%(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2101,7 +2039,7 @@ msgstr ""
 "Alterar \"%(amount)s\" %(unit)s para \"%(text)s\" %(unit)s somente onde o "
 "ingrediente chave é %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2110,11 +2048,11 @@ msgstr ""
 "Alterar \"%(amount)s\" %(unit)s para \"%(text)s\" %(unit)s somente onde o "
 "ingrediente chave é %(key)s e onde o item é %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Alterar todas as linhas selecionadas?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2123,7 +2061,7 @@ msgstr ""
 "Esta ação não poderá ser desfeita. Tem certeza que deseja definir os "
 "seguintes valores para todas as colunas %s selecionadas:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2132,7 +2070,7 @@ msgstr ""
 "\n"
 "Chave para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2141,7 +2079,7 @@ msgstr ""
 "\n"
 "Item para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2150,7 +2088,7 @@ msgstr ""
 "\n"
 "Unidade para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2159,8 +2097,8 @@ msgstr ""
 "\n"
 "Quantidade para %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2169,23 +2107,23 @@ msgstr[1] "%s ingredientes"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Mostrando ingredientes %(bottom)s a %(top)s de %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Quantidade"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Identificadores de Ingredientes"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2193,11 +2131,11 @@ msgstr ""
 "Identificadores de Ingredientes são nomes de ingredientes normalizados, "
 "utilizados em listas de compras e em cálculos."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Sugerir identificadores"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2205,59 +2143,59 @@ msgstr ""
 "Sugerir os valores mais adequados para todos os identificadores de "
 "ingredientes com base em valores já presentes na base de dados"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Editar Associações de Identificadores"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 "Editar associações com identificador e outros atributos presentes na base de "
 "dados"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Editor de chaves"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "_Item:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Chave:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>_Alterar os ingredientes selecionados</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Categoria de Compras"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 "Exibição de unidades conforme escrito para cada receita (sem alterações)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Sempre exibir as unidades no sistema americano"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Sempre exibir unidades métricas"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Ajustar automaticamente as unidades"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Definir preferências de exibição de _unidades"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2265,42 +2203,42 @@ msgstr ""
 "Converter automaticamente as unidades, sempre que possível, para o sistema "
 "preferido (métrico, imperial etc.)."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Estrelas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s anterior"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Auto-Mesclar receitas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Sempre usar a receita mais recente"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Sempre usar a receita mais antiga"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2308,97 +2246,97 @@ msgstr ""
 "Algumas das receitas importados parecem ser duplicados. Você pode mesclar-"
 "los aqui, ou fechar esta janela para deixá-las como elas são."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Procurar _receitas duplicadas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Encontre e remova receitas duplicadas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Receitas com informações similares"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Receitas com ingredientes similares"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Receitas com informações e ingredientes similares"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Receitas duplicadas</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "_Incluir receitas da lixeira"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Mostrando:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Juntar _todas as duplicadas"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Juntar receitas</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "Juntar _automaticamente"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Para cada valor selecionado"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Onde %(field)s é %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "A alteração afetará %s receita"
 msgstr[1] "A alteração afetará %s receitas"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Apagar %s onde seja %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Mudar %s de %s para \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Esta mudança não é reversível.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Editor de Campo"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Editar campos entre múltiplas receitas simultaneamente."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Enviar receitas por e-mail"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Enviar por e-mail todas as receitas selecionadas (ou todas as receitas, caso "
@@ -2407,163 +2345,151 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 "Você deseja realmente enviar por e-mail todas as %s receitas selecionadas?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Sim, envie-as por e-mail"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Impossível converter %s para %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "É necessária informação da densidade."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Conversor de _unidade"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Calcular conversões de unidade"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Conversor de Unidades"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>De</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "I_tem:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Densidade:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Informação_de_Densidade"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>Para</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Resultado:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Pacote (zip, tarball)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Carregando arquivo ZIP"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Descompactando arquivo ZIP"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "Página web HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Exportando Webpage"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Exportando receitas para arquivos HTML no diretório %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Receita salva como arquivo HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Página original de %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "opcional"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Exportando Webpage"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Exportando receitas para arquivos HTML no diretório %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Receita salva como arquivo HTML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Arquivo de texto simples"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Exportar como Texto"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Exportando receitas para o arquivo de texto %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Receita salva como arquivo de texto simples %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Arquivo Grande"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "O arquivo %s é grande demais para importação"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2575,81 +2501,54 @@ msgstr ""
 "importar esse arquivo, use um editor de textos para dividi-lo em arquivos "
 "menores e tente importá-lo novamente."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Página Web"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Baixando %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Lista de compras para %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Recebendo %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Arquivo XML Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Exportar XML do Gourmet"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Exportando receitas para arquivo XML do Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Receitas salvas em arquivo XML do Gourmet %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Arquivo Gourmet XML (Obsoleto)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Arquivo XML do Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Arquivo de texto do Mastercook"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Importação Mastercook terminada."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Arrumando XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "Arquivo XML do KRecipe"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr "Não é possível encontrar o \"Adobe Reader\" em seu sistema."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2658,272 +2557,293 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Layout de Página"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Imprimir Receitas"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Exportar para PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Exportando receitas para PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Receita salva como PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Carta"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Retrato"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Puro"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "pontos"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Cartão de Índice (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Cartão de Índice (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Cartão de Índice (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Cartão de Índice (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Carta"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Ofício"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Índice de Cartões (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Índice de Cartões (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Índice de Cartões (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Paisagem"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Puro"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Coluna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Coluna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Coluna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Coluna"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s Coluna"
 msgstr[1] "%s Colunas"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Retrato"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Paisagem"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Tamanho do Papel"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientação"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Tamanho da _Fonte"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Configuração da Página"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Tamanho da _Fonte"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Margem Esquerda"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Margem Direita"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Margem Superior"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Margem Inferior"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "Opções PDF"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "Arquivo MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Exportar para MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Exportando receitas para Arquivos MealMaster %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Receitas salvas como Arquivo MealMaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "porção"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr "Arquivo MCB"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr "Arquivo MCB do My CookBook"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr "Exportar MCB"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Exportando receitas para o arquivo MCB do My CookBook %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Receita salva no arquivo MCB do My CookBook %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Armazenador de listas de compras"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Salvar lista como receita"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Salvar a lista de compras atual como uma receita para uso futuro"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr "Menu para %s (%s)"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Informações nutricionais refletem a quantidade por %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Informação nutricional reflete valores para toda a receita"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Estão faltando as informações nutricionais dos %s ingredientes: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Qualquer grupo alimentar"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "seleção"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Converter unidade para %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Para calcular informações nutricionais, o Gourmet precisa que você ajude-o a "
 "converter \"%s\" para uma unidade que ele entenda."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Alterar identificador do ingrediente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2932,29 +2852,29 @@ msgstr ""
 "Trocar chave de ingrediente de %(old_key)s para %(new_key)s em todos os "
 "lugares ou apenas na receita %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Mudar _em todos lugares"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "Ape_nas na receita %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 "Alterar identificador do ingrediente de %(old_key)s para %(new_key)s em "
 "todas as ocorrências?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Mudar a unidade"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2963,11 +2883,11 @@ msgstr ""
 "Mudar a unidade de %(old_unit)s para %(new_unit)s para todos os ingredientes "
 "%(ingkey)s ou apenas na receita %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2976,198 +2896,199 @@ msgstr ""
 "possui várias descrições dessa comida com diferentes densidades. Por favor, "
 "escolha a correta abaixo."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Para aplicar a informação nutricional, Gourmet precisa de uma quantidade e "
 "uma unidade válidas."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Nutrição"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingrediente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Equivalente na base de dados USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gramas"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Calorias"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Gordura total"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Gordura Saturada"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Colesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sódio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Total de carboidratos"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Fibra de dieta"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Açúcares"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteína"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-caroteno"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Ash"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-caroteno"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta-criptoxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Cálcio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Cobre"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Total de Folato"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Ácido Fólico"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Folato"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Dieta equivalente de folato"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Ferro"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Licopene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Luteina+Zeazantina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnésio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Manganês"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Ácido Pantotênico"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fósforo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potássio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamina A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavina (Vitamina B2)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selênio"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamina A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamina A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zinco"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitaminas e minerais"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3176,11 +3097,11 @@ msgstr ""
 "Faltando informação nutricional\n"
 "para %(missing)s de %(total)s ingredientes."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% do valor _diário"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3189,368 +3110,368 @@ msgstr ""
 "Porcentagem de valores diários recomendados em %i calorias por dia. Clique "
 "para editar o número de calorias diárias."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Quantidade por %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Quantidade por receita"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Carregando Dados Nutricionais"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Importação dos dados nutricionais completada!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Buscando banco de dados nutricional do arquivo %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Extraindo %s do arquivo."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Analisando informação nutricional..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Lendo dados nutricionais: importadas %s de %s entradas."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Analisando dados de peso..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Lendo dados de peso para itens nutricionais: importadas %s de %s entradas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Água"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Quilocalorias"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g proteínas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipídios"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g ash"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g carboidratos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g fibra"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g açúcar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg cálcio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg iron"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnésio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fósforo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg de potássio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg de sódio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg de zinco"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg de cobre"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg de manganês"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mg de selênio"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg de vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg de tiamina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg de riboflavin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg de niacina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg de ácido pantotênico"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamina B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "micrograma Ácido Fólico Total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "micrograma ácido Fólico"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "Micrograma de Folato Alimentar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "micrograma de equivalentes de ácido fólico na dieta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Colina total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "micrograma de vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamina A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamina A (micrograma Equivalentes de Atividade Retinal)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "micrograma de retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "microgramas de Alfa-caroteno"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "microgramas de Beta-caroteno"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "micrograma Beta Criptoxantina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "microgramas de Licopeno"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "micrograma Luteína+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg de vitamina E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg de vitamina K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g de Ácido de Gordura Saturada"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g de Ácidos de Gordura Mono-dessaturada"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g de Ácidos de Gordura Poli-dessaturada"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg de colesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Percentual de recusa"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Produtos granjeiros"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Temperos e ervas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Comidas de bebê"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Gorduras e Óleos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Aves Domésticas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Sopas & Molhos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Linguiças e carnes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Cereais de café da manhã"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Frutas & Sucos de fruta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Suínos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Vegetais"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Nozes & Sementes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Carne bovina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Bebidas"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Peixes & Moluscos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Legumes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Cordeiro, Vitela & Caça"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Produtos Cozidos"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Doces"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Grãos e Pasta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Fast foods"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Refeições, Entradas e Acompanhantes"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Lanches"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Comidas étnicas"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "Banco de dados inteiro"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Identificador do ingrediente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "Número de identificação do Ministério da Agricultura"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "Descrição do item no Ministério da Agricultura"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Densidade Equivalente"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "Identificação do Ministério da Agricultura"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3564,295 +3485,249 @@ msgstr "Ferramentas"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Obter informações nutricionais para a lista atual"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Montante para a lista de compras"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "Editar informações _nutricionais"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "estrelas"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Exportadas %(number)s de %(total)s receitas"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Exportação completa."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Incluir a Receita no Corpo do E-Mail"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Enviar receita por e-mail anexada como HTML"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Enviar a Receita como anexo em formato PDF"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Opções de e-mail"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Não pergunte antes de enviar e-mail."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-mail não enviado"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 "Você não escolheu incluir a receita no corpo da mensagem ou como um anexo."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Salvar receita como..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "O Gourmet não pode exportar arquivo do tipo \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Exportar Receitas"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "receitas"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Não é possível exportar Tipo de arquivo: Desconhecido \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Por favor, certifique-se de selecionar um tipo de arquivo a partir do menu "
 "ao salvar."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Exportar"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr "Receitas exportadas com sucesso para <a href=\"file:///%s\">%s</a>"
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Não é possível imprimir: sem plugins de impressão ativos!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Imprimir %s receita"
 msgstr[1] "Imprimir %s receitas"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Recebendo arquivo"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "rendimento"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Informe a URL do arquivo de receita ou da página de receita."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Digite o endereço do site"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Entrar com URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Digite o endereço de um site ou arquivo de receita."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Não é possível importar URL"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet não tem um plug-in capaz de importar a URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Não foi possível importar a URL %(url)s do mimetype %(type)s. Arquivo salvo "
-"em local temporário %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Abrir receita..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Digite o endereço do site"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Modificações"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Digite o endereço de um site ou arquivo de receita."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importar"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Todos os arquivos importáveis"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "%s receitas importadas."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "porção"
 msgstr[1] "porções"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Importado %s de %s receitas."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "Ok"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Página não reconhecida. Usando importador genérico..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Importação completa."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Importando receita"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Processando ingredientes"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Processando ingredientes."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Porções"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Ingrediente Subgrupo"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Ocultar"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Texto"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Ações"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importar receita"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Limpar _Tags"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Importar Receita"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "em qualquer lugar"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "título"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrediente"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "modo de preparo"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "notas"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "cozinha"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "origem"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Usar expressões regulares na busca"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Use expressões regulares (uma linguagem de pesquisa avançada) em busca de "
 "texto"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Pesquisa na medida que você digita (desligar se busca é muito lenta)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Mostrar _opções de pesquisa"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Mostrar opções de buscas avançadas"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3861,104 +3736,98 @@ msgstr[1] "%s receitas"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Mostrando receitas %(bottom)s a %(top)s de %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s em %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Pausado"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "Receitas importadas com sucesso"
 msgstr[1] "Receitas importadas com sucesso"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pausa"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Concluído"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Erro"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Erro %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Traceback"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "segundo"
 msgstr[1] "segundos"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuto"
 msgstr[1] "minutos"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "hs."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "hora"
 msgstr[1] "horas"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
 msgstr[1] "dias"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
 msgstr[1] "semanas"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -3967,7 +3836,7 @@ msgstr[1] "meses"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"
@@ -3979,81 +3848,30 @@ msgstr[1] "anos"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " e "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "e"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "para"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-"O gestor de receitas Gourmet é uma aplicação que permite coletar, pesquisar, "
-"organizar e encontrar facilmente as suas receitas. O Gourmet também pode "
-"gerar listas de compras e calcular informação nutricional."
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-"Uma visão simples do índice de suas receitas lhe permite ver todas as suas "
-"receitas como uma lista e encontrar rapidamente alguma delas por "
-"ingrediente, título, categoria, culinária, classificação, ou modo de preparo."
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-"Receitas são abertas em suas próprias janelas, cartões tiradas de uma caixa "
-"de receitas. Da visão do cartão da receita, você pode multiplicar ou dividir "
-"instantaneamente uma receita, e o Gourmet irá ajustar todas as quantidades "
-"dos ingredientes."
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr "Gourmet"
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr "Gestor de receitas"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organize as receitas, criar listas de compras, calcular as informações "
-"nutricionais, e muito mais."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr "receitas;cozinhar;nutrição;informação nutricional;listas de compras;"
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Navegar pelas receitas"
@@ -4063,7 +3881,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Selecione receitas navegando por categorias, tipo de cozinha, etc."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Principal"
@@ -4076,38 +3893,6 @@ msgstr "Procurar receitas duplicadas"
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr "Um assistente para encontrar e remover ou juntar receitas duplicadas."
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Enviar por e-mail"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Enviar receitas do Gourmet por e-mail"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Suporte à arquivos Zip, Gzip, e Tarball"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Importar receitas de arquivos ZIP ou TAR"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Importação/Exportação"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4117,6 +3902,18 @@ msgstr "Exportar para PDF"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Criar páginas web a partir de receitas."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Importação/Exportação"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4129,14 +3926,6 @@ msgid ""
 msgstr ""
 "Importação e exportação de receitas como arquivos XML do Gourmet, adequados "
 "para backup ou troca com outros usuários do Gourmet."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "Exportação HTML"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Criar páginas web a partir de receitas."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4196,22 +3985,6 @@ msgid ""
 msgstr ""
 "Ajuda o usuário a identificar trechos na importação de texto simples. Também "
 "fornece exportação de texto simples."
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Importação de página web"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Importar receitas da web."
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Importadores de websites"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Importadores para o about.com, www.foodnetwork.com, e outros"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4280,6 +4053,244 @@ msgstr ""
 "Habilite isto se seus arquivos de texto UTF-16 não são importados "
 "corretamente no Gourmet. Desative isso se você nunca usa UTF16 e está sendo "
 "constantemente incomodado com diálogo \"Codificação\" ao importar arquivos."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Enviar a receita selecionada por e-mail"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "Enviar receita por _e-mail"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Assistência para Converter para Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Instalador Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr ""
+#~ "Richard Ferguson (aperfeiçoamentos na interface do conversor de unidades)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (aperfeiçoamentos na exportação para Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (telas de logo e \"splash screen\")"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (ícones de nutrição e adicionar à lista de compras)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (melhorias na "
+#~ "internacionalização, correções diversas)"
+
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Mantenedor dede a versão 0.16.0, "
+#~ "redesenho do site)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Atualizando banco de dados"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Dependendo do tamanho do seu banco de dados, este pode ser um processo "
+#~ "intensivo e pode demorar algum tempo. Foi feito backup automático de seus "
+#~ "dados no caso de algo correr errado."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Colar ingredientes"
+
+#~ msgid "Import from file"
+#~ msgstr "Importar de um arquivo"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Escolher um arquivo contendo sua lista de ingredientes."
+
+#~ msgid "No file selected"
+#~ msgstr "Nenhum arquivo selecionado"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Nenhum arquivo selecionado, a ação foi cancelada"
+
+#~ msgid ""
+#~ "Please consider making a donation to support our continued effort to fix "
+#~ "bugs, implement features, and help users!"
+#~ msgstr ""
+#~ "Por favor, considere fazer uma doação para apoiar o nosso esforço "
+#~ "contínuo para corrigir problemas, implementar recursos e ajudar os "
+#~ "usuários!"
+
+#~ msgid "Donate via PayPal"
+#~ msgstr "Doar via PayPal"
+
+#~ msgid "Micro-donate via Flattr"
+#~ msgstr "Micro-doar via Flattr"
+
+#, fuzzy
+#~ msgid "Donate weekly via Gratipay"
+#~ msgstr "Doe semanalmente via Gittip"
+
+#~ msgid "_Import file"
+#~ msgstr "_Importar arquivo"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Importar _página web"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Importar receita de página da web"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Abrir _Lixeira"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Pacote (zip, tarball)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Carregando arquivo ZIP"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Descompactando arquivo ZIP"
+
+#~ msgid "Webpage"
+#~ msgstr "Página Web"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Baixando %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Lista de compras para %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Recebendo %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Recebendo arquivo"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Informe a URL do arquivo de receita ou da página de receita."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Entrar com URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Não é possível importar URL"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet não tem um plug-in capaz de importar a URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Não foi possível importar a URL %(url)s do mimetype %(type)s. Arquivo "
+#~ "salvo em local temporário %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Página não reconhecida. Usando importador genérico..."
+
+#~ msgid "Import complete."
+#~ msgstr "Importação completa."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Importando receita"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Processando ingredientes"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Processando ingredientes."
+
+#~ msgid ""
+#~ "Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
+#~ "search, organize, and browse your recipes. Gourmet can also generate "
+#~ "shopping lists and calculate nutritional information."
+#~ msgstr ""
+#~ "O gestor de receitas Gourmet é uma aplicação que permite coletar, "
+#~ "pesquisar, organizar e encontrar facilmente as suas receitas. O Gourmet "
+#~ "também pode gerar listas de compras e calcular informação nutricional."
+
+#~ msgid ""
+#~ "A simple index view allows you to look at all your recipes as a list and "
+#~ "quickly search through them by ingredient, title, category, cuisine, "
+#~ "rating, or instructions."
+#~ msgstr ""
+#~ "Uma visão simples do índice de suas receitas lhe permite ver todas as "
+#~ "suas receitas como uma lista e encontrar rapidamente alguma delas por "
+#~ "ingrediente, título, categoria, culinária, classificação, ou modo de "
+#~ "preparo."
+
+#~ msgid ""
+#~ "Individual recipes open in their own windows, just like recipe cards "
+#~ "drawn out of a recipe box. From the recipe card view, you can instantly "
+#~ "multiply or divide a recipe, and Gourmet will adjust all ingredient "
+#~ "amounts for you."
+#~ msgstr ""
+#~ "Receitas são abertas em suas próprias janelas, cartões tiradas de uma "
+#~ "caixa de receitas. Da visão do cartão da receita, você pode multiplicar "
+#~ "ou dividir instantaneamente uma receita, e o Gourmet irá ajustar todas as "
+#~ "quantidades dos ingredientes."
+
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet"
+
+#~ msgid "Recipe Manager"
+#~ msgstr "Gestor de receitas"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organize as receitas, criar listas de compras, calcular as informações "
+#~ "nutricionais, e muito mais."
+
+#~ msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
+#~ msgstr ""
+#~ "receitas;cozinhar;nutrição;informação nutricional;listas de compras;"
+
+#~ msgid "Send to Email"
+#~ msgstr "Enviar por e-mail"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Enviar receitas do Gourmet por e-mail"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Suporte à arquivos Zip, Gzip, e Tarball"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Importar receitas de arquivos ZIP ou TAR"
+
+#~ msgid "HTML Export"
+#~ msgstr "Exportação HTML"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Criar páginas web a partir de receitas."
+
+#~ msgid "Webpage import"
+#~ msgstr "Importação de página web"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Importar receitas da web."
+
+#~ msgid "Website Importers"
+#~ msgstr "Importadores de websites"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Importadores para o about.com, www.foodnetwork.com, e outros"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4402,9 +4413,6 @@ msgstr ""
 #~ "Você pode optar por parar o temporizador, ou simplesmente fechar a "
 #~ "janela. Se você apenas fechar a janela, ela reaparecerá quando o "
 #~ "temporizador chegar ao tempo limite."
-
-#~ msgid "Select File_type"
-#~ msgstr "Selecione Tipo de arquivo"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Um arquivo com %s já existe"

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2011-03-13 08:16+0000\n"
 "Last-Translator: Bădilă Alin-Petrişor <demon981@gmail.com>\n"
 "Language-Team: Romanian <ro@li.org>\n"
@@ -20,506 +20,509 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "Reteta _Noua"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Adăugați în li_sta de cumpărături"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Fişier"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detalii"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Administrator rețete culinare Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "Ș_tergere rețeta"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Ștergeți rețetele selectate"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Reteta _Noua"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +530,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +563,287 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Administrator rețete culinare Gourmet"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,651 +858,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Lista cumparaturi"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Editează"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Ajutor"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Du-te"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Adăugați în li_sta de cumpărături"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1509,111 +1465,110 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Importul oprit momentan"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Opriți importul"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "_Index reţete"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Lista de cumpărături"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1623,335 +1578,319 @@ msgstr ""
 "  Paperkite https://launchpad.net/~ub2l\n"
 "  SERGUY https://launchpad.net/~serguy-the-seeker"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Coș de gunoi"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Ștergeți rețetele selectate"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Importul oprit momentan"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "Ș_tergere rețeta"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Acțiuni"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr ""
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Coș de gunoi"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Despre"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "Unelte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "Cronometru"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "_Index reţete"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1959,12 +1898,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1972,78 +1911,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2052,386 +1991,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Niciunul"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Convertor _unitati de masura"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2439,81 +2366,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2522,881 +2422,898 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Fişier"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3410,288 +3327,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3700,104 +3571,98 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3806,7 +3671,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3818,72 +3683,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Administrator rețete culinare Gourmet"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organizați rețete culinare, creați liste de cumpărături, calculați "
-"informații nutriționale și altele."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3893,7 +3716,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3906,44 +3728,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3954,14 +3756,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4015,22 +3809,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4089,6 +3867,17 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Administrator rețete culinare Gourmet"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organizați rețete culinare, creați liste de cumpărături, calculați "
+#~ "informații nutriționale și altele."
 
 #~ msgid "Importing old recipe data"
 #~ msgstr "Se încarcă reţete existente"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-08-27 07:16+0000\n"
 "Last-Translator: Beatrix Kiddo <mashksharn@gmail.com>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -15,198 +15,201 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Индекс рецепта"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "Новый рецепт"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Добавить в список покупок"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Посмотреть рецепт"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Поиск:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Поиск рецептов по мере ввода"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "в"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Поиск по другим критериям, в текущих результатах поиска."
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Добавить критерий поиска"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Ограничить поиск по:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Р_езультаты поиска"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "Добавить _изображение"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "Удалить изображение"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "Источник:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "О_ценка:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "Кухня"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "Категория:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "Время подготовки"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Время готовки"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "Веб-страница"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Изображение:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Мера Выхода"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Установить все значения для_ всех выбранных рецептов"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "SQLite (хранится в локальном файле)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "MySQL (требует соединения с базой данных)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Выберите базу данных"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Выберите систему базы данных для использования в Gourmet</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "Система базы _данных"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Хост:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "Имя _пользователя:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "Пароль"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Пароль к вашему логину  в базе данных"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Имя базы данных"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Файл"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -214,11 +217,11 @@ msgstr ""
 "Имя узла системы, где расположен ваш сервер базы данных. Если сервер базы "
 "данных находится на локальной системе, используйте  localhost."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "localhost"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -226,11 +229,11 @@ msgstr ""
 "Сохранить пароль. Это значит, что пароль будет храниться небезопасно в вашем "
 "конфигурационном файле."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "Сохранить пароль"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -238,299 +241,300 @@ msgstr ""
 "Имя базы данных, в которой Gourmet  должен хранить информацию. Gourmet  "
 "попытается создать базу с таким именем, если она еще не существует."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "рецепт"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Ваш логин в базе данных"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "Просмотр"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "Свойства"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Менеджер рецептов Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Показать таймер"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "Количество рецептов на страницу"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "Разрешить менять величины измерения во время умножения"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Что должен делать Gourmet с необязательными ингридиентами при добавлении "
 "рецептов  в список покупок? </i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "Всегда добавлять необязательные ингридиенты"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "Никогда не добавлять необязательные ингридиенты"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Список покупок"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Заголовок"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "Заголовок"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "Время подготовки"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "категории"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "оценка"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Порций"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Мера Выхода"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Изменить описание"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Время готовки:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Время подготовки:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Кухняe:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Категория:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Веб-страница:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Ссылка</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Источник:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Оценка:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>Умножить на:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Инструкции</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Изменить инструкции"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Примечания</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Изменить примечания"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Рецепт"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Ингредиенты</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Изменить ингредиенты"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Добавить ингредиент"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Продукты"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Добавить рецепт в список покупок"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Добавить  в список покупок"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Удалить выбранный рецепт"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "Удалить рецепт"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Открыть выбранный рецепт"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Выбрать рецепт"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -538,31 +542,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Категория"
 
@@ -571,289 +575,291 @@ msgstr "Категория"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Ключ"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Поиск в процессе набора"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Таймер"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Величина:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "единица"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "Единица _измерения:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Информация о каллориях"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Менеджер рецептов Gourmet"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Копирайт (c) 2004,2005,2006,2007,2008,2009,2010,2011 Thomas M. Hinkle. GNU "
 "GPL v2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -877,212 +883,165 @@ msgstr ""
 "и кроме этого может подсчитать пищевую информацию для рецепта, основываясь "
 "на ингредиентах."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Помощь при портировании на Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Установщик для Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (Совершенствование интерфейса конвертера)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (Совершенствование экпорта в Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (логотип и экран-заставка)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (пищевые и добавть-в -лист-покупок иконки)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (Совершенствование "
-"интернационализации, множественные исправления )"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Бернхард Райтер (Bernhard Reiter) <ockham@raz.or.at> (поддержка версии для "
-"Windows и изменение дизайна веб-сайта)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Выбрать файл базы данных"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Oбновление базы данных"
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-"В зависимости от размера Вашей базы данных это может занять время. Ваши "
-"данные были автоматически сохранены, в случае, если что-то пойдет не так "
-"база данных восстановится."
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr "Подробности"
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Новый Рецепт"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Имя базы данных"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr "Подробности"
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Изменить категорию"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Создать новую категорию"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Сменить категорию выбранного элемента"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Кладовка"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Перенести в список _покупок"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Отправить в кладовку"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Удалить из списка покупок"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Переместить выбранный элемент в %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Список покупок"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Уже есть (_Товары в буфете )"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Введите категорию"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Категория для добавления %s в"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Категория:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Рецепты"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Добавить элементы:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Удалить рецепты"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Удалить рецепты из списка покупок"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Правка"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Справка"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Добавить элементы"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Добавить элементы в список покупок"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Нет выделенных рецептов. Вы хотите очистить весь список?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Сохранить Лист Покупок Как..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Выбрать необязательные ингридиенты"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1091,55 +1050,57 @@ msgstr ""
 "бы добавить в лист покупок."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Рецепт"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Перейти"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Экспортировать рецепт"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Экспортировать выбранный рецепт (сохранить в файл)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Удалить рецепт"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Удалить этот рецепт"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Корректировать единицы измерения при умножении"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr "При умножении изменить единицы измерения на более читаемые"
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Печать рецепта"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Добавить в список покупок"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1147,150 +1108,144 @@ msgstr ""
 "Прежде, чем добавить в список покупок, спросить обо всех дополнительных "
 "компонентах, даже о тех которые Вы ранее помнили."
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Экспортировать рецепт"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Имеются несохраненные изменения"
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "применить изменения перед печатью?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "применить изменения перед печатью?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "Необязательный"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "невозможно найти рецепт %s в базе данных"
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Редактировать Рецепт:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Сохранить правки в базе данных"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Просмотр карточки рецепта"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Редактировать"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Сохранить изменения в %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Добавить ингридиент"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Добавить группу"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Вставить ингридиенты"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Импортировать из файла"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Добавить _рецепт"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Добавить другой рецепт как ингридиент в этот рецепт"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Вверх"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Вниз"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Выберите файл содержащий ваш список ингредиентов"
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Описание"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Приготовление"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "&Заметки"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Кол-во"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Единицы измерения"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Элемент"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Дополнительно"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Рецепт %s (ID %s) не содержиться в базе данных."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Сконвертировано: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Не изменено: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Изменена еденица."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1299,246 +1254,245 @@ msgstr ""
 "Вы изменили единицу для %(item)s с %(old)s на %(new)s. Желаете ли вы "
 "переконвертировать количество?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "переведено из %(old_amt)s %(old_unit)s в %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Невозможно перевести из %(old_unit)s в %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Добавить группу ингредиентов"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Введите имя для новой подгруппы ингредиентов"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Имя группы:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Выбрать рецепт"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Рецепт не может использовать сам себя как ингредиент!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Бесконечные рекурсии недопустимы в рецепте!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Не выделено ни одного рецепта!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Рецепты"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Звук Звонка"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Звук Предупреждения"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Звук Ошибки"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Остановить таймер?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Остановить _таймер"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Продолжить отсчет"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Модули"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
-msgstr ""
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
+msgstr "Управление модулями с дополнительными возможностями к Gourmet"
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Плагин необходим для работы других плагинов. Все равно отключить плагин?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Следующие плагины требуют %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Отключить в любом случае"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Активировать плагин"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "или"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Ошибка при активации плагина"
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Ошибка при отключении плагина"
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Кухня"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Источник"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Веб-сайт"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Время подготовки"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Время приготовления"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Варианты"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "ошибка ввода"
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Нет номера"
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Пауза"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Остановить"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Больше не спрашивать об этом."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Вы действительно хотите это сделать?"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "превосходный"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "отличный"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "хороший"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "чистый"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "скудный"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Конвертировать рейтинг в 5 звезд"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Конвертировать рейтинг"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Пожалуйста оцените рейтинг по шкале от 1 до 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Текущий рейтинг"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Рейтинг из 5 звезд"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Файл не выбран"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Выберите тип файла"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Файл не выбран, действие отменено"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr "Ппостите, Я не могу понять величину \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Величины должны быть числами (обыкновенными или десятичными дробями), серией "
 "цифр, или пустыми."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1558,86 +1512,86 @@ msgstr ""
 "Для ввода диапозона чисел используйте \"-\" для их разделения.\n"
 "Например, вы можете ввести 2-4 или 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "Имя _пользователя:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "Пароль"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "Мука, на все нужды"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "сахар"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "соль"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "Перец черный молотый"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "лёд"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "вода"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "Растительное Масло"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "Оливковое Масло"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Рецепт требует себя в качестве ингридиента"
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Ингридиент %s будет проигнорирован."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Лист Покупок Для %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Для Следующих рецептов:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Для Следующих рецептов:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Выберите кодировку"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1645,29 +1599,28 @@ msgstr ""
 "Невозможно опредлелить кодировку. Пожалуйста выберите правильную кодировку "
 "списка."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Просмотр _файла в кодировке"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Импорт приостановлен"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Остановить импорт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Список рецептов"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Список покупок"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1697,336 +1650,323 @@ msgstr ""
 "  nikolay.olyunin@gmail.com https://launchpad.net/~nikolay-olyunin\n"
 "  Рей https://launchpad.net/~ray-no-gay"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Сохранен"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Сохранить изменения для %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Импорт в процессе"
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Экпорт в процессе"
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Удаление в процессе"
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Выйти из программы?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Не выходить"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "%s рецептов из %s безвозвратно удалены"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Корзина"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Посмотреть, удалить или восстановить удалённые рецепты"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Восстановленные рецепты "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Количество %(unit)s из %(title)s нужное для покупуи"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Различные %s благодаря:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Установить %(attributes)s для %(num)s выбранного рецепта?"
 msgstr[1] "Установить %(attributes)s для %(num)s выбранных рецептов?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Существующие значения не будут изменены."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Новые значения заместят предыдущие"
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Это изменение не может быть отменено"
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Установить значения для выбранных рецептов"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Поиск рецептов"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Открыть рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Открыть выбранный рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Удалить рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Удалить выбранные рецепты"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Редактировать рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Открыть выбранные рецепты в редакторе рецептов"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "_Экспортировать рецепты"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Экспортировать выбранные рецепты в файл"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Печать"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "рецепты"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Пакетное _редактирование рецептов"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Новый"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "Импортировать файл"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Импортировать рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Импортировать рецепт из файла"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Импортировать веб-страницу"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Импортировать рецепт из веб-страницы"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Экспортировать _все рецепты"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Экспортировать все рецепты в файл"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "В_ыйти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Действия"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Открыть корзину"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Корзина"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Настройки"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Модули"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Управление модулями с дополнительными возможностями к Gourmet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Настройки"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "О программе"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Инструменты"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "Таймер"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Показать таймер"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Индекс для поиска рецептов в базе данных"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Удалить %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "Имеются несохраненные изменения в %s. Вы действительно желаете удалить?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Удалено"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Без названия"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Удалить рецепты навсегда?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Удалить рецепт навсегда?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Вы и правда хотите удалить рецепт <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Вы действительно хотите удалить перечисленные рецепты?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Вы действительно хотите удалить все отмеченные рецепты (%s шт.)?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Посмотреть рецепты"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Удалить рецепты"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Индекс рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Удален рецепт %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Готово!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Импортируется..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Редактор ключевых ингридиентов"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Пакетное редактирование ключевых ингридиентов"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "ключ"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "элемент"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Поле"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Значение"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Количество"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Изменить все ключи %s на %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2034,12 +1974,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Изменить вс элементы  %s на %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2050,12 +1990,12 @@ msgstr ""
 "ключом \"%s\", вы не сможете разделить пункты которые были раньше и пункты "
 "которые вы измените сейчас."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Изменить _все примеры \"%(unit)s\" на \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2064,12 +2004,12 @@ msgstr ""
 "Изменить \"%(unit)s\" на \"%(text)s\" только для  _ингредиентов \"%(item)s\" "
 "с ключом \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr "Изменить _все примеры \"%(amount)s\" \"%(text)s\" на %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2078,7 +2018,7 @@ msgstr ""
 "Изменить \"%(amount)s\" %(unit)s на \"%(text)s\" %(unit)s только там, _где "
 "ингредиенты с ключом %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2087,11 +2027,11 @@ msgstr ""
 "Изменить \"%(amount)s\" %(unit)s на \"%(text)s\" %(unit)s только для "
 "ингредиентов с ключом %(key)s _и там где  пункты равны %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Изменить все выделенные строки"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2100,7 +2040,7 @@ msgstr ""
 "Это действие не может быть невыполненно. Вы уверены что для всех %s "
 "выделенных рядов, вы хотите выставить следующие значения:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2109,7 +2049,7 @@ msgstr ""
 "\n"
 "Ключ для %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2118,7 +2058,7 @@ msgstr ""
 "\n"
 "Элемент для %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2127,7 +2067,7 @@ msgstr ""
 "\n"
 "Еденица для %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2136,8 +2076,8 @@ msgstr ""
 "\n"
 "Количество для %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2147,23 +2087,23 @@ msgstr[2] "%s ингредиенты"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Показать ингредиенты %(bottom)s для %(top)s для %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Сумма"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "ключевые ингридиенты"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2171,66 +2111,66 @@ msgstr ""
 "Ключевые ингридиенты это нормализованные названия используемые в списках "
 "закупок и для расчётов"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Отредактировать ассоциации ключей"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Отредактировать ассоциации ключа и других атрибутов в базе данных"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Категория покупок"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Отображать единицы измерения в рецептах как написано (без изменений)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Всегда показывать в американских единицах"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Всегда отображать в метрической системе"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Автоматически корректировать единицы измерения"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Установка предпочтений по единицам измерения"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2238,42 +2178,42 @@ msgstr ""
 "Автоматически, где возможно, переводить единицы измерения в предпочитаемую "
 "систему (метрическую, имперскую, и т.п.)"
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Звёздочки"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s назад"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Автообъединение рецептов"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Всегда использовать более новый рецепт"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Всегда использовать более старый рецепт"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Нет"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2281,61 +2221,61 @@ msgstr ""
 "Некоторые из импортированных рецептов дублируются в базе данных. Вы можете "
 "объединить эти рецепты или закрыть этот диалог чтобы оставить  все как есть."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Поиск _дупликатов рецептов"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Поиск и удаление дупликатов рецептов"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Для каждго выбранного значения"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Где %(field)s в %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
@@ -2343,36 +2283,36 @@ msgstr[0] "Изменение затронет %s рецепт"
 msgstr[1] "Изменение затронет %s рецепта"
 msgstr[2] "Изменение затронет %s рецептов"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Удалить %s там где есть %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Сменить %s с %s на %s ?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Это изменение невозможно отменить.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Редактор Атрибутов"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Редактировать атрибуты в нескольких рецептах одновременно."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Электронная почта для рецептов:"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Отправить по электронной почте выбранные рецепты (или все рецепты если не "
@@ -2381,162 +2321,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Отправить все %s выбранных рецептов по электронной почте?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Да, отправить"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Невозможно конвертировать %s в %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Требуется инофрмация о концентрации"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Конвертор величин"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Перевести едниницы измерения"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Преобразование величин"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Из</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "Ингредиент"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Плотность_информации"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>В</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "Результат:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Загрузка zip архива"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Распаковка zip архива"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "веб-страница HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Экспортировать в Веб-страницу"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Экпортировать рецепты в HTML файлы в директорию %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Рецепты сохранены как HTML файлы %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Оригинальная Страница от %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "необязательный"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Экспортировать в Веб-страницу"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Экпортировать рецепты в HTML файлы в директорию %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Рецепты сохранены как HTML файлы %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Простой текстовый файл"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Экспорт в текст"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Экспорт рецептов в текстовый файл %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "рецепты сохранены в текстовый файл %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Большой Файл"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Файл %s очень большой для импорта"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2548,81 +2476,54 @@ msgstr ""
 "используйте редактора текста, чтобы разделить его на меньшие файлы и "
 "попытаться импортировать снова."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Вебстраница"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Загрузка %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Лист Покупок Для %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Восстановление %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Файл Гурман XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Экспорт в Гурман XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Экспортируются рецепты в файл Гурман XML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Рецепты сохранены как файл Гурман XML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML файл (Устаревший)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML файл"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook текстовый файл"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "импорт из MasterCook завершен"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Чистка XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML файл"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2631,106 +2532,119 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Формат страницы"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Печать Рецептов"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Экспорт в PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Экпортируются рецепты в файл PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Рецепт сохранен как файл PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Letter"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Книжная"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Простой"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "см."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "пункты"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Учетная Карточка (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Учетная Карточка (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Учетная Карточка (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Учетная Карточка (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Letter"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Учетная Карточка (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Учетная Карточка (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Учетная Карточка (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Альбомная"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Простой"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Столбец"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Столбец"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Столбец"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Столбец"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
@@ -2738,168 +2652,176 @@ msgstr[0] "%s Столбец"
 msgstr[1] "%s Столбцы"
 msgstr[2] "%s Столбцы"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Книжная"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Альбомная"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "_Размер Бумаги"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Ориентация"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Размер _Шрифта"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Схема _Страницы"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Размер _Шрифта"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Левый Отступ"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Правый Отступ"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Верхний Отступ"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Нижний Отступ"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "файл MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Экспорт в MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Экпортируются рецепты в файлы MealMaster %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Рецепты сохранены как MealMaster файлы %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "порции"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Большой Файл"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Экспорт"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Экспортируются рецепты в файл Гурман XML %(file)s"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Рецепты сохранены как файл Гурман XML %(file)s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Сохранить список покупок"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Сохранить список как рецепт"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Сохранить список покупок как рецепт для дальнейшего использования"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Меню"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Информация о каллорийности для всего рецепта"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Информация о каллорийности отсутствует для %s компонентов: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Любая группа еды"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "выделение"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "мл"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Изменить еденицу для %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Для того, чтобы подсчитать пищевую информацию, Гурману необходимо помочь "
 "переконвертировать  \"%s\" в единицы, которые он понимает."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Изменить ключ ингридиента"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2908,27 +2830,27 @@ msgstr ""
 "Изменить ключ ингредиента с %(old_key)s на %(new_key)s для всех или только в "
 "рецепте %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Изменить_везде"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Только в рецепте %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Изменить единицу"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2937,11 +2859,11 @@ msgstr ""
 "Изменить единицу из %(old_unit)s в %(new_unit)s для всех ингредиентов "
 "%(ingkey)s или только в рецепте %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2950,198 +2872,199 @@ msgstr ""
 "информации содержит несколько вариантов плотности для данного продукта. "
 "Пожалуйста, выберите верный из предложенных."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Для подсчета диетической информации Гурману нужны правильные количество и "
 "единица."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Каллорийность"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ингредиент"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Эквивалент базы данных USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 граммов"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Калории"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Всего Жиров"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Насыщенных Жиров"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Холестерин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Соль"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Всего Углеводов"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Клетчатка"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Сахар"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Белок"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Альфа-каротин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Поташ"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Бета-каротин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Бета Криптоксантин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Кальций"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Медь"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Всего Фолатома"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Фолиевая кислота"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Пищевой Фолатом"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Диетичейский эквивалент фолатома"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Железо"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Ликопин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Лютеин+Зексантин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Магний"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Марганец"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Никотиновая кислота"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Пантотеновая кислота"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Фосфор"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Калий"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Витамин А"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Ретинол"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Рибофлавин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Селен"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Тиамин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Витамин А (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Витамин А (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Витамин B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Витамин B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Витамин C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Витамин E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Витамин К"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Цинк"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Витамины и минералы"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3150,11 +3073,11 @@ msgstr ""
 "отсутсвующая пищевая информация\n"
 "для %(missing)s за %(total)s ингридиентов."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Дневная Норма"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3163,368 +3086,368 @@ msgstr ""
 "Процент от рекомендуемого значения ежедневной нормы в %i калорий в день. "
 "Нажмите для того, чтобы изменить количество калорий в день."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Количество на %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Количество на рецепт"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Загружается Пищевая Информация"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Импорт диетной базы данных завершен!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Извлечение пищевой базы данных из zip архива %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Извлечение %s из zip архива."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Анализ пищевой информации..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Чтение пищевой информации: Импорт %s из %s записей."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Анализ весовой информации..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Чтение весовой информации для пищевых единиц : Импорт %s из %s записей."
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Вода"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Килокалорий"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "граммов белка"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "граммов липида"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "граммов поташа"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "граммов углеводов"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "граммов грубых волокон"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "граммов сахара"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "миллиграммов кальция"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "миллиграммов железа"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "миллиграммов магния"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "миллиграммов фосфора"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "миллиграммов калия"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "миллиграммов натрия"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "миллиграммов цинка"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "миллиграммов меди"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "миллиграммов марганца"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "микрограмм селена"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "миллиграммов витамина с"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "миллиграммов тиамина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "миллиграммов рибофлавина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "миллиграммов никотиновой кислоты"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "миллиграммов пантотеновой кислоты"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "миллиграммов витамина B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "Всего микрограммов Фолата"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "Микрограммов Фолиевой кислоты"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "Микрограммов пищевого фолата"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "микрограммов диетического эквивалента фолата"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "миллиграммов витамина B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "витамина A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Витамина А (миллиграммов RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "микрограммов Ретинола"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "микрограммов Альфа-каротина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "микрограммов Бета-каротина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "микрограммов Бета Криптоксантина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "Микрограммов Ликопина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "Микрограммов Лютеина+Зезантина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "миллиграммов  Витамина E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "миллиграммов Витамина К"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "граммов Насыщенных жирных кислот"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "граммов Мононасыщенных жирных кислот"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "граммов Полинасыщенных жирных кислот"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "миллиграммов Холестерина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Процент отходов"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Молочные и Яичные Продукты"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Специи и Зелень"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Детское Питание"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Жиры и Масла"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Домашняя птица"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Супы и Соусы"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Колбасы и Бутербродное мясо"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Хлеб для завтрака"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Фрукты и Фруктовые Соки"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Свинина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Овощи"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Орехи и Семечки"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Говядина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Напитки"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Рыба и Морепродукты"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Бобовые"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Баранина, Телятина и Дичь"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Печеные Продукты"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Сладкое"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Крупы и Макаронные изделия"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Фастфуд"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Еда, Закуски и Блюда"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Закуски"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Национальная Пища"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "всю базу данных"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Ключ ингридиента"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA описание пункта"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3538,109 +3461,109 @@ msgstr "Инструменты"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Получить информацию о каллорийности для текущего списка"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Количество для Списка Покупок"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "звезды"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Экспортированно %(number)s из %(total)s рецептов"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Экспорт завершён."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Включить рецепт в текст письма (универсальный вариант)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Отправить рецепт как приложенный html-файл"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "отправить рецепт по электронной почте как PDF вложение"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Настройки e-mail"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Отправлять e-mail без лишних вопросов"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Письмо не отправлено"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 "Вы не выбрали, включить рецепт в тело письма или прикрепить как вложение."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Сохранить рецепт как..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Гурман не может экспортировать файл типа  \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Экспорт рецептов"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "рецепты"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Невозможно экспортировать: Неизвестный тип файла \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Пожалуйста, проверьте, что выбран верный тип файла в выпадающем меню при "
 "сохранении."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Экспорт"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Ошибка печати: нет активных плагинов печати"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
@@ -3648,185 +3571,140 @@ msgstr[0] "Печать %s рецепта"
 msgstr[1] "Печать %s рецепты"
 msgstr[2] "Печать %s рецептов"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Восстановление файла"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "порций"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Введите URL: рархива рецептов или сайта рецептов."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Введите адрес сайта"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Введите URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Введите адрес сайта или архива с рецептами"
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Не могу импортировать URL"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Нет плагина способного  импортировать URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Открыть рецепт..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Введите адрес сайта"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Варианты"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Введите адрес сайта или архива с рецептами"
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Импорт"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Все возможные для импорта файлы"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Импортированно %s рецептов."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "порции"
 msgstr[1] "порций"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Импортированно %s из %s рецептов."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "Ок"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-"Не распознавать эту веб-страницу. использовать стандартный мастер импорта..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Импорт завершен"
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Импорт рецепта"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Обработка ингредиентов"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Обработка ингредиентов."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Персоны"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Подгруппа ингридиентов"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Скрыть"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Текст"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Действия"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Импортировать рецепт"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Очистить _метки"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Импортировать рецепт"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "везде"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "название"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "продукт"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "приготовление"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "комментарии"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "кухня"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "сырье"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Использовать регулярные выражения в поиске"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Использовать регулярные выражения (специальный поисковый язык) в текстовом "
 "поиске"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Поиск в процессе набора (отключить если поиск слишком медленный)"
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Показать _опции поиска"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Показать дополнительные опции поиска"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3836,64 +3714,58 @@ msgstr[2] "%s рецептов"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Показать рецепты %(bottom)s в %(top)s из %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s в %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Приостановлено"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Приостановить"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Готово"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Ошибка: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Ошибка %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Traceback"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "секунда"
@@ -3901,11 +3773,11 @@ msgstr[1] "секунд"
 msgstr[2] "секунды"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "мин"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "минута"
@@ -3913,32 +3785,32 @@ msgstr[1] "минуты"
 msgstr[2] "минут"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "ч"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "час"
 msgstr[1] "часа"
 msgstr[2] "часов"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
 msgstr[1] "дня"
 msgstr[2] "дней"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "неделя"
 msgstr[1] "недели"
 msgstr[2] "недель"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месяц"
@@ -3948,7 +3820,7 @@ msgstr[2] "месяцев"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "год"
@@ -3961,73 +3833,30 @@ msgstr[2] "лет"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " и "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "и"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "до"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Файл Гурман XML"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Менеджер рецептов Gourmet"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Управляйте своими рецепты, создавайте списки покупок, расчитывайте "
-"информацию о питательной ценности продуктов и т.д."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -4037,7 +3866,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -4050,38 +3878,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4089,6 +3885,18 @@ msgstr "Экспорт в PDF"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -4099,14 +3907,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4160,22 +3960,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4234,6 +4018,149 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Помощь при портировании на Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Установщик для Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (Совершенствование интерфейса конвертера)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (Совершенствование экпорта в Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (логотип и экран-заставка)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (пищевые и добавть-в -лист-покупок иконки)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (Совершенствование "
+#~ "интернационализации, множественные исправления )"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Бернхард Райтер (Bernhard Reiter) <ockham@raz.or.at> (поддержка версии "
+#~ "для Windows и изменение дизайна веб-сайта)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Oбновление базы данных"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "В зависимости от размера Вашей базы данных это может занять время. Ваши "
+#~ "данные были автоматически сохранены, в случае, если что-то пойдет не так "
+#~ "база данных восстановится."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Вставить ингридиенты"
+
+#~ msgid "Import from file"
+#~ msgstr "Импортировать из файла"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Выберите файл содержащий ваш список ингредиентов"
+
+#~ msgid "No file selected"
+#~ msgstr "Файл не выбран"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Файл не выбран, действие отменено"
+
+#~ msgid "_Import file"
+#~ msgstr "Импортировать файл"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Импортировать веб-страницу"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Импортировать рецепт из веб-страницы"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Открыть корзину"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Загрузка zip архива"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Распаковка zip архива"
+
+#~ msgid "Webpage"
+#~ msgstr "Вебстраница"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Загрузка %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Лист Покупок Для %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Восстановление %s"
+
+#~ msgid "ml"
+#~ msgstr "мл"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Восстановление файла"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Введите URL: рархива рецептов или сайта рецептов."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Введите URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Не могу импортировать URL"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Нет плагина способного  импортировать URL"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr ""
+#~ "Не распознавать эту веб-страницу. использовать стандартный мастер "
+#~ "импорта..."
+
+#~ msgid "Import complete."
+#~ msgstr "Импорт завершен"
+
+#~ msgid "Importing recipe"
+#~ msgstr "Импорт рецепта"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Обработка ингредиентов"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Обработка ингредиентов."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Файл Гурман XML"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Менеджер рецептов Gourmet"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Управляйте своими рецепты, создавайте списки покупок, расчитывайте "
+#~ "информацию о питательной ценности продуктов и т.д."
 
 #~ msgid "_Label"
 #~ msgstr "Метка"
@@ -4348,9 +4275,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "Порции"
-
-#~ msgid "Select File_type"
-#~ msgstr "Выберите тип файла"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Файл с именем %s уже существует"

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-10-26 16:23+0000\n"
 "Last-Translator: Eduard Hummel <22edel22@gmail.com>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -22,508 +22,511 @@ msgstr ""
 "X-Language: sk_SK\n"
 "X-Source-Language: C\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nový recept"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Pridať do _nákupného zoznamu"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Jednotka výnosu"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Súbor"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recept"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detaily"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Správca receptov Gourmet"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Zobraziť časovač"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Nákupný zoznam"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Názov"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategóriách"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Výnos"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Jednotka výnosu"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recept"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Prísady"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Odstrániť recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Otvoriť vybraný recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Vybrať recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -531,31 +534,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategória"
 
@@ -564,286 +567,288 @@ msgstr "Kategória"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Kľúč"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Vyhľadávať v priebehu písania"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Minútky"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "jednotka"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Nutričné hodnoty"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Správca receptov Gourmet"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -866,214 +871,166 @@ msgstr ""
 "Gourmet podporuje pridávanie obrázkov k receptom. Tiež dokáže vypočítať "
 "nutričné hodnoty pre recept na základe prísad."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (podpora pri portovaní do Windows)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Inštalátor pre Windows)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (vylepšenia rozhrania na prevod jednotiek)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (vylepšenia v exporte Mealmastert)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo a úvodná obrazovka)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-"Yula Zubritsky (nutričné hodnoty a ikony pre pridanie do nákupného zoznamu)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (vylepšenie prekladu, rôzne "
-"bugfixy)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (Udržovanie verzie pre Windows a nový "
-"dizajn webových stránok)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Vybrať súbor s databázou"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Aktualizujem databázu"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Nový recept"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
 msgstr ""
-"V závislosti na veľkosti vašej databázy to môže chvíľu trvať. Vaše dáta boli "
-"pre istotu automaticky zálohované."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Detaily"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Pre istotu bola v %s vytvorená záloha. V prípade problémov s povýšením "
 "zálohu premenujte na recipes.db a môžete ju používať zo starým Gourmetom."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Nový recept"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Zmeniť _kategóriu"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Vytvoriť novú kategóriu"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Zmeniť kategóriu vybranej pložky"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Zásobáreň"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Presunúť do _nákupného zoznamu"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Presunúť do _zásobárne"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Odstrániť z nákupného zoznamu"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Presunúť vybrané položky do %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Nákupný zoznam"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Už mám (_Položky zo špajze)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Vložiť kategóriu"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Pridať %s do kategórie"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategórie:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recepty"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Pridať položky:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Odstrániť recepty"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Odstrániť recepty z nákupného zoznamu"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Uverejniť"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Pomocník"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Pridať položky"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Pridať ľubovoľné položky do nákupného zoznamu"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Nebol vybraný žiadny recept. Prajete si vyprázdniť celý zoznam?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Uložiť nákupný zoznam ako..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Označiť voliteľné prísady"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1082,56 +1039,58 @@ msgstr ""
 "vložili do vášho nákupného zoznamu."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recept"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Prejsť"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Exportovať recept"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Exportovať vybraný recept (uložiť do súboru)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "O_dstrániť recept"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Odstráni tento recept"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Upraviť jednotky pri násobení"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Pri násobení upraviť jednotky pre lepšiu prehľadnosť kdekoľvek je to možné."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Vytlačiť recept"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Pridať do _nákupného zoznamu"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Zabudnúť voliteľné prísady"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1139,150 +1098,144 @@ msgstr ""
 "Pred pridaním do nákupného zoznamu potvrdzovať všetky voliteľné prísady, i "
 "tie, ktoré boli pôvodne zapamätané"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Exportovať recept"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Máte neuložené zmeny."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Aplikovať z pred tlačou?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Aplikovať z pred tlačou?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Voliteľné)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Recept %s nebol nájdený v databáze."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Zmeniť recept:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Uložiť úpravy do databázy"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Ukáž kartu receptu"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Upraviť"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Uložiť zmeny do %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Pridať prísadu"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Pridať skupinu"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Vložiť prísady"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Importovať zo súboru"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Pridať _recept"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Pridať iný recept ako prísadu tohto"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Odstrániť"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Nahor"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Dole"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Vybrať súbor obsahujúci zoznam prísad."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Popis"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Postup"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Poznámky"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Mnž."
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Jednotka"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Položka"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Voliteľné"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Recept %s (ID %s) nie je v databáze."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Prevedené: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Neprevedené: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Zmenená jednotka."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1291,231 +1244,230 @@ msgstr ""
 "Zmenili ste jednotku pre %(item)s z %(old)s na %(new)s. Želáte si tiež "
 "previesť aj množstvo?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Prevedené %(old_amt)s %(old_unit)s na %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Prevod z %(old_unit)s na %(new_unit)s nie je možný."
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Pridať skupinu prísad"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Vložiť meno pre novú podskupinu prísad"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Meno skupiny:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Vybrať recept"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Recept nie je možné použiť ako prísadu v sebe samom!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "V receptoch nie je povolená nekonečná rekurzia!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Nevybrali ste žiadny recept!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recepty"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Zvuk budíku"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Zvuk varovania"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Zvuk chyby"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Zastaviť minútky?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "_Zastaviť minútky"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Pokračuj"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Zásuvné moduly"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
-msgstr ""
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
+msgstr "Spravovať zásuvné moduly, ktoré pridávajú do Gourmetu ďalšie funkcie."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr "Zásuvný modul je vyžadovaný iným modulom. Má byť aj tak deaktivovaný?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Nasledujúce zásuvné moduly vyžadujú %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Aj tak deaktivovať"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Ponechať zásuvný modul aktivovaný"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "alebo"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Pri aktivácii zásuvného modulu nastala chyba."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Pri ukončovaní zásuvného modulu nastala chyba."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Kuchyňa"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Hodnotenie"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Zdroj"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Webová stránka"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Čas prípravy"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Čas varenia"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Zmeny"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Neplatný vstup."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Nieje číslo."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pozastaviť"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Zastaviť"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Nepýtaj sa ma to znovu."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Naozaj to chcete?"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "vynikajúce"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "prima"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "dobré"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "ujde"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "nič moc"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Zmeniť hodnotenie na 5 hviezdičkovú stupnicu."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Zmeniť hodnotenie."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Prideľte, prosím, každému hodnoteniu ekvivalent zo stupnice 1 až 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Aktuálne hodnotenie"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Hodnotenie z 5 hviezdičiek"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Nie je vybraný žiadny súbor"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Vybrať _typ súboru"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Nebol vybraný žiadny súbor, takže akcia bola zrušená."
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1524,14 +1476,14 @@ msgstr ""
 "Ľutujem, ale nerozumiem\n"
 "množstvo \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Množstvo musí byť číslo (zlomok alebo desatinné číslo), rozsah čísel alebo "
 "prázdne."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1550,84 +1502,84 @@ msgstr ""
 "AK chcete vložiť rozsah čísel, oddeľte ich znakom \"-\".\n"
 "Napríklad, môžete zadať 2-4 alebo 1 1/2-3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "múka, na každé použitie"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "cukor"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "soľ"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "čierne korenie, mleté"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "ľad"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "voda"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "olej, rastlinný"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "olej, olivový"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Neznáme"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Recept používa sám seba ako prísadu."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Prísada %s sa ignoruje."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Nákupný list pre %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Pre nasledujúce recepty:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Pre nasledujúce recepty:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Vybrať kódovanie"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1635,29 +1587,28 @@ msgstr ""
 "Nie je možné určiť správne kódovanie. Vyverte, prosím, správne kódovanie zo "
 "zoznamu."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Prezrieť _súbor s kódovaním"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Import je pozastavený"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Zastaviť import"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Zoznam _receprov"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Nákupný _zoznam"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "translator-credits\n"
@@ -1669,82 +1620,63 @@ msgstr ""
 "  Marek Krempa https://launchpad.net/~markus-kaa\n"
 "  Pavol Babinčák https://launchpad.net/~scrool"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Uložené!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Uložiť vaše zmeny do %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Práve prebieha import."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Práve prebieha export."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Práve prebieha odstraňovanie."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Naozaj ukončiť program?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Nekončiť!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Nenávratne zmazaných %s z %s receptov"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Kôš"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Prechádzajte, mažte a obnovujte recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Obnovené recepty "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Nakúpiť %(unit)s na %(title)s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Vynásobiť %s:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
@@ -1752,285 +1684,291 @@ msgstr[0] "Nastaviť %(attributes)s %(num)s vybraným receptom?"
 msgstr[1] "Nastaviť %(attributes)s %(num)s vybranému receptu?"
 msgstr[2] "Nastaviť %(attributes)s %(num)s vybraným receptom?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Žiadna z predchádzajúcich hodnôt nebude zmenená."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Nové hodnoty prepíšu predchádzajúe hodnoty."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Táto zmena je nevratná."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Nastaviť hodnoty označeným receptom"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Hľadať recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Otvoriť recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Otvoriť vybraný recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Zmazať recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Odstrániť vybrané recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Upraviť recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Otvoriť označené recepty v editore"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_xportovať vybrané recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Exportovať vybrané recepty do súboru"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Tlačiť"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "recepty"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Dávkovo upraviť r_ecepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nový"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Importovať súbor"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Importovať recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Importovať recept zo súboru"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Importovať _webstránku"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s receptov"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Importovať recept z webstránky"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Exportovať _všetky recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Exportovať všetky recepty do súboru"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Ukončiť"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Akcie"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Otvoriť _koš"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Kôš"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "Na_stavenia"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Zásuvné moduly"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Spravovať zásuvné moduly, ktoré pridávajú do Gourmetu ďalšie funkcie."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "_Nastavenia"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_O programe"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Nástroje"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Časovač"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Zobraziť časovač"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Prehľadávateľný zoznam receptov v databáze."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Zmazať %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Máte neuložené zmeny v %s. Želáte si ich zahodiť?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Zmazané"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Bez názvu"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Odstrániť recepty natrvalo?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Odstrániť recept natrvalo?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Naozaj chcete odstrániť recept <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Naozaj chcete odstrániť nasledovné recepty?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Naozaj chcete odstrániť %s vybraných receptov?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Pozrieť recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Zmazať recepty"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Zoznam _receprov"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Odstrániť recept %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Hotovo!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importuje sa..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Editor _kľúčov prísad"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Upraviť kľúče prísad hromadne"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "kľúč"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "položka"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Pole"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Hodnota"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Počet"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Zmeniť všetky kľúče \"%s\" na \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
 "the key \"%s\", you won't be able to distinguish between those items and the "
 "items you are changing now."
 msgstr ""
-"Táto akcia nebude môcť byť vrátená späť. Ak existujú prísady s kľúčom \"%s"
-"\", potom nebudete môcť rozlíšiť medzi pôvodnými položkami a tými, ktoré "
+"Táto akcia nebude môcť byť vrátená späť. Ak existujú prísady s kľúčom "
+"\"%s\", potom nebudete môcť rozlíšiť medzi pôvodnými položkami a tými, ktoré "
 "práve meníte."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Zmeniť všetky položky \"%s\" na \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
 "the item \"%s\", you won't be able to distinguish between those items and "
 "the items you are changing now."
 msgstr ""
-"Táto akcia nebude môcť byť vrátená späť. Ak existujú prísady s položkou \"%s"
-"\", potom nebudete môcť rozlíšiť medzi pôvodnými položkami a tými, ktoré "
+"Táto akcia nebude môcť byť vrátená späť. Ak existujú prísady s položkou "
+"\"%s\", potom nebudete môcť rozlíšiť medzi pôvodnými položkami a tými, ktoré "
 "práve meníte."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Zmeniť _všetky výskyty \"%(unit)s\" na \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2039,12 +1977,12 @@ msgstr ""
 "Zmeniť \"%(unit)s\" na \"%(text)s\" iba pre _prísady \"%(item)s\" s kľúčom "
 "\"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr "Zmeniť všetky výskyty \"%(amount)s\" %(unit)s na %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2053,7 +1991,7 @@ msgstr ""
 "Zmeniť \"%(amount)s\" %(unit)s na \"%(text)s\" %(unit)s iba _kde kľúč "
 "prísady je %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2062,11 +2000,11 @@ msgstr ""
 "Zmeniť \"%(amount)s\" %(unit)s na \"%(text)s\" %(unit)s iba kde kľúč prísady "
 "je %(key)s _a kde položka je %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Zmeniť všetky vybrané riadky?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2075,7 +2013,7 @@ msgstr ""
 "Táto akcia nebude môcť byť vrátená. Ste si istí, že pre všetky %s vybraných "
 "riadkov chcete zmeniť nasledujúce hodnoty:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2084,7 +2022,7 @@ msgstr ""
 "\n"
 "Kľúč na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2093,7 +2031,7 @@ msgstr ""
 "\n"
 "Položku na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2102,7 +2040,7 @@ msgstr ""
 "\n"
 "Jednotku zmeniť na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2111,8 +2049,8 @@ msgstr ""
 "\n"
 "Množstvo zmeniť na %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2122,23 +2060,23 @@ msgstr[2] "%s prísady"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Zobrazené ingrediencie od %(bottom)s do %(top)s z %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Množstvo"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Kľúče prísad"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2146,11 +2084,11 @@ msgstr ""
 "Kľúče prísad sú normalizované mená prísad používané v nákupných listoch a "
 "pre výpočty."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Odhadnúť kľúče"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2158,56 +2096,56 @@ msgstr ""
 "Odhadne najlepšie hodnoty pre kľúče prísad na základe hodnôt vo vašej "
 "databáze"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Upraviť asociácie kľúčov"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Upraviť asociácie s kľúčom a ďalšími atribútmi v databáze"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Nákupná kategória"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Zobrazovať jednotky ako sú v recepte (bez zmeny)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Vždy zobrazovať americké jednotky"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Vždy zobrazovať metrické jednotky"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Automaticky upravovať jednotky"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Nastaviť predvoľby zobrazenia _jednotiek"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2215,42 +2153,42 @@ msgstr ""
 "Automaticky prevádzať jednotky do preferovaných jednotiek (metrické, "
 "britských, atď.) kdekoľvek je to možné."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Hviezd"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "pred %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Automaticky spojovať recepty"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Vždy použiť najnovší recept"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Vždy použiť najstarší recept"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Žiadne"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2258,61 +2196,61 @@ msgstr ""
 "Niektoré z importovaných receptov vyzerajú duplicitne. Môžete ich teraz "
 "spojiť, alebo zatvoriť toto okno a nechať ich ako sú."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Nájsť _duplicitné recepty"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Nájsť a odstrániť duplicitné recepty"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Pre každú vybranú hodnotu"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Kde %(field)s je %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
@@ -2320,36 +2258,36 @@ msgstr[0] "Zmena sa dotkne %s receptu"
 msgstr[1] "Zmena sa dotkne %s receptu"
 msgstr[2] "Zmena sa dotkne %s receptov"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Zmazať %s kde je %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Zmeniť %s z %s na \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Táto zmena je nevratná.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Editor polí"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Upravte pole v niekoľkých receptoch zároveň."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Odoslať recepty e-mailom"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Odoslať e-mailom všetky označené recepty (alebo všetky recepty ak niesú "
@@ -2358,162 +2296,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Naozaj chete poslať e-mail z %s vybranými receptami?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Áno, odoslať ich"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Nie je možné previesť %s na%s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Je potrebná informácia o hustote"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Prevodník jednotiek"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Spočítať prevod jednotiek"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Načítam zip archív"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Rozbaľujem zip archív"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML web-stránka"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Exportuje sa Web-stránka"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Recepty z adresára %(file)s sa exportujú do HTML"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Recept bol uložený ako HTML súbor %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Pôvodná stránka z %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "voliteľný"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Exportuje sa Web-stránka"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Recepty z adresára %(file)s sa exportujú do HTML"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Recept bol uložený ako HTML súbor %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Textový súbor"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Textový export"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Recepty sú exportované do textového súboru %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Recept uložený ako textový súbor %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Veľký súbor"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Súbor %s je na import príliš veľký"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2524,81 +2450,54 @@ msgstr ""
 "ho ani importovať nechceli. Ak ho skutočne chcete importovať, rozdeľte ho v "
 "textovom editore na menšie súbory a skúste to znovu."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Webová stránka"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Sťahuje sa %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Nákupný list pre %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Získavam %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Súbor MasterCook XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Export Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Exportujú sa recepty do Gourmet XML súboru %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Recept uložený v Gourmet XML súbore %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "XML súbor Gourmetu (zastaralý)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML súbor"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook textový súbor"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Import súboru vo formáte MasterCook dokončený."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Čistí sa XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecpie XML súbor"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2607,106 +2506,119 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Rozloženie stránky"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Tlačiť recepty"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF export"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Exportujem recepty do PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Recept uložený ako PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "List"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Na výšku"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Jednoduchý"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "bodov"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17''"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Kartička (3.5x5'')"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Kartička (4x6'')"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Kartička (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Kartička (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "List"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Kartička (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Kartička (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Kartička (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Na šířku"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Jednoduchý"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s Stĺpcov"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s Stĺpcov"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s Stĺpcov"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s Stĺpcov"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
@@ -2714,168 +2626,176 @@ msgstr[0] "%s Stĺpcov"
 msgstr[1] "%s Stĺpec"
 msgstr[2] "%s Stĺpce"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Na výšku"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Na šířku"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Veľko_sť papiera"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientácia"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Veľkosť _písma"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Vz_hľad strany"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Veľkosť _písma"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Ľavý okraj"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Pravý okraj"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Horný okraj"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Spodný okraj"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "Súbor MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Export do MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Recepty sa exportuju do súboru pre MealMaster %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Recept bol uložený do súboru MealMaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "porcií"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Veľký súbor"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Export"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Exportujú sa recepty do Gourmet XML súboru %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Recept uložený v Gourmet XML súbore %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Uložiť nákupný zoznam"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Uložiť zoznam ako recept"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Uložiť nákupný zoznam ako recept do budúcna"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Ponuka %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Ponuka"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Nutričné hodnoty zodpovedajú množstvu %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Nutričné hodnoty zodpovedajú množstvu pre celý recept"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Chýbajú nutrične hodnoty pre %s prísad: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Akákoľvek skupina jedál"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "výber"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Prevod jednotky pre %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Pre výpočet nutričných informácií Gourmet potrebuje vašu pomoc s prevodom "
 "\"%s\" na jednotku ktorej rozumie."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Zmeniť kľúč prísady"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2884,27 +2804,27 @@ msgstr ""
 "Zmeniť kľúč prísady z %(old_key)s na %(new_key)s všade, alebo iba v recepte "
 "%(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Zmeniť _všade"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Iba v recepte %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Chcete zmeniť kľúč prísady z %(old_key)s na %(new_key)s všade?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Zmena jednotky"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2913,11 +2833,11 @@ msgstr ""
 "Zmeniť jednotku z %(old_unit)s na %(new_unit)s pre všetky ingrediencie "
 "%(ingkey)s, alebo iba pre recept %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2925,196 +2845,197 @@ msgstr ""
 "Gourmet poznať hustotu. V našej databáze máme pre túto prísadu niekoľko "
 "hodnôt, prosím , zvoľte nižšie tú správnu."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr "Pre nutričné hodnoty je potrebné zadať množstvo a jendotku."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Výživa"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Prísada"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Ekvivalent databazy USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gramov"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalórie"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Tuk celkom"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Nasýtené tuky"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Cholesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sodík"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Karbohydrátov spolu"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Vlákniny"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Cukry"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteín"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-karotén"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Popoľ"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-karotén"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Vápnik"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Meď"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Vitamín B9"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Železo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Horčík"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangán"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Niacín"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Vitamín B9"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Draslík"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamín A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Vitamín A1"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavín"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selén"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamín"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamín A(IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamín A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamín B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamín B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamín C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamín E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamín K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zinok"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamíny a minerály"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3123,11 +3044,11 @@ msgstr ""
 "Chýbajú nutričné hodnoty \n"
 "pre %(missing)s z %(total)s prísad."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Dennej dávky"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3136,369 +3057,369 @@ msgstr ""
 "Percentuálne množstvo odporúčanej dennej dávky zaležené na %i kalórií na "
 "deň. Počet kalórií na deň zmeníte kliknutím."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Množstvo na %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Množstvo na recept"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Nahrávam nutričné dáta"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Import nutričnej databázy ukončený!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Načítam nutričnú databázu zo zip archívu %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Rozbaľujem %s zo zip archívu."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Analyzujem nutričné dáta ..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Načítanie nutričných dát: importovaných %s z %s záznamov."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Analyzujem dáta o hmotnostiach ..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Načítanie dát o hmotnostiach pre nutričné položky: importovaných %s z %s "
 "záznamov"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Voda"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalórií"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g proteínov"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipidov"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g popola"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g karbohydrátov"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g vlákniny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g cukru"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg vápniku"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg železa"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnézia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosforu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg draslíku"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg sodíku"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg zinku"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg medi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg magnézia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mikrogram selénu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamínu C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg tiamínu (vit. B1)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg riboflavínu (vit. B2)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niacínu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg kyseliny pantoténovej"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamínu B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "spolu mikrogramov kyseliny listovej"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "mikrogramov kyseliny listovej"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "cholínu, celkom"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mikrogramov vitamínu B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "vitamín A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "vitamín A v mikrogramoch"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "mikrogram Alfa-karoténu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "mikrogram Beta-karoténu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg vitamínu E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg vitamínu K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g nasýtaných mastných kyselín"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg cholesterolu"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Mliečne produkty a vajcia"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Korenia a bylinky"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Jedlá pre deti"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Tuky a oleje"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Hydina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Polievky & omáčky"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Údeniny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Cerálie"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Ovocie a ovocné šťavy"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Bravčové"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Zelenina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Orechy a semená"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Hovädzie"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Nápoje"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Ryby a mušle"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Strukoviny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Jahňacie, telacie a zverina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Pečené produkty"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Sladkosti"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Obilniny a cestoviny"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Rýchle jedlá"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Jedlá, hlavné chody a prílohy"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Ľahké jedlá"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Národné jedlá"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "celá databáza"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Kľúč prísady"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "USDA ID číslo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA popis položky"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Zodpovedajúca hustota"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA ID#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3512,106 +3433,106 @@ msgstr "Nástroje"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Získať nutričné hodnoty pre tento zoznam"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Množstvo do nákupného zoznamu"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "hviezdičiek"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Exportovaných %(number)s z %(total)s receptov"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Export dokončený."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Vložiť recept do E-mailu (Dobrý nápad v každom ohľade)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Odoslať recept E-mailom ako HTML prílohu"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Poslať recept e-amilom ako PDF prílohu."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Voľby pre E-mail"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Nepýtať sa pred odoslaním E-mailu."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "E-mail nebol odoslaný."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr "Nezvolili ste vloženie receptu do E-mailu ani pripojenie ako prílohu."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Uložiť recept ako..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet nemôže exportovať súbor typu \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Exportovať recepty"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recepty"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Export sa nepodaril: neznámy typ súboru \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "Pri ukladaní nezabudnite z rozbaľovacieho menu vybrať typ súboru."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Export"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Tlač sa nepodarila: niesú aktívne žiadne tlačové zásuvné moduly!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
@@ -3619,187 +3540,141 @@ msgstr[0] "Vytlačiť %s receptov"
 msgstr[1] "Vytlačiť %s recept"
 msgstr[2] "Vytlačiť %s recepty"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Získavam súbor"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "výnos"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Zadajte URL archívu receptov alebo Web-stránku receptov"
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Vložte adresu web stránky"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Zadajte URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Zadajte webovú adresu stránky či archívu receptov."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Import URL sa nepodaril."
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gourmet neobsahuje zásuvný modul umožňujúci importovať URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Nepodarilo sa importovať URL %(url)s mimetypu %(type)s. Súbor bol dočasne "
-"uložený do %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Otvoriť recept ..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Vložte adresu web stránky"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Zmeny"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Zadajte webovú adresu stránky či archívu receptov."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Import"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Všetky importovateľné súbory"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Importovaných %s receptov"
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "porcií"
 msgstr[1] "porcia"
 msgstr[2] "porcie"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Importovaných %s z %s receptov."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "v poriadku"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Web stránka nebola rozpoznaná. Používam univerzálny importér ..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Import kompletný."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Importujem recept"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Spracovávam prísady"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Spracovávam prísady."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Porcií"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Podskupina prísad"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Skryť"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Text"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Akcie"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importovať recept"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Odstrániť ští_tky"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Importovať recept"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "kdekoľvek"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "názvoch"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "prísadách"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "postupoch"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "poznámkach"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "kuchyniach"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "zdrojoch"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Používať regulárne výrazy vo vyhľadávaní"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 "Používať regulárne výrazy (pokročilý vyhľadávací jazyk) vo vyhľadávaní textu"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 "Vyhľadáva v priebehu písania (vypnite, ak je vyhľadávanie príliš pomalé)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Zobraziť m_ožnosti vyhľadávania"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Zobrazí pokročilé možnosti vyhľadávania"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3809,64 +3684,58 @@ msgstr[2] "%s recepty"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Zobrazujem recepty %(bottom)s do %(top)s %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s in %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Prerušené"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Prerušiť"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Dokončené"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Chyba: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Chyba"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Chyba %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Spätné sledovanie"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "sekúnd"
@@ -3874,11 +3743,11 @@ msgstr[1] "sekunda"
 msgstr[2] "sekundy"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minút"
@@ -3886,32 +3755,32 @@ msgstr[1] "minúta"
 msgstr[2] "minúty"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "hod"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "hodín"
 msgstr[1] "hodina"
 msgstr[2] "hodiny"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dní"
 msgstr[1] "deň"
 msgstr[2] "dni"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "týždňov"
 msgstr[1] "týždeň"
 msgstr[2] "týždne"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mesiacov"
@@ -3921,7 +3790,7 @@ msgstr[2] "mesiace"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rokov"
@@ -3934,73 +3803,30 @@ msgstr[2] "roky"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " a "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "a"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "do"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Súbor MasterCook XML"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Správca receptov Gourmet"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Zorganizujte svoje recepty, vytvárajte si nákupné zoznamy, spočítajte si "
-"nutričné hodnoty a omnoho viac."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -4010,7 +3836,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -4023,38 +3848,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4062,6 +3855,18 @@ msgstr "PDF export"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -4072,14 +3877,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4133,22 +3930,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4207,6 +3988,156 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (podpora pri portovaní do Windows)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Inštalátor pre Windows)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (vylepšenia rozhrania na prevod jednotiek)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (vylepšenia v exporte Mealmastert)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo a úvodná obrazovka)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr ""
+#~ "Yula Zubritsky (nutričné hodnoty a ikony pre pridanie do nákupného "
+#~ "zoznamu)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (vylepšenie prekladu, rôzne "
+#~ "bugfixy)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (Udržovanie verzie pre Windows a nový "
+#~ "dizajn webových stránok)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Aktualizujem databázu"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "V závislosti na veľkosti vašej databázy to môže chvíľu trvať. Vaše dáta "
+#~ "boli pre istotu automaticky zálohované."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Vložiť prísady"
+
+#~ msgid "Import from file"
+#~ msgstr "Importovať zo súboru"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Vybrať súbor obsahujúci zoznam prísad."
+
+#~ msgid "No file selected"
+#~ msgstr "Nie je vybraný žiadny súbor"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Nebol vybraný žiadny súbor, takže akcia bola zrušená."
+
+#~ msgid "_Import file"
+#~ msgstr "_Importovať súbor"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Importovať _webstránku"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Importovať recept z webstránky"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Otvoriť _koš"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Načítam zip archív"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Rozbaľujem zip archív"
+
+#~ msgid "Webpage"
+#~ msgstr "Webová stránka"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Sťahuje sa %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Nákupný list pre %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Získavam %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Získavam súbor"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Zadajte URL archívu receptov alebo Web-stránku receptov"
+
+#~ msgid "Enter URL:"
+#~ msgstr "Zadajte URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Import URL sa nepodaril."
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gourmet neobsahuje zásuvný modul umožňujúci importovať URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Nepodarilo sa importovať URL %(url)s mimetypu %(type)s. Súbor bol dočasne "
+#~ "uložený do %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Web stránka nebola rozpoznaná. Používam univerzálny importér ..."
+
+#~ msgid "Import complete."
+#~ msgstr "Import kompletný."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Importujem recept"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Spracovávam prísady"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Spracovávam prísady."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Súbor MasterCook XML"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Správca receptov Gourmet"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Zorganizujte svoje recepty, vytvárajte si nákupné zoznamy, spočítajte si "
+#~ "nutričné hodnoty a omnoho viac."
 
 #~ msgid "Select recipe image"
 #~ msgstr "Vyberte obrázok k receptu"
@@ -4306,9 +4237,6 @@ msgstr ""
 #~ "Chcete zatvoriť okno s aktívnymi minútkami. Môžete zastaviť minútky, "
 #~ "alebo iba zatvoriť okno. Ak zatvoríte okno, objaví sa znovu, len čo sa "
 #~ "ozve signál."
-
-#~ msgid "Select File_type"
-#~ msgstr "Vybrať _typ súboru"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Súbor s menom %s už existuje."

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2013-12-08 23:53+0000\n"
 "Last-Translator: Kristijan <kiki.tkalec@gmail.com>\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -15,513 +15,516 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n"
-"%100==4 ? 3 : 0);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || "
+"n%100==4 ? 3 : 0);\n"
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Kazalo receptov"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nov Recept"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Dodaj v _Nakupovalni seznam"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Pokaži recept"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Poišči:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Iskanje receptov med tipkanjem"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_v"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Iskanje po drugih merilih, znotraj trenutnih rezultatih iskanja."
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "A_dd Iskalni kriterij"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Omejevanje iskanja na:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Iskanje _rezultati"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Nastavite polja za izbrane recepte"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "_Dodajte sliko"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Odstranite sliko"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Ocena:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Kategorija:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "_Čas priprave:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Spletna stran"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Slika:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Enota izkoristka"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "_Samo določi vrednosti kjer je polje trenunto prazno"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Nastavite vse vrednosti za _vse izbrane recepte"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Izberite podatkovno zbirko"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "_Sistem podatkovne zbirke"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Gostitelj:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Uporabniško ime:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Geslo:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Datoteka"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "_Shrani geslo"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recept"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Brskanje"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Podrobnosti"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gurman, upravljalnik receptov"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Prikaži odštevalnik časa"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Nakupovalni seznam"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Ime"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategorija"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Izkoristek"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Enota izkoristka"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recept"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Sestavine"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Izbriši Recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Odpri izbran recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Izberi recept"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -529,31 +532,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategorija"
 
@@ -562,286 +565,288 @@ msgstr "Kategorija"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Ključ"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Išči med tipkanjem"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Odštevalnik"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Količina:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "enota"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Enota:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Podatki o hranilni vrednosti"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gurman, upravljalnik receptov"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -864,215 +869,167 @@ msgstr ""
 "Gurmana. Gurman podpira povezavo slik z recepti. Gurman lahko prav tako "
 "izračuna hranilno vrednost za recepte, izhajajoč iz sestavin."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Windows porting assistance)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (izboljšave vmesnika za Pretvornik enot)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (izboljšave za izvoz v Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (logo and splash screen)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (mednarodne izboljšave, "
-"odpravljanje različnih težav s hrošči)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Bernhard Reiter <ockham@raz.or.at> (vzdrževanje verzije za Windowa in "
-"oblikovanje spletne strani)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Izberi datoteko iz zbirke podatkov"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Posodobitev zbirke podatkov"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Nov Recept"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
 msgstr ""
-"Glede na velikost vaše datoteke lahko proces traja dalj časa. Vaši podatki "
-"so bili avtomatično shranjeni v arhivski kopiji, v primeru, da gre kaj "
-"narobe."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Podrobnosti"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "V primeru, da gre kaj narobe, je bila narejena arhivska kopija v %s. \r\n"
 "Če posodobitev ne uspe, lahko ročno preimenujete arhivsko datoteko recipes."
 "db in jo obnovite za uporabo s starejšim Gurmanom."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Nov Recept"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Spremeni _kategorijo"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Ustvari novo kategorijo"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Spremeni kategorijo trenutno izbrane postavke"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Shramba"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Premakni v _Nakupovalni seznam"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Premakni v _skladišče"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Izbriši iz nakupovalnega seznama"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Premakni izbrane postavke v %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Nakupovalni Seznam"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Že Imam (_Stvari v shrambi)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Vstavite Kategorijo"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Kategorija za dodati %s k"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategorija:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recepti"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Dodaj podatke:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Odstrani Recepte"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Odstrani recepte iz nakupovalnega seznama"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Uredi"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Pomoč"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Dodaj podatke"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Dodaj arbitrarne podatke na nakupovalni seznam"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Izbrani niso nobeni recepti. Želite izbrisati celotni seznam?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Shrani nakupovalni seznam kot..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Izberi opcijske sestavine"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1080,56 +1037,58 @@ msgstr ""
 "Prosim določite katero od sestavin, bi rdi dodali na nakupovalni seznam."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recept"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "Pojdi"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Izvozi recept"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Izvozi izbran recept (shrani v datoteko)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Izbriši recept"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Izbriši ta recepti"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Prilagodi enote pri pomnoževanju"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Kjer je mogoče, sremeni enote pri pomnoževanju, da postanejo lažje berljive."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Natisni recept"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Dodaj v _Nakupovalni seznam"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Ignoriraj shranjenje pomožne sestavine"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1137,150 +1096,144 @@ msgstr ""
 "Preden dodaš na nakupovalni seznam, vprašaj za vse pomožne sestave, tudi "
 "tiste, ki si jih hotel prej shraniti."
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Izvozi Recept"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Imete neshranjene spremembe."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Uporabim spremembe preden natisnem?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Uporabim spremembe preden natisnem?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Po želji)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Ne najdem recepta %s v bazi."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Uredi Recept:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Shrani podatke v bazo"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Poglej Kartico Recepta"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Uredi"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Shrani spremembe v %s"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Dodaj sestavino"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Dodaj skupino"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Prilepi sestavine"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Uvozi iz datoteke"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Dodaj recept"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Dodaj drug recept kot sestavino v ta recept"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Izbriši"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Gor"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Dol"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Izberite datoteko ki vsebuje seznam sestavin."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Opis"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Navodila"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Opombe"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Znesek"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Enota"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Stvar"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Po želji"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Recept %s (ID %s) ni v bazi."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Pretvorjeno: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Nepretvorjeno: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Spremenjena enota."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1289,233 +1242,232 @@ msgstr ""
 "Spremenili ste enoto za %(item)s iz %(old)s v %(new)s. Želite količino "
 "spremeniti ali ne?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Spremenjene %(old_amt)s %(old_unit)s v %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Ne morem spremeniti iz %(old_unit)s v %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Dodajanje skupine za sestavine"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Vpiši ime za novo podskupino sestavin"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Ime skupine:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Izberi recept"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Recept ne more biti sestavina!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Neskončno ponavljanje ni dovoljeno v receptih!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Niste izbrali nobenih receptov!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Koliko %(title)s zahteva tvoj recept?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recepti"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Zvok Zvonenja"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Zvok Opozorila"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Zvok Napake"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Ustavim Odštevalnik?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Zaustavi_odštevalnik"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Nadaljuj z timingom"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Vtičniki"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
-msgstr ""
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
+msgstr "Upravljaj dodatke, ki dodajo Gurmanu funkcionalnost"
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 "Ta vtičnik je nujen za delovanje ostalih vtičnikov. Ga želite vseeno "
 "izklopiti?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Naslednji vtičniki zahtevajo %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Vseeno izključi"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Ne izključi vtičnika"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "ali"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Ob izklopu vtičnika je prišlo do napake."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Ob vklopu vtičnika je prišlo do napake."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Kuhinja"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Ocena"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Izvor"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Spletna stran"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Čas priprave"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Čas kuhanja"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Spremembe"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Nepravilen vnos."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Ni številka."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Premor"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Ustavi"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Ne sprešuj več tega."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Ali želite to res storiti"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "odlično"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "zelo dobro"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "dobro"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "v redu"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "slabo"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Pretvori ocene v petstopenjsko lestvico."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Pretvori ocene."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Prosim, dodaj vsaki oceni ustreznik na lestvici od 1 do 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Trenutna ocena"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Ocena od 1-5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Izbrana ni nobena datoteka"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Izberi tip _datoteke"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Dejanje je bilo preklicani, ker ni izbrana nobena datoteka."
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1525,14 +1477,14 @@ msgstr ""
 "\n"
 "količine \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Količine morajo biti številke (ulomki ali decimalke), skupine številk, ali "
 "prazno polje."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1558,86 +1510,86 @@ msgstr ""
 "\n"
 "Na primer, vpišete lahko 2-4 ali 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Uporabniško ime:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Geslo:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "moka, večnamenska"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "sladkor"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "sol"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "Črni poper, celi"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "led"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "voda"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "olje, rastlinsko"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "olje, olivno"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Neznano"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Recept je koz sestavina."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Sestavina %s ne bo upoštevana."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Nakupovalni seznam za %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Za sledeče recepte:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Za sledeče recepte:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Izberi kodiranje"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1645,29 +1597,28 @@ msgstr ""
 "Ne morem določiti pravilnega kodiranja. Prosim, izberite pravilno kodiranje "
 "iz naslednjega seznama."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Poglej _datoteko z naslednjim kodiranjem"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Uvoz trenutno zaustavljen"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Ustavi uvoz"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Seznam _Receptov"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Nakupovalni _Seznam"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1677,82 +1628,63 @@ msgstr ""
 "  niko https://launchpad.net/~sajko\n"
 "  orto https://launchpad.net/~ortosplet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Shranjeno!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Shrani moje spremembe v %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Trenutno se izvaja uvoz."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Trenutno se izvaja izvoz."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Trenutno se izvaja brisanje."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Vseeno končam program?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Prekliči!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Začasno je izbrisano %s od %s receptov"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Pošlji v Smeti"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Preglej, trajno izbriši ali povrni izbrisane recepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Neizbrisani recepti "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Število %(unit)s od %(title)s nakupovanja"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Pomnoži %s z:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
@@ -1761,285 +1693,291 @@ msgstr[1] "Nastavi %(attributes)s za %(num)s izbrana recepta?"
 msgstr[2] "Nastavi %(attributes)s za %(num)s izbrane recepte?"
 msgstr[3] "Nastavi %(attributes)s za %(num)s izbranih receptov?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Predhodno nastavljene vrednosti se ne bodo spremenile."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Stare obstoječe vrednosti bodo prepisane z novimi vrednostmil."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Te spremembe ne bo mogoče razveljaviti."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Nastavi vrednosti za izbrane recepte."
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Brskaj po receptih"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Odpri recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Odpri izbran recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Izbriši recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Izbriši izbrane recepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Uredi recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Odpri izbrane recepte v urejevalniku"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "I_zvozi izbrane recepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Izvozi izbrane recepte v datoteko"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Natisni"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "recepti"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Uredi _več receptov hkrati"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Nov"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Uvozi datoteko"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Uvozi recept"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Uvozi recept iz datoteke"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Uvozi _spletno stran"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s receptov"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Uvozi recept s spletne strani"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Izvozi _vse recepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Izvozi vse recepte v datoteko"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Izhod"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Dejanja"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "Odpri _Koš"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Pošlji v Smeti"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Nastavitve"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Razširitve"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Upravljaj dodatke, ki dodajo Gurmanu funkcionalnost"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "Nasta_vitve"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_O programu"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Orodja"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Odštevalnik časa"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Prikaži odštevalnik časa"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Iskalnik po receptih v datoteki"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Izbriši %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Imate neshranjene spremembe v %s. Ste prepričani, da želite izbrisati?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Izbrisano"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Brez naslova"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Dokončno izbrišem recepte?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Dokončno izbrišem recept?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Ali res želite izbrisati recept <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Ali res želite izbrisati naslednje recepte?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Ali res želite izbrisat %s izbranih receptov?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Poglej recepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Izbriši recepte"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Kazalo receptov"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Izbriši recept %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Končano!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Uvažam..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Urejevalnik _sestavin"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Uredi ključe sestavin po teži"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "ključ"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "stvar"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Polje"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Vrednost"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Števec"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Spremenim vse ključe \"%s\" v \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
 "the key \"%s\", you won't be able to distinguish between those items and the "
 "items you are changing now."
 msgstr ""
-"Tega dejanja ni možno razveljaviti. Če že obstajajo sestavine z ključem \"%s"
-"\", ne bo možno razlikovati med temi predmeti in predmeti, ki jih sedaj "
+"Tega dejanja ni možno razveljaviti. Če že obstajajo sestavine z ključem "
+"\"%s\", ne bo možno razlikovati med temi predmeti in predmeti, ki jih sedaj "
 "spreminjate."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Spremenim vse predmete \"%s\" v \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
 "the item \"%s\", you won't be able to distinguish between those items and "
 "the items you are changing now."
 msgstr ""
-"Tega dejanja ni možno razveljaviti. Če že obstajajo sestavine z ključem \"%s"
-"\", ne bo možno razlikovati med temi predmeti in predmeti, ki jih sedaj "
+"Tega dejanja ni možno razveljaviti. Če že obstajajo sestavine z ključem "
+"\"%s\", ne bo možno razlikovati med temi predmeti in predmeti, ki jih sedaj "
 "spreminjate."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Spremeni _vse primere \"%(unit)s\" v \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2048,12 +1986,12 @@ msgstr ""
 "Spremeni \"%(unit)s\" v \"%(text)s\" samo za _sestavine \"%(item)s\" z "
 "ključem \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr "Spremeni _vse količine od \"%(amount)s\" %(unit)s do %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2062,7 +2000,7 @@ msgstr ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2071,11 +2009,11 @@ msgstr ""
 "Spremeni \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Spremenim vse označene vrste?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2084,7 +2022,7 @@ msgstr ""
 "Tega dejanja se ne da povrniti. Ste prepričani, da želite za vse %s označene "
 "vrste dodati naslednje vrednosti:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2093,7 +2031,7 @@ msgstr ""
 "\n"
 "Ključi do %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2102,7 +2040,7 @@ msgstr ""
 "\n"
 "Predmeti do %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2111,7 +2049,7 @@ msgstr ""
 "\n"
 "Enote do %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2120,8 +2058,8 @@ msgstr ""
 "\n"
 "Količine do %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2132,23 +2070,23 @@ msgstr[3] "%s sestavine"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Sestavine so prikazane od %(bottom)s do %(top)s od %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Znesek"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Ključi sestavin"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2156,11 +2094,11 @@ msgstr ""
 "Ključi sestavin so normalizirana imena sestavin, uporabljena za nakupovalni "
 "list in za izračune."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Predstavi ključe"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2168,56 +2106,56 @@ msgstr ""
 "Predstavi najboljše vrednosti za vse ključe sestavin, ki temeljijo na "
 "vrednostih v tvoji zbirki podatkov"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Uredi zveze ključev"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Uredi zveze s ključi in ostalimi atributi v zbirki podatkov"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Kategorija nakupa"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Prikaži enote kot pisane za vsak recept (brez spremembe)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Vedno prikazuj enote ZDA"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Vedno prikazuj metrične enote"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Avtomatično prilagodi enote"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Nastavi _enotam izbirne prikaze"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2225,42 +2163,42 @@ msgstr ""
 "Avtomatično pretvori enote v nastavljeni sistem (metrični, imperialni, ipd), "
 "kjer je mogoče."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Zvezdice"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "pred %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Samodejno spoji recepte"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Vedno uporabi najnovejši recept"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Vedno uporabi najstarejši recept"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Brez"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2268,61 +2206,61 @@ msgstr ""
 "Nekateri uvoženi recepti so morda podvojeni. Lahko jih spojite tukaj ali pa "
 "zaprete okno in jih pustite v trenutni obliki."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Najdi _podvojene recepte."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Najdi in izbriši podvojene recepte"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "Za vsako izbrano vrednost"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Kjer je %(field)s je %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
@@ -2331,198 +2269,186 @@ msgstr[1] "Sprememba bo vplivala na %s recepta"
 msgstr[2] "Sprememba bo vplivala na %s recepte"
 msgstr[3] "Sprememba bo vplivala na %s receptov"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Izbrišem %s, če je %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Spremenim %s iz %s v \"%s\"?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Ta sprememba je NEpovratna.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Urejevalnik polj"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Uredi polja v več receptih hkrati"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Pošlji recepte po e-pošti"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr "Pošlji vse izbrane recepte (ali vse recepte, če ni izbran noben"
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Ali želite vse %s izbrane recepte poslati po e-pošti?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Da, pošlji."
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Ne morem pretvoriti %s v %s."
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Potrebujem informacije o gostoti."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Pretvornik Enot"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Izračunaj pretvorbe enot"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Pretvornik enot"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Gostota:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Informacija o gostoti"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Rezultat:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Nalagam zip arhiv"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Odpiram zip arhih"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML spletna stran"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Izvažanje spletne strani"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Izvažanje receptov v HTML datoteke v direktorij %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Recept shranjen kot HTML datoteka %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Originalna stran iz %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "po izbiri"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Izvažanje spletne strani"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Izvažanje receptov v HTML datoteke v direktorij %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Recept shranjen kot HTML datoteka %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Datoteka z neoblikovanim tekstom"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Izvoz teksta"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Izvažam recepte v besedilno datoeko %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Recept je shranjen kot datoteka z neoblikovanim besedilom %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Velika datoteka"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Datoteka %s je prevelika za uvoz"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2533,81 +2459,54 @@ msgstr ""
 "uporabite urejevalnik teksta, jo razdelite v manjše datoteke in ponovno "
 "poskusite uvoziti."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Spletna stran"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Prenašam %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Nakupovalni seznam za %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Pridobivam %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML datoteka"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML Izvoz"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Izvažanje receptov v Gurman XML datoteko %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Recept shranjen kot Gurmet XML datoteka %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gurman XML datoteka (zastarela)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "Mastercook XML datoteka"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Mastercook tekstovna datoteka"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Mastercook uvoz končan."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Sestavljam XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML File"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2616,106 +2515,119 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Podoba strani"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Natisni Recepte"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Izvoz PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Izvažanje receptov v PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Recept shranjen kot PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Črka"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Pokončno"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Navadni"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "točke"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "27,9x43,2 cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Kartica (8,9x7,6 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Kartica (10,2x15,2 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Kartica (12,7x20,3 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Kartica (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Črka"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "legalno"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Kartica (8,9x7,6 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Kartica (10,2x15,2 cm)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Kartica (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Ležeče"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Navadni"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s stolpec"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s stolpec"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s stolpec"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s stolpec"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
@@ -2724,168 +2636,176 @@ msgstr[1] "%s stolpca"
 msgstr[2] "%s stolpci"
 msgstr[3] "%s stolpcev"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Pokončno"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Ležeče"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Velikost papairja"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "Orientacija"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Velikost pisave"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Izgled strani"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Velikost pisave"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Levi odmik"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Desni odmik"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Vrhnji rob"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Spodnji rob"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster datoteka"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster Izvoz"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Izvažanje receptov v MealMaster datoteko %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Recepti shranjeni kot MealMaster datoteka %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "Obrok"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Velika datoteka"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Izvozi"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Izvažanje receptov v Gurman XML datoteko %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Recept shranjen kot Gurmet XML datoteka %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Shranjevalnik nakupovalnega lista"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Shrani seznam kot recept"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Shrani trenutni nakupovalni list kot recept za prihodnjo uporabo"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Meni za %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Meni"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Podatki o hranilni vrednosti odražajo količino po %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Podatki o hranilni vrednosti odražajo količino za celoten recept"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Hranilni podatki manjkajo za %s sestavin: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Katerakoli skupina hrane"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "izbor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Spremeni enoto za %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Da lahko izračuna kalorično vrednost, potrebuje Gourmet vašo pomoč, da "
 "spremeni \"%s\" v enoto, ki jo pozna."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Spremeni ključ sestavin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2894,27 +2814,27 @@ msgstr ""
 "Spremeni ključ sestavine %(old_key)s do %(new_key)s vseposod ali samo v "
 "receptu %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Spremeni _vseposod"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_samo v receptu %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Spremeni ključ sestavin od %(old_key)s v %(new_key)s povsod?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Spremeni enoto"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2923,11 +2843,11 @@ msgstr ""
 "Spremeni enoto od %(old_unit)s v %(new_unit)s za vse sestavine %(ingkey)s "
 "ali samo v receptu %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2936,198 +2856,199 @@ msgstr ""
 "različnih opisov te hrane z različnimi gototami. Prosim, izberite ustrezno "
 "na spodnjem seznamu."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Da bi apliciral podatke o hranilnih vrednostih, potrebuje Gurman pravilno "
 "količino in enoto."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "vsebnost hranil"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Sestavina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "ekvivalent USDA Bazi"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gramov"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "kalorije"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Skupna maščoba"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Nasičene Maščobe"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Holesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Natrij"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Vsi Ogljikovi Hidrati"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Predpisane vlaknine"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Sladkorji"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Proteini"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-karotin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Ash"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-karotin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Kalcij"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "baker"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Folate Total"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Folna kislina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Food Folate"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Dietary folate equivalents"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Železo"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Lycopene"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Lutein+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "magnezij"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "vitamin B3"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "pantotenska kislina"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "kalij"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Vitamin A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "vitamin A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Vitamin B2"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "selen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamin A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamin A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamin C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Cink"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitamini in minerali"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3137,11 +3058,11 @@ msgstr ""
 "\n"
 "za %(missing)s do %(total)s sestavin."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Dnevne Potrebe"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3150,367 +3071,367 @@ msgstr ""
 "Procent priporočene količine po %i kalorijah na dan. Pritisni za spremembo "
 "kalorij na dan."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Količina za %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Količina na recept"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Nalagam podatke o hranilni vrednosti"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Uvoz baze hranilnih podatkov je končan!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Pridobivam bazo hranilnih podatkov iz zip arhiva %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Pridobivam %s iz zip arhiva."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Obdelujem podatke o kalorični vrednosti"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Berem podatke o kalorični vrednosti: uvoženo %s od %s vnosov"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Pridobivam podatke o teži..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr "Berem podatke o teži: uvoženo %s od %s vnosov"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Voda"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalorije"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g protein"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipid"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g ash"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g ogljikovi hidrati"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g vlaknine"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g sladkor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg kalcija"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg železo"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnezij"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg kalij"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg natrija"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg cinka"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg bakra"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg mangana"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mikrogram selena"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamina C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg vitamina B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg vitamina B2"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niacina (nikotinske kisline)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg pantotetske kisline"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamin B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "mikrogram Folate Total"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "mikrogram folne kisline"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "mikrogram Food Folate"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "mikrogram dietary folate equivalents"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "holin, skupno"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mikrogram Vitamin B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamin A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamin A"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "mikrogram Retinol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "mikrogram Alpha-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "mikrogram Beta-carotene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "mikrogram Beta Cryptoxanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "mikrogram Lycopene"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "microgram Lutein+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamin E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamin K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g Nasičenih Maščobnih Kislin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g Enoenasičenih Maščobnih Kislin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g Polinenasičenih Maščobnih Kislin"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Holesterola"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Procent odklona"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Mlečni in Jačni Izdelki"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Začimbe in Zelišča"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Otroška Hrana"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Maščobe in Olja"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Perutnina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Juhe in Omake"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Klobasice in Meso za malico"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Kosmiči"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Sadje in sadni sokovi"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "svinjina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "zelenjava"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "oreščki & semena"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "govedina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Pijače"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Ribe & Morski sadeži"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "stročnice"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "jagnetina, teletina & divjačina"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Pekarski izdelki"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Sladkarije"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Testenine"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Hitropripravljena hrana"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Malice, Začetne jedi in Priloge"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Prigrizki"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Etnična Hrana"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "celotna baza"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Ključ sestavin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "identifikacija številka osebne izkaznice (ZDA)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "opis postavke ZDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "ekvivalent gostote"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "ID za ZDA"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3524,59 +3445,59 @@ msgstr "Orodja"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Pridobi hranilne vrednost za trenuten seznam"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Količina za nakupovalni seznam"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "zvezdic"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Izvožene %(number)s od %(total)s receptov"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Izvoz končan."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Uporabi recept v tekstu E-pošte (Vedno dobra ideja)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Pošlji recept po elektronski pošti kot HTML priponko"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Pošlji recept po elektronski pošti kot PDF priponko"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Nastavitve elektronske pošte"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Ne sprašuje pred pošiljanjem elektronske pošte."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Elektronska pošta ni bila poslana."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
@@ -3584,48 +3505,48 @@ msgstr ""
 "Niste odločili, ali vključite recept v tekst elektronskega sporočila ali kot "
 "priponko."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Shrani recept kot..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet ne more izvoziti datoteke tipa \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Izvozi recepte"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recepti"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Izvoz ni mogoč: neznan tip datoteke \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "Prosim, izberite tip datoteke iz padajočega seznama, ko shranjujete."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Izvozi"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Tiskanje ni mogoče: aktiven ni noben dodatek za tiskanje!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
@@ -3634,66 +3555,42 @@ msgstr[1] "Natisni %s recept"
 msgstr[2] "Natisni %s recepta"
 msgstr[3] "Natisni %s recepte"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Sprejemam datoteko"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "izkoristek"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Vpišite URL naslov za arhiv receptov, oz. spletno stran z recepti."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Vnesite naslov spletne strani"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Vnesite URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Vnesite naslov spletne strani ali arhiva receptov."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Ne morem uvoziti URL"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Gurman nima dodatka, ki bi lahko uvozil URL"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Ne morem uvoziti URL %(url)s internetnega medijskega %(type)s. Datoteka je "
-"shranjena na začasno lokacijo %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Odpri recept..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Vnesite naslov spletne strani"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Spremembe"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Vnesite naslov spletne strani ali arhiva receptov."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Uvoz"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Vse datoteke za uvoz"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Uvoženo %s receptov"
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "Obrok"
@@ -3701,119 +3598,97 @@ msgstr[1] "Obroka"
 msgstr[2] "Obroki"
 msgstr[3] "Obrokov"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Uvoženo %s od %s receptov."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "v redu"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Ne prepoznam te spletne strani. Uporaba splošnega uvoza..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Uvoz končan."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Uvažam recept"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Obdelujem sestavine"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Obdelujem sestavine."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Število obrokov"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Podskupina sestavin"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Skrij"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Besedilo"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Dejanja"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Uvozi recept"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Počisti _Vnose"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Uvozi recept"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "kjerkoli"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "ime"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "sestavina"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "priprava"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "beležke"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "kuhinja"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "izvor"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Uporabi običajne izraze pri iskanju"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr "Uporabi običajne izraze (napredni jezik iskanja) v tekstovnem iskanju"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Išči med tipkanjem (izklopi, čle je iskanje prepočasno)"
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Pokaži možnosti _iskanja"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Pokaži napredne možnosti iskanja"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3824,21 +3699,21 @@ msgstr[3] "%s receptov"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Prikazujem recepte %(bottom)s do %(top)s od %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s v %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Začasno ustavljeno"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
@@ -3846,43 +3721,37 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Premor"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Končano"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Napaka: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Napaka"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Napaka %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Traceback"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "sekund"
@@ -3891,11 +3760,11 @@ msgstr[2] "sekundi"
 msgstr[3] "sekunde"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min."
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
@@ -3904,11 +3773,11 @@ msgstr[2] "minut"
 msgstr[3] "minute"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "ur"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ur"
@@ -3916,7 +3785,7 @@ msgstr[1] "ura"
 msgstr[2] "ur"
 msgstr[3] "ure"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dni"
@@ -3924,7 +3793,7 @@ msgstr[1] "dan"
 msgstr[2] "dni"
 msgstr[3] "dnevi"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tednov"
@@ -3932,7 +3801,7 @@ msgstr[1] "teden"
 msgstr[2] "tedna"
 msgstr[3] "tedni"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mesecev"
@@ -3943,7 +3812,7 @@ msgstr[3] "meseci"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "let"
@@ -3957,73 +3826,30 @@ msgstr[3] "leta"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " in "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "in"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "do"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML datoteka"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gurman, upravljalnik receptov"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Organizirajte recepte, ustvarjajte nakupovalne sezname, izračunajte "
-"hranljive vrednosti in več."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -4033,7 +3859,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -4046,38 +3871,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4085,6 +3878,18 @@ msgstr "Izvoz PDF"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -4095,14 +3900,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4156,22 +3953,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4230,6 +4011,155 @@ msgid ""
 "Disable this if you never use UTF16 and you're constantly being annoyed by "
 "the 'Encoding' dialog when you import files."
 msgstr ""
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Windows porting assistance)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (izboljšave vmesnika za Pretvornik enot)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (izboljšave za izvoz v Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (logo and splash screen)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (mednarodne izboljšave, "
+#~ "odpravljanje različnih težav s hrošči)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (vzdrževanje verzije za Windowa in "
+#~ "oblikovanje spletne strani)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Posodobitev zbirke podatkov"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "Glede na velikost vaše datoteke lahko proces traja dalj časa. Vaši "
+#~ "podatki so bili avtomatično shranjeni v arhivski kopiji, v primeru, da "
+#~ "gre kaj narobe."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Prilepi sestavine"
+
+#~ msgid "Import from file"
+#~ msgstr "Uvozi iz datoteke"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Izberite datoteko ki vsebuje seznam sestavin."
+
+#~ msgid "No file selected"
+#~ msgstr "Izbrana ni nobena datoteka"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Dejanje je bilo preklicani, ker ni izbrana nobena datoteka."
+
+#~ msgid "_Import file"
+#~ msgstr "_Uvozi datoteko"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Uvozi _spletno stran"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Uvozi recept s spletne strani"
+
+#~ msgid "Open _Trash"
+#~ msgstr "Odpri _Koš"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Nalagam zip arhiv"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Odpiram zip arhih"
+
+#~ msgid "Webpage"
+#~ msgstr "Spletna stran"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Prenašam %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Nakupovalni seznam za %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Pridobivam %s"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Sprejemam datoteko"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Vpišite URL naslov za arhiv receptov, oz. spletno stran z recepti."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Vnesite URL:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Ne morem uvoziti URL"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Gurman nima dodatka, ki bi lahko uvozil URL"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Ne morem uvoziti URL %(url)s internetnega medijskega %(type)s. Datoteka "
+#~ "je shranjena na začasno lokacijo %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Ne prepoznam te spletne strani. Uporaba splošnega uvoza..."
+
+#~ msgid "Import complete."
+#~ msgstr "Uvoz končan."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Uvažam recept"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Obdelujem sestavine"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Obdelujem sestavine."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML datoteka"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gurman, upravljalnik receptov"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Organizirajte recepte, ustvarjajte nakupovalne sezname, izračunajte "
+#~ "hranljive vrednosti in več."
 
 #~ msgid "_Raw recipe:"
 #~ msgstr "_Surovi recept:"
@@ -4339,9 +4269,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "_Obroki"
-
-#~ msgid "Select File_type"
-#~ msgstr "Izberi tip _datoteke"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Datoteka z imenom %s že obstaja."

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-11-17 12:46+0000\n"
 "Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
 "Language-Team: Serbian <gnom@prevod.org>\n"
@@ -15,70 +15,70 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr "Попис рецепта"
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Нови рецепт"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Додај на _списак за куповину"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr "Прикажи _рецепт"
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr "_Потражи:"
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr "Потражите рецепте како будете куцали"
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr "_у"
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr "Потражите према другом правилу у резултатима текуће претраге."
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr "Додај _критеријум претраге"
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr "Ограничавам претрагу на:"
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr "Резултати _претраге"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr "Подеси поља за изабране рецепте"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
@@ -86,129 +86,132 @@ msgstr ""
 "<span size=\"large\" weight=\"bold\">Подесите поља рецепта за изабране "
 "рецепте</span>"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr "Додај _слику"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr "_Уклони слику"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr "_Извор:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr "_Пласман:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr "_Кухиња:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr "_Категорија:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr "_Време спремања:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr "Време _кувања:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr "_Веб страница:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr "Слика:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr "_Принос:"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 #, fuzzy
 msgid "Yield U_nit:"
 msgstr "Јединица приноса"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr "_Постави вредности само за тренутно празно поље"
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr "Постави све вредности за _све изабране рецепте"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr "Метакит (основно, ускладиштен у месној датотеци)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr "СКуЛајт (ускладиштен у месној датотеци)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr "МајСКуЛ (захтева везу са базом података)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr "Изаберите базу података"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr "<b>Изабери систем базе података за Гурманка да користи</b>"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr "_Систем базе података"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr "_Рачунар:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr "_Корисничко име:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr "_Лозинка:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr "Лозинка за ваше корисничко име на бази података."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr "*"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr "Назив _базе података:"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Датотека"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
@@ -216,11 +219,11 @@ msgstr ""
 "Назив домаћина система на коме ради ваш сервер базе података. Ако ваш сервер "
 "базе података ради на вашем месном систему, користите месног домаћина."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr "локални домаћин"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
@@ -228,11 +231,11 @@ msgstr ""
 "Сачувајте лозинку за следећи пут. Ово значи да ће лозинка бити ускладиштена "
 "несигурно у датотеци подешавања."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr "_Сачувај лозинку"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
@@ -240,299 +243,300 @@ msgstr ""
 "Назив базе података у којој Гурманко треба да чува своје податке. Гурманко "
 "ће покушати да направи ову базу података ако већ не постоји."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "рецепт"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr "Ваше корисничко име на бази података."
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr "_Разгледај"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Детаљи"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
 msgstr "Поставке Гурманковог управника рецептима"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr "<b>Поставке прегледа пописа</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Прикажи _опције"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr "_Рецепта по страници:"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr "<i>Подесите које колоне су укључене у прегледу пописа рецепта.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr "Преглед пописа"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr "<b>Поставке прегледа картице</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr "_Допусти јединицама да се промене приликом множења"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr "_Користи разломке"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr "Користи разломке за приказ када је могуће"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr "<i>Уклоните ставке које не користите из сучеља картице рецепта.</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr "Преглед картице"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr "<b>Поставке списка куповине</b>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
+#, fuzzy
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 "<i>Шта Гурманко треба да уради са додатним састојцима када додаје рецепте на "
 "списак за куповину?</i>"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr "Питај _да ли да укључиш додатне састојке"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr "_Запамти корисникове изборе по основи"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr "_Очисти упамћене додатне састојке"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr "_Увек додај додатне састојке"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr "_Никада не додај додатне састојке"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Списак за куповину"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr "служење"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Назив"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr "_Назив:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr "_Време спремања:"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "категорија"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr "пласман"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Принос"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Јединица приноса"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr "_Купи"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr "Уреди _опис"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr "<b>Време кувања:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr "<b>Време спремања:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr "<b>Кухиња:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr "<b>Категорија:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr "<b>Веб страница:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr "<b>_Приноси:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr "<span underline=\"single\" color=\"blue\">Веза</span>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr "<b>Извор:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr "<b>Пласман:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr "<b>_Помножи са:</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr "<b>Упутства</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr "Уреди _упутства"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr "<b>Напомене</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr "Уреди _напомене"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Рецепт"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr "<b>Састојци</b>"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr "Уреди _састојке"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr "Додај _састојак:"
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Састојци"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr "Додајте рецепт на списак за куповину"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr "Додај на _списак за куповину"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr "Скочи на рецепт у прегледу картице рецепта"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr "Обриши изабрани рецепт"
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Обриши рецепт"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr "Уредите особине изабраних рецепта"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr "_Групно уреди рецепте"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr "Пошаљи ел. поштом изабрани рецепт"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Отворите изабрани рецепт"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr "_Пошаљи рецепт ел. поштом"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "Изабери рецепт"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr "Штампајте изабрани рецепт"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr "_Штампај рецепт"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -544,31 +548,31 @@ msgstr ""
 "укључен када сачувате или одштампате списак осим ако ми не кажете да треба "
 "да га купите."
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr "Додај у _шпајз"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr "Прикажи _опције"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr "Потражи _у"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr "_Користи регуларне изразе (напредна претрага)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr "Тражи док _куцам"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr "<i>Опције претраге</i>"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Категорија"
 
@@ -577,291 +581,293 @@ msgstr "Категорија"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Кључ"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr "Уређивач категорије"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr "Тражи према"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Тражи док куцам"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr "Користи регуларне изразе"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr "Напредна претрага"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr "Додај категорију: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Одбројавач"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr "<b><span size=\"larger\">Одбројавач</span></b>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr "<i>Одбројавач је завршио!</i>"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 "Одбројавач ће настави да ради све док не затворите ово прозорче или "
 "поништите одбројавач."
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr "Постави _одбројавач: "
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr "_Поништи"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr "_Покрени"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr "_Звук"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr "_Напомена"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr "Понављај _аларм док га не искључим"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr "_Подешавања"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr "<b>Уреди поља широм базе података</b>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr "Поље за _уређивање:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr "За сваку изабрану вредност:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr "_Остави вредност таквом"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr "<i>Нова вредност ће бити додата на крају сваког постојећег текста</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr "<i>Нова вредност ће заменити све постојеће вредности</i>"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr "_Поље:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr "_Вредност:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr "Уреди _друго поље:"
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr "Уреди _вредност у: "
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr "_Обриши вредност"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr "<i>Изабери еквивалент за</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr "<i>из УСДА базе података</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr "_Измени састојак"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr "<i>или</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr "_Претражи базу података УСДА састојака:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr "Тражи док _куцам"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr "Прикажи само храну у _групи:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr "<b>Резултати _претраге:</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr "<i>Из:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr "_Износ:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr "Јединица:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "јединици"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr "_Измени јединицу"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr "_Сачувај нову јединицу"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr "<i>У:</i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr "_Јединица:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr "<i>Унесите хранљиве вредности за </i>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr "<b>Изаберите густину</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr "<b>Кључ састојка: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr "<b>УСДА ставка: </b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr "Уреди _УСДА придруживања"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr "<b>Хранљиве вредности</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr "Уреди _податке"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr "_Хранљиве вредности"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr "Густина:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr "УСДА еквиваленти:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr "Произвољни еквиваленти:"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr "Подаци о _густини"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr "<b>Познате хранљиве вредности</b>"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr "_Напредна претрага"
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Хранљиве вредности"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr "_Занемари"
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Управник рецепта Гурманко"
 
-#: ../src/gourmet/version.py:5
+#: ../src/gourmand/__version__.py:4
 #, fuzzy
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 "Ауторска права (c) 2004,2005,2006,2007,2008,2009,2010,2011 Томас М. Хинкле. "
 "ГНУ ОЈЛ в2"
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -884,215 +890,168 @@ msgstr ""
 "Подржава повезивање слика са рецептима. Може такође да израчуна хранљиве "
 "вредности рецепата на основу састојака."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Роланд Дихејм (испомоћ за прилагођавање на Виндоуз)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Данијел Фолкинштајн <nanotube@gmail.com> (Инсталација за Виндоуз)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Ричард Фергусон (побољшања сучеља претварача јединица)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "Р.С. Борн (побољшања за извоз Мајстора јела)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "иксат <ixat.deviantart.com> (логотип и поздравни екран)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Јула Зубрицки (иконице хранљивости и додавања на списак за куповину)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Сајмно Дарлингтон <simon.darlington@gmx.net> (побољшања за "
-"интернационализацију, разне исправке грешака)"
-
-#: ../src/gourmet/version.py:33
-#, fuzzy
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-"Бернард Рајтер <ockham@raz.or.at> (Одржавање издања за Виндоуз и осмишљавање "
-"веб сајта)"
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Изаберите датотеку базе података"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Надограђујем базу података"
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
+msgid "New Recipe"
+msgstr "Нови рецепт"
 
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+#, fuzzy
+msgid "Database Backup"
+msgstr "Назив _базе података:"
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
 msgstr ""
-"У зависности од величине базе података, ово може да буде интензиван поступак "
-"и може да потраје неко време. У случају да нешто крене наопако резерва ваших "
-"података бива направљена самостално."
 
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Детаљи"
 
-#: ../src/gourmet/backends/db.py:475
-#, python-format
+#: ../src/gourmand/backends/db.py:2188
+#, fuzzy, python-format
 msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
 msgstr ""
 "Резерва је направљена у %s у случају да нешто крене наопако. Ако ова "
 "надоградња не успе, можете ручно да преименујете датотеку резерве „recipes."
 "db“ да је повратите за коришћење са старијим Гурманком."
 
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
-msgid "New Recipe"
-msgstr "Нови рецепт"
-
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Промени _категорију"
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Направите нову категорију"
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Измените категорију тренутно изабране ставке"
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Шпајз"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Премести на _списак за куповину"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ктрл>Б"
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Премести у _шпајз"
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ктрл>Д"
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Уклони са списка за куповину"
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Премести изабране ставке у %s"
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Списак за куповину"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Већ имам (Ставке у _шпајзу)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Унеси категорију"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Категорија у коју додати „%s“"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Категорија:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Рецепти"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "_Додај ставке:"
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Уклони рецепте"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Уклоните рецепте са списка за куповину"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Уреди"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "По_моћ"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Додај ставке"
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Додај произвољне ставке на списак за куповину"
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "количина"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Није изабран ниједан рецепт. Да ли желите да очистите читав списак?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Сачувај списак за куповину као..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Изабери додатне састојке"
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1101,56 +1060,58 @@ msgstr ""
 "куповину."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Рецепт"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Иди"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Извези рецепт"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Извези изабране рецепте (сачувај у датотеку)"
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "_Обриши рецепт"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Обришите овај рецепт"
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Дотерај јединице приликом множења"
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 "Измените јединице да их учините читљивијим где је могуће приликом множења."
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Штампај рецепт"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Додај на _списак за куповину"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Заборави упамћене додатне састојке"
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1158,150 +1119,144 @@ msgstr ""
 "Пре додавања на списак за куповину, питаће о свим додатним састојцима, чак и "
 "онима које сте претходно заборавили"
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Извези рецепт"
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Имате несачуване измене."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Да применим измене пре штампања?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Да применим измене пре штампања?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Необавезно)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Не могу да пронађем рецепт „%s“ у бази података."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Уреди рецепт:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Сачувај измене у базу података"
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Прикажи картицу рецепта"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Уреди"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Сачувај измене у „%s“"
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Додај састојак"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Додај групу"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr "Убаци састојак"
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Увези из датотеке"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Додај _рецепт"
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Додајте још један рецепт као састојак овом рецепту"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Обриши"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Горе"
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Доле"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Изаберите датотеку која садржи ваш списак састојака."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Опис"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Упутства"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Белешке"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Кол"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Јединица"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Ставка"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Необавезно"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Рецепт „%s“ (ИБ %s) није у нашој бази података."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Претворени: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Нису претворени: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Измени јединицу."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1310,231 +1265,230 @@ msgstr ""
 "Изменили сте јединицу за „%(item)s“ из %(old)s у %(new)s. Да ли желите да "
 "претворите и количину или не?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Претворио сам %(old_amt)s %(old_unit)s у %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Не могу да претворим из %(old_unit)s у %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Додавање групе састојака"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Унесите назив за нову подгрупу састојака"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Назив групе:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Изабери рецепт"
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Рецепт не може сам себе да позове као састојак!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Неограничено дубачење није дозвољено у рецептима!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Нисте изабрали ниједан рецепт!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Колико „%(title)s“ ваш рецепт позива?"
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Рецепти"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Звук звоњаве"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Звук упозорења"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Звук грешке"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Да зауставим одбројавач?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Заустави _одбројавач"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Настави одбројавање"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Прикључци"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
 msgstr "Прикључци дају Гурманку посебне функције."
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr "Прикључак је потребан другим прикључцима. Да га ипак искључим?"
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Следећи прикључци захтевају %s:"
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Ипак искључи"
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Остави га укљученим"
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "или"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Дошло је до грешке покретања прикључка."
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Дошло је до грешке искључивања прикључка."
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Кухиња"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Пласман"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Извор"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Веб страница"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Време спремања"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Време кувања"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Измене"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Неисправан улаз."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Није број."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Застани"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Заустави"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Не питај ме поново."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Да ли заиста желите да урадите ово"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "сјајно"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "одлично"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "добро"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "просечно"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "оскудно"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Претворите пласмане у лествицу са 5 звездица."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Претворите пласмане."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Дајте сваком пласману еквивалент на лествици од 1 до 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Тренутни пласман"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Пласман од 5 звездица"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Није изабрана ниједна датотека"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Изаберите врсту _датотеке"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Није изабрана ниједна датотека, тако да је радња отказана"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1543,14 +1497,14 @@ msgstr ""
 "Жао ми је, не могу да разумем\n"
 "количину „%s“."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Количине морају бити бројеви (разломци или децимални), опсези бројева, или "
 "празне."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1571,115 +1525,114 @@ msgstr ""
 "Да унесете опсег бројева, користите „-“ за раздвајање.\n"
 "На пример, можете да унесете 2-4 или 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Username"
 msgstr "_Корисничко име:"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 #, fuzzy
 msgid "Password"
 msgstr "_Лозинка:"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "брашно, за сваку употребу"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "šećer"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "со"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "црни бибер, основа"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "лед"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "вода"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "уље, биљно"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "уље, оливе"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Непознато"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Рецепт сам себе позива као састојак."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Састојак „%s“ ће бити занемарен."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Списак за куповину за %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "За следеће рецепте:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "За следеће рецепте:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Изабери кодирање"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 "Не могу да одредим одговарајуће кодирање. Изаберите тачно кодирање са списка."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Види _датотеку са кодирањем"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Увоз је заустављен"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Заустави увоз"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Попис _рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Списак за _куповину"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1688,82 +1641,63 @@ msgstr ""
 "  homoludens https://launchpad.net/~marko-homoludens\n"
 "  Мирослав Николић https://launchpad.net/~lipek"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Сачувано је!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Сачувајте измене у %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Један увоз је у току."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Један извоз је у току."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Брисање је у току."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Да ипак изађем из програма?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Не излази!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "За стално је обрисано %s од %s рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Смеће"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Разгледајте, трајно обришите или повратите обрисане рецепте"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Необрисани рецепти "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Укупно %(unit)s %(title)s за куповину"
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Помножи %s са:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
@@ -1771,254 +1705,260 @@ msgstr[0] "Да поставим %(attributes)s за %(num)s изабрани р
 msgstr[1] "Да поставим %(attributes)s за %(num)s изабрана рецепта?"
 msgstr[2] "Да поставим %(attributes)s за %(num)s изабраних рецепата?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Било која претходно постојећа вредност неће бити измењена."
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "Нове вредности ће преписати било коју претходно постојећу вредност."
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Ова измена не може бити поништена."
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Постави вредности за изабране рецепте"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Потражите рецепте"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Отвори рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Отворите изабрани рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Обриши рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Обришите изабране рецепте"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Уреди рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Отворите изабране рецепте у прегледу уређивача рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "_Извези изабране рецепте"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Извезите изабране рецепте у датотеку"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Штампај"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "рецепти"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "Групно _уреди рецепте"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Нови"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr "_Увези датотеку"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Увезите рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Увезите рецепт из датотеке"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Увези _веб страницу"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Увезите рецепт са веб странице"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Извези _све рецепте"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Извезите све рецепте у датотеку"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Изађи"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Радње"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "_Отвори смеће"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Смеће"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Поставке"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Прикључци"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Управљајте прикључцима који Гурманку додају посебне функције."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "_Подешавања"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_О програму"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Алати"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Одбројавач"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Прикажите одбројавач"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Претраживи попис рецепта у бази података."
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Да обришем %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 "Имате несачуваних измена у %s. Да ли сте сигурни да желите да обришете?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Обрисан"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Неименован"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Да ли трајно да обришем рецепте?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Да ли трајно да обришем рецепт?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Да ли сте сигурни да желите да обришете рецепт <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Да ли сте сигурни да желите да обришете следеће рецепте?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Да ли сте сигурни да желите да обришете %s изабрана рецепта?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Види рецепте"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Обриши рецепте"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Попис рецепта"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Обрисан рецепт %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Готово!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Увозим..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Уређивач _кључа састојка"
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Уредите кључеве састојака на гомили"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "кључу"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "ставки"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Поље"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Вредност"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Укупност"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Да изменим све „%s“ кључеве у „%s“?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2029,12 +1969,12 @@ msgstr ""
 "кључем „%s“, нећете бити у могућности да разликујете те ставке од ставки "
 "које сада мењате."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Да изменим све „%s“ ставке у „%s“?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -2045,12 +1985,12 @@ msgstr ""
 "ставком „%s“, нећете бити у могућности да разликујете те ставке од ставки "
 "које сада мењате."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Измени _све примерке „%(unit)s“ у „%(text)s“"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2059,12 +1999,12 @@ msgstr ""
 "Измени „%(unit)s“ у „%(text)s“ само за _састојке „%(item)s“ са кључем "
 "„%(key)s“"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr "Измени _све примерке „%(amount)s“ %(unit)s у %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2073,7 +2013,7 @@ msgstr ""
 "Промени „%(amount)s“ %(unit)s у „%(text)s“ %(unit)s само _где је кључ "
 "састојка %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2082,11 +2022,11 @@ msgstr ""
 "Промени „%(amount)s“ %(unit)s у „%(text)s“ %(unit)s само где је кључ "
 "састојка %(key)s _а где је ставка %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Да изменим све изабране редове?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2095,7 +2035,7 @@ msgstr ""
 "Ова радња неће бити поништљива. Да ли ви то за све изабране редове — %s, "
 "желите да поставите следеће вредности:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2104,7 +2044,7 @@ msgstr ""
 "\n"
 "Кључ у %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2113,7 +2053,7 @@ msgstr ""
 "\n"
 "Ставка у %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2122,7 +2062,7 @@ msgstr ""
 "\n"
 "Јединица у %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2131,8 +2071,8 @@ msgstr ""
 "\n"
 "Количина у %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2142,23 +2082,23 @@ msgstr[2] "%s састојака"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Приказујем састојке %(bottom)s на %(top)s од %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Количина"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Кључеви састојка"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
@@ -2166,11 +2106,11 @@ msgstr ""
 "Кључеви састојака су нормализовани називи састојака који се користе за "
 "спискове за куповину и за прорачуне."
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Погоди кључеве"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2178,56 +2118,56 @@ msgstr ""
 "Погодите најбоље вредности за све кључеве састојака на основу вредностима "
 "које су већ у вашој бази података"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Уредите придруживања кључа"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Уредите придруживања са кључем и другим особинама у бази података"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr "Уређивач кључа"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr "_Ставка:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr "_Кључ:"
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr "<b>_Измени изабране састојке</b>"
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Категорија за куповину"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr "Прикажите јединице како су написане за сваки рецепт (без промена)"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr "Увек прикажи америчке јединице"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr "Увек прикажи метричке јединице"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Сам подеси јединице"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Подеси поставке приказа _јединица"
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2235,42 +2175,42 @@ msgstr ""
 "Самостално претворите јединице у жељени систем (метрички, царски, итд.) где "
 "је то могуће."
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Звездице"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "Пре %s"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Сам стопи рецепте"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Увек користи новији рецепт"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Увек користи старији рецепт"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Ништа"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2278,61 +2218,61 @@ msgstr ""
 "Неки од увезених рецепата изгледа да су дупликати. Можете их обједините "
 "овде, или затворити ово прозорче да их остави таквим какви су."
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Пронађи _дуплиране рецепте"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Пронађи и уклони дуплиране рецепте"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr "Рецепти са сличним подацима о рецепту"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr "Рецепти са сличним састојцима"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr "Рецепти са сличним подацима о рецепту и састојцима"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr "<b><span size=\"large\">Удвостручи рецепте</span></b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr "_Укључи рецепте из смећа"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr "<i>_Приказујем:</i>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr "Стопи _све дупликате"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr "<b>Стопи рецепте</b>"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr "_Сам стопи"
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "За сваку изабрану вредност"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Где %(field)s је %(value)s"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
@@ -2340,36 +2280,36 @@ msgstr[0] "Измена ће утицати на %s рецепт"
 msgstr[1] "Измена ће утицати на %s рецепта"
 msgstr[2] "Измена ће утицати на %s рецепата"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Да обришем „%s“ где је %s?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Да изменим „%s“ из „%s“ у „%s“?"
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Ова измена није повратна.</i>"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Уређивач поља"
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Уредите поља у више рецепта у исто време."
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "Пошаљи рецепте ел. поштом"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 "Пошаљи ел. поштом све изабране рецепте (или све рецепте ако није изабран "
@@ -2378,162 +2318,150 @@ msgstr ""
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Да ли заиста желите да пошаљете ел. поштом свих %s изабраних рецепта?"
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Да, пошаљи их _ел. поштом"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Не могу да претворим %s у %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Треба ми податак о густини."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Претварач јединица"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Израчунавање претварања јединица"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr "Претварач јединица"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr "<b>Из</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr "1"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr "_Ставка:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr "_Густина:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr "Подаци о _густини"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr "<b>У</b>"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr "_Резултат:"
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr "?"
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr "Архива (зип, тарбал)"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Учитавам зип архиву"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Распакујем зип архиву"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "ХТМЛ веб страница"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Извозим веб страницу"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Извозим рецепте у ХТМЛ датотеке у директоријуму %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Рецепт је сачуван као ХТМЛ датотека %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Оригинална страница из %s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "необавезно"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Извозим веб страницу"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Извозим рецепте у ХТМЛ датотеке у директоријуму %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Рецепт је сачуван као ХТМЛ датотека %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Датотека обичног текста"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Извоз у текст"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Извозим рецепте у текстуалну датотеку %(file)s."
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Рецепт је сачуван као датотека обичног текста %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Велика датотека"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Датотека %s је исувише велика за увоз"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2545,81 +2473,54 @@ msgstr ""
 "уређивач текста да је поделите на мање датотеке и покушајте опет да је "
 "увезете."
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Веб страница"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "Преузимам %s"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Списак за куповину за %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Довлачим „%s“"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Гурманкова ИксМЛ датотека"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Гурманков ИксМЛ извоз"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Извозим рецепте у Гурманкову ИксМЛ датотеку %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Рецепт је сачуван у Гурманковој ИксМЛ датотеци %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Гурманкова ИксМЛ датотека (застарело)"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr "ИксМЛ датотека Мајстора кувања"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr "Текстуална датотека Мајстора кувања"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Завршен је увоз Мајстора кувања."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Сређујем ИксМЛ"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "ИксМЛ датотека КРецепта"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2628,106 +2529,119 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Распоред странице"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Штампај рецепт"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "ПДФ (запис преносивог документа)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Извоз у ПДФ"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Извозим рецепте у ПДФ %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Рецепт је сачуван као ПДФ %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Писмо"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Портрет"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Равно"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "цм"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "тачака"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Пописна картица (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Пописна картица (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Пописна картица (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Пописна картица (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Писмо"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Правни"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Пописне картице (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Пописне картице (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Пописне картице (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Положено"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Равно"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s колона"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s колона"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s колона"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s колона"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
@@ -2735,168 +2649,176 @@ msgstr[0] "%s колона"
 msgstr[1] "%s колоне"
 msgstr[2] "%s колона"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Портрет"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Положено"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Величина _папира"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Усмерење"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Величина слова"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Распоред _странице"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Величина слова"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Лева маргина"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Десна маргина"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Горња маргина"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Доња маргина"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "Опције ПДФ‑а"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "Датотека Мајстора јела"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Извоз Мајстора јела"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Извозим рецепте у датотеку Мајстора јела %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Рецепт је сачуван као датотека Мајстор јела %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "служење"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Велика датотека"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Извоз у ХТМЛ"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Извозим рецепте у Гурманкову ИксМЛ датотеку %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Рецепт је сачуван у Гурманковој ИксМЛ датотеци %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr "Складиштар списка за куповину"
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Сачувајте списак као рецепт"
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ктрл><Помак>С"
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Сачувајте текући списак куповине као рецепт за будућу употребу"
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, fuzzy, python-format
 msgid "Menu for %s (%s)"
 msgstr "Јеловник за %s"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Јеловник"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Подаци о хранљивости осликавају количину за %s."
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Подаци о хранљивости осликавају количину за читав рецепт"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Подаци о хранљивости недостају за %s састојка: %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Било која група хране"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "избор"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Претвори јединицу за %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Да би израчунао хранљиву вредност, Гурманку је потребна ваша помоћ да би "
 "претворио „%s“ у јединицу коју разуме."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Измени кључ састојка"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2905,27 +2827,27 @@ msgstr ""
 "Да изменим кључ састојка из %(old_key)s у %(new_key)s свуда или само у "
 "рецепту %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Измени _свуда"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Само у рецепту „%s“"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr "Да ли свуда да изменим кључ састојка из %(old_key)s у %(new_key)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Измени јединицу"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2934,11 +2856,11 @@ msgstr ""
 "Да изменим јединицу из %(old_unit)s у %(new_unit)s за све састојке "
 "%(ingkey)s или само у рецепту %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2946,198 +2868,199 @@ msgstr ""
 "Гурманко мора да зна њихове густине. Наша база података о хранљивости има "
 "неколико описа ове хране са различитим густинама. Изаберите испод ону праву."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Да би применио хранљиве вредности, Гурманку требају исправна количина и "
 "јединица."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Исхрана"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Састојак"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Еквивалент УСДА базе података"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 грама"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Калорије"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Укупно масти"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Засићене масти"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Холестерол"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Натријум"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Укупно угљених хидрата"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Дијетална влакна"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Шећери"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Протеини"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Алфа-каротин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Пепео"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Бета-каротин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Бета криптоксантин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Калцијум"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Бакар"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Укупно витамина Б9"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Витамин Б9"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Витамин Б9 у храни"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Дијететски еквивалент витамина Б9"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Гвожђе"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Ликопен"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Лутеин+Зеаксантин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Магнезијум"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Манган"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Витамин Б3"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Витамин Б5"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Фосфор"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Калијум"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Витамин А"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Ретинол"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Витамин Б2"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Селен"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Витамин Б1"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Витамин А (ИУ)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Витамин А (РАЕ)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Витамин Б6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Витамин Б12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Витамин Ц"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Витамин Е"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Витамин К"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Цинк"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Витамини и минерали"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3146,11 +3069,11 @@ msgstr ""
 "Недостају хранљиве вредности за\n"
 "%(missing)s од %(total)s састојка."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _дневне вредности"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3159,367 +3082,367 @@ msgstr ""
 "Проценат препоручене дневне вредности на основу %i калорије по дану. "
 "Кликните да уредите број калорија по дану."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Количина за %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Количина по рецепту"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Учитавам податке о хранљивости"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Завршен је увоз базе података о хранљивости!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Довлачим базу података о хранљивости из зип архиве %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Извлачим „%s“ из зип архиве."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Обрађујем податке о хранљивости..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Читам податке о хранљивости: увезох %s од %s ставке."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Обрађујем податке тежине..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr "Читам податке о тежини за хранљиве ставке: увезох %s од %s ставке"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Вода"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Килокалорија"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g протеина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g масти"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g пепела"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g угљених хидрата"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g влакна"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g шећера"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg калцијума"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg гвожђа"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg магнезијума"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg фосфора"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg калијум"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg натријума"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg цинка"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg бакра"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg мангана"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "микрограма селена"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg витамина ц"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg витамина Б1"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg витамина Б2"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg витамина Б3"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg витамина Б5"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg витамина Б6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "микрограма витамина Б9"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "микрограма витамина Б9"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "микрограма витамина Б9 у храни"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "микрограма дијететских еквивалената витамина Б9"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Холина, укупно"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "микрограма витамина Б12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Витамин А ИУ"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Витамин А (микрограма еквивалената активности мрежњаче"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "микрограма ретинола"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "микрограма Алфа-каротина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "микрограма Бета-каротина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "микрограма бета криптоксантина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "микрограма ликопена"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "микрограма Лутеина+Зеаксантина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg витамина Е"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg витамина К"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g засићених масних киселина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g мононезасићених масних киселина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g вишенезасићених масних киселина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg холестерола"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Проценат отпада"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Производи од млека и јаја"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Зачини и мирођије"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Дечја храна"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Масти и уља"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Живина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Супе и умаци"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Кобасице и месо"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Житарице за доручак"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Воће и воћни сокови"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Свињетина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Поврће"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Језгра и семенке"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Говедина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Напици"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Риба и остриге"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Махунарке"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Јагњетина, телетина и игра"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Пекарски производи"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Слаткиши"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Зрневље и тестенина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Брза храна"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Оброци, предјела, и прилози"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Грицкалице"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Народна јела"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "читава база података"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "Кључ састојка"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "ИБ број УСДА"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "Опис УСДА ставке"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Еквивалент густине"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "УСДА ИБ#"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3533,108 +3456,108 @@ msgstr "Алати"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr "Добавите хранљиве вредности за тренутни списак"
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Количина за списак за куповину"
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr "Уреди податке о _хранљивсти"
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "звездице"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Извезох %(number)s од %(total)s рецепта"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Извоз је завршен."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Укључи рецепт у тело ел. поште (Одлична замисао без обзира шта ли је)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Пошаљи рецепт ел. поштом као ХТМЛ прилог"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Пошаљи рецепт ел. поштом као ПДФ прилог"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Опције ел. поште"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Не питај пре слања ел. поште."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Е-пошта није послата"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr "Нисте изабрали да укључите рецепт у тело поруке или као прилог."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Сачувај рецепт као..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Гурманко не може да извезе датотеку „%s“ врсте"
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Извези рецепте"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "рецепти"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Не могу да извезем: непозната врста датотеке „%s“"
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 "Уверите се да сте изабрали врсту датотеке из падајућег изборника приликом "
 "чувања."
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Извези"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "Не могу да штампам: није покренут прикључак штампања!"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
@@ -3642,185 +3565,139 @@ msgstr[0] "Штампај %s рецепт"
 msgstr[1] "Штампај %s рецепта"
 msgstr[2] "Штампај %s рецепата"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Довлачим датотеку"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "принос"
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Унесите адресу архиве рецепта или веб страницу рецепта."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr "Унеси веб страницу"
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Унеси адресу:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr "Унесите адресу веб сајта или архиве рецепта."
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr "Не могу да увезем адресу"
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr "Гурманко нема прикључак за увоз адреса"
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-"Не могу да увезем %(url)s миме врсте %(type)s. Датотека је сачувана на "
-"привремено место %(fn)s"
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Отвори рецепт..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Унеси веб страницу"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Измене"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr "Унесите адресу веб сајта или архиве рецепта."
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Увези"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Све увозиве датотеке"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Увезох %s рецепта."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "служење"
 msgstr[1] "служења"
 msgstr[2] "служења"
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Увезох %s од %s рецепта."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "у реду"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Не препознајем ову веб страницу. Користим општег увозника..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Увоз је завршен."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Увозим рецепт"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Обрађујем састојке"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Обрађујем састојке."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Служење"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Подгрупа састојка"
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Сакриј"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Текст"
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Радње"
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Увези рецепт"
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Очисти _ознаке"
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Увезите рецепт"
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "било где"
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "наслову"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "састојку"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "упутствима"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "белешкама"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "кухињи"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "извору"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Користи регуларне изразе код претраге"
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr "Користи регуларне изразе (напредни језик претраге) у претрази текста"
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Тражите док куцате (искључите ако је претрага превише спора)."
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Прикажи _опције претраге"
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Прикажите напредне опције претраге"
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3830,21 +3707,21 @@ msgstr[2] "%s рецепата"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Приказујем рецепте %(bottom)s до %(top)s од %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s у %s"
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Заустављено"
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 #, fuzzy
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
@@ -3852,43 +3729,37 @@ msgstr[0] "Увоз из Крецепта"
 msgstr[1] "Увоз из Крецепта"
 msgstr[2] "Увоз из Крецепта"
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Паузирај"
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Урађено"
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Грешка: %s"
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Грeшкa"
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Грешка %s: %s"
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr "Повратно праћење"
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "секунда"
@@ -3896,11 +3767,11 @@ msgstr[1] "секунде"
 msgstr[2] "секунди"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "мин"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "минут"
@@ -3908,32 +3779,32 @@ msgstr[1] "минута"
 msgstr[2] "минута"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "сати"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "сат"
 msgstr[1] "сата"
 msgstr[2] "сати"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "дан"
 msgstr[1] "дана"
 msgstr[2] "дана"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "седмица"
 msgstr[1] "седмице"
 msgstr[2] "седмица"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месец"
@@ -3943,7 +3814,7 @@ msgstr[2] "месеци"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "година"
@@ -3956,73 +3827,30 @@ msgstr[2] "година"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " и "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "и"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "до"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Гурманкова ИксМЛ датотека"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Управник рецепта Гурманко"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Организујте рецепте, направите спискове за куповину, израчунајте хранљиве "
-"вредности и још много тога."
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr "Разгледај рецепте"
@@ -4032,7 +3860,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr "Бирајте рецепте разгледањем категорије, кухиње, итд."
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr "Главно"
@@ -4045,38 +3872,6 @@ msgstr "Пронађи дуплиране рецепте"
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr "Чаробњак који проналази и уклања или стапа удвојене рецепте."
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr "Пошаљи ел. поштом"
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr "Пошаљи ел. поштом рецепте из Гурманка"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr "Зип, Гзип, и Тарбал подршка"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr "Увезите рецепте из зип и тар архива"
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr "Увозник/Извозник"
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4086,6 +3881,18 @@ msgstr "Извоз у ПДФ"
 #, fuzzy
 msgid "Create an epub book from recipes."
 msgstr "Направите веб страницу рецепта из рецепта."
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
+msgstr "Увозник/Извозник"
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
 msgid "Gourmet XML Import and Export"
@@ -4098,14 +3905,6 @@ msgid ""
 msgstr ""
 "Увезите и извезите рецепте као Гурманкове ИксМЛ датотеке, пригодне за "
 "резерву или размену са другим корисницима Гурманка."
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr "Извоз у ХТМЛ"
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
-msgstr "Направите веб страницу рецепта из рецепта."
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
 msgid "KRecipe import"
@@ -4167,22 +3966,6 @@ msgid ""
 msgstr ""
 "Помаже кориснику да означи и извезе обичан текст. Такође обезбеђује извоз у "
 "обичан текст."
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr "Увоз са веб странице"
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr "Увезите рецепте са веб странице."
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr "Увозници веб сајта"
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
-msgstr "Увозници за „about.com“, „www.foodnetwork.com“, и друге"
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
 msgid ""
@@ -4250,6 +4033,195 @@ msgstr ""
 "Укључите ово ако се ваше утф-16 текстуалне датотеке не увозе исправно у "
 "Гурманка. Искључите ово ако никада не користите УТФ16 и ако вам стално смета "
 "прозорче „Кодирања“ када увозите датотеке."
+
+#~ msgid "E-mail selected recipe"
+#~ msgstr "Пошаљи ел. поштом изабрани рецепт"
+
+#~ msgid "_E-Mail recipe"
+#~ msgstr "_Пошаљи рецепт ел. поштом"
+
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Роланд Дихејм (испомоћ за прилагођавање на Виндоуз)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Данијел Фолкинштајн <nanotube@gmail.com> (Инсталација за Виндоуз)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Ричард Фергусон (побољшања сучеља претварача јединица)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "Р.С. Борн (побољшања за извоз Мајстора јела)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "иксат <ixat.deviantart.com> (логотип и поздравни екран)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr ""
+#~ "Јула Зубрицки (иконице хранљивости и додавања на списак за куповину)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Сајмно Дарлингтон <simon.darlington@gmx.net> (побољшања за "
+#~ "интернационализацију, разне исправке грешака)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
+#~ "design)"
+#~ msgstr ""
+#~ "Бернард Рајтер <ockham@raz.or.at> (Одржавање издања за Виндоуз и "
+#~ "осмишљавање веб сајта)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Надограђујем базу података"
+
+#~ msgid ""
+#~ "Depending on the size of your database, this may be an intensive process "
+#~ "and may take  some time. Your data has been automatically backed up in "
+#~ "case something goes wrong."
+#~ msgstr ""
+#~ "У зависности од величине базе података, ово може да буде интензиван "
+#~ "поступак и може да потраје неко време. У случају да нешто крене наопако "
+#~ "резерва ваших података бива направљена самостално."
+
+#~ msgid "Paste ingredients"
+#~ msgstr "Убаци састојак"
+
+#~ msgid "Import from file"
+#~ msgstr "Увези из датотеке"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Изаберите датотеку која садржи ваш списак састојака."
+
+#~ msgid "No file selected"
+#~ msgstr "Није изабрана ниједна датотека"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Није изабрана ниједна датотека, тако да је радња отказана"
+
+#~ msgid "_Import file"
+#~ msgstr "_Увези датотеку"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Увези _веб страницу"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Увезите рецепт са веб странице"
+
+#~ msgid "Open _Trash"
+#~ msgstr "_Отвори смеће"
+
+#~ msgid "Archive (zip, tarball)"
+#~ msgstr "Архива (зип, тарбал)"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Учитавам зип архиву"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Распакујем зип архиву"
+
+#~ msgid "Webpage"
+#~ msgstr "Веб страница"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "Преузимам %s"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Списак за куповину за %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Довлачим „%s“"
+
+#~ msgid "ml"
+#~ msgstr "ml"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Довлачим датотеку"
+
+#~ msgid "Enter the URL of a recipe archive or recipe website."
+#~ msgstr "Унесите адресу архиве рецепта или веб страницу рецепта."
+
+#~ msgid "Enter URL:"
+#~ msgstr "Унеси адресу:"
+
+#~ msgid "Unable to import URL"
+#~ msgstr "Не могу да увезем адресу"
+
+#~ msgid "Gourmet does not have a plugin capable of importing URL"
+#~ msgstr "Гурманко нема прикључак за увоз адреса"
+
+#, python-format
+#~ msgid ""
+#~ "Unable to import URL %(url)s of mimetype %(type)s. File saved to "
+#~ "temporary location %(fn)s"
+#~ msgstr ""
+#~ "Не могу да увезем %(url)s миме врсте %(type)s. Датотека је сачувана на "
+#~ "привремено место %(fn)s"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr "Не препознајем ову веб страницу. Користим општег увозника..."
+
+#~ msgid "Import complete."
+#~ msgstr "Увоз је завршен."
+
+#~ msgid "Importing recipe"
+#~ msgstr "Увозим рецепт"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Обрађујем састојке"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Обрађујем састојке."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Гурманкова ИксМЛ датотека"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Управник рецепта Гурманко"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Организујте рецепте, направите спискове за куповину, израчунајте хранљиве "
+#~ "вредности и још много тога."
+
+#~ msgid "Send to Email"
+#~ msgstr "Пошаљи ел. поштом"
+
+#~ msgid "Email recipes from Gourmet"
+#~ msgstr "Пошаљи ел. поштом рецепте из Гурманка"
+
+#~ msgid "Zip, Gzip, and Tarball support"
+#~ msgstr "Зип, Гзип, и Тарбал подршка"
+
+#~ msgid "Import recipes from zip and tar archives"
+#~ msgstr "Увезите рецепте из зип и тар архива"
+
+#~ msgid "HTML Export"
+#~ msgstr "Извоз у ХТМЛ"
+
+#~ msgid "Create recipe webpages from recipes."
+#~ msgstr "Направите веб страницу рецепта из рецепта."
+
+#~ msgid "Webpage import"
+#~ msgstr "Увоз са веб странице"
+
+#~ msgid "Import recipes from the web."
+#~ msgstr "Увезите рецепте са веб странице."
+
+#~ msgid "Website Importers"
+#~ msgstr "Увозници веб сајта"
+
+#~ msgid "Importers for about.com, www.foodnetwork.com, and others"
+#~ msgstr "Увозници за „about.com“, „www.foodnetwork.com“, и друге"
 
 #~ msgid ""
 #~ "<i>Select text from the raw recipe and categorize it by labelling which "
@@ -4387,9 +4359,6 @@ msgstr ""
 
 #~ msgid "_Servings"
 #~ msgstr "_Служење"
-
-#~ msgid "Select File_type"
-#~ msgstr "Изаберите врсту _датотеке"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Датотека под називом „%s“ већ постоји."

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gourmet Recipe Manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-15 10:46+0200\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2022-08-15 17:26+0200\n"
 "Last-Translator: jens persson <jens@persson.cx>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -26,11 +26,11 @@ msgstr "Receptindex"
 
 #. Set up hard-coded functional buttons...
 #: ../src/gourmand/ui/app.ui.h:2
-#: ../src/gourmand/importers/interactive_importer.py:151
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Nytt recept"
 
-#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:105
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Lägg till i _inköpslistan"
 
@@ -82,8 +82,7 @@ msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
-"<span size=\"large\" weight=\"bold\">Sätt receptfält för valda recept</"
-"span>"
+"<span size=\"large\" weight=\"bold\">Sätt receptfält för valda recept</span>"
 
 #: ../src/gourmand/ui/batchEditor.ui.h:3
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
@@ -201,8 +200,11 @@ msgstr "*"
 msgid "Database _Name:"
 msgstr "Databas_namn:"
 
-#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:669
-#: ../src/gourmand/main.py:1035
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Arkiv"
 
@@ -239,9 +241,9 @@ msgstr ""
 "bara att försöka skapa denna databas om den inte redan existerar."
 
 #: ../src/gourmand/ui/databaseChooser.ui.h:19
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "recept"
 
@@ -254,8 +256,8 @@ msgid "_Browse"
 msgstr "_Bläddra"
 
 #: ../src/gourmand/ui/databaseChooser.ui.h:22
-#: ../src/gourmand/gtk_extras/dialog_extras.py:853
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1288
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Detaljer"
 
@@ -339,9 +341,9 @@ msgstr "Lägg all_tid till valfria ingredienser"
 msgid "_Never add optional ingredients"
 msgstr "Lägg al_drig till valfria ingredienser"
 
-#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:145
-#: ../src/gourmand/shopgui.py:534 ../src/gourmand/shopgui.py:844
-#: ../src/gourmand/shopgui.py:995
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Inköpslista"
 
@@ -351,11 +353,9 @@ msgstr "portioner"
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmand/shopgui.py:745 ../src/gourmand/gglobals.py:28
-#: ../src/gourmand/exporters/rtf_exporter.py:86
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Titel"
 
@@ -368,7 +368,7 @@ msgid "Pre_paration Time:"
 msgstr "_Förberedelsetid:"
 
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmand/recindex.py:51 ../src/gourmand/recindex.py:58
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategori"
 
@@ -377,12 +377,12 @@ msgid "rating"
 msgstr "betyg"
 
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmand/gglobals.py:34
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr "Avkastning"
 
 #: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmand/gglobals.py:35
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr "Enhet för avkastning"
 
@@ -451,10 +451,10 @@ msgid "Edit _notes"
 msgstr "Redigera _anteckningar"
 
 #: ../src/gourmand/ui/recCardDisplay.ui.h:17
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmand/exporters/exporter.py:620
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Recept"
 
@@ -471,16 +471,15 @@ msgid "Add _ingredient:"
 msgstr "Lägg _till ingrediens:"
 
 #: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmand/reccard.py:1070
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
 #: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:617
-#: ../src/gourmand/exporters/exporter.py:248
-#: ../src/gourmand/importers/interactive_importer.py:45
-#: ../src/gourmand/importers/interactive_importer.py:60
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Ingredienser"
 
@@ -501,7 +500,7 @@ msgid "Delete selected recipe"
 msgstr "Radera valt recept"
 
 #. saveEdits
-#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:871
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Ta bort recept"
 
@@ -564,7 +563,7 @@ msgstr "Sök medan du _skriver"
 msgid "<i>Search Options</i>"
 msgstr "<i>Sökinställningar</i>"
 
-#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategori"
 
@@ -573,11 +572,11 @@ msgstr "Kategori"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2138
-#: ../src/gourmand/reccard.py:2198
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:116
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Tangent"
 
@@ -589,7 +588,7 @@ msgstr "Kategoriredigerare"
 msgid "Search by"
 msgstr "Sök i"
 
-#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:107
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "Sök medan du skriver"
 
@@ -607,8 +606,8 @@ msgstr "Avancerad sökning"
 msgid "Add Category: "
 msgstr "Lägg till kategori: "
 
-#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:190
-#: ../src/gourmand/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Tidtagarur"
 
@@ -749,7 +748,7 @@ msgid "Unit:"
 msgstr "Enhet:"
 
 #: ../src/gourmand/ui/nutritionDruid.ui.h:12
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "enhet"
 
@@ -832,10 +831,10 @@ msgstr "_Avancerad sökning"
 #. name
 #. stock
 #: ../src/gourmand/ui/nutritionDruid.ui.h:35
-#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
 #: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
 #: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr "Näringsvärde"
@@ -845,7 +844,6 @@ msgid "I_gnore"
 msgstr "I_gnorera"
 
 #: ../src/gourmand/__version__.py:3
-#| msgid "Gourmet Recipe Manager"
 msgid "Gourmand Recipe Manager"
 msgstr "Gourmand Recepthanterare"
 
@@ -883,7 +881,7 @@ msgstr ""
 "* Länka bilder till recepten.\n"
 "* Beräkna näringsvärdet för recept baserat på dess ingredienser.\n"
 
-#: ../src/gourmand/__version__.py:25
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr "Nyall Dawson (kakicon)"
 
@@ -891,28 +889,28 @@ msgstr "Nyall Dawson (kakicon)"
 msgid "Kati Pregartner (splash screen image)"
 msgstr "Kati Pregartner (Startskärmsbild)"
 
-#: ../src/gourmand/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "Välj databas fil"
 
-#: ../src/gourmand/backends/db.py:1472 ../src/gourmand/reccard.py:942
-#: ../src/gourmand/importers/interactive_importer.py:100
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Nytt recept"
 
-#: ../src/gourmand/backends/db.py:2120 ../src/gourmand/backends/db.py:2121
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
 msgid "Database Backup"
 msgstr "Databas backup"
 
-#: ../src/gourmand/backends/db.py:2122
+#: ../src/gourmand/backends/db.py:2184
 msgid "Depending on the size of your database, this may take some time."
 msgstr "Beroende på databasstorleken så kan detta ta lång tid."
 
-#: ../src/gourmand/backends/db.py:2123 ../src/gourmand/threadManager.py:351
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
 msgid "Details"
 msgstr "Detaljer"
 
-#: ../src/gourmand/backends/db.py:2124
+#: ../src/gourmand/backends/db.py:2188
 #, python-format
 msgid ""
 "A backup will be made as %s in case something goes wrong. If this upgrade "
@@ -922,128 +920,128 @@ msgstr ""
 "uppgradering går fel kan du manuellt byta namn på din backup-fil till "
 "recipes.db för att återskapa den."
 
-#: ../src/gourmand/shopgui.py:120 ../src/gourmand/shopgui.py:127
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr "Ändra _kategori"
 
-#: ../src/gourmand/shopgui.py:121
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr "Skapa ny kategori"
 
-#: ../src/gourmand/shopgui.py:129
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr "Byt kategori på den valda produkten"
 
-#: ../src/gourmand/shopgui.py:135
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr "Skafferi"
 
 #. name
 #. stock
-#: ../src/gourmand/shopgui.py:138
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Flytta till _inköpslista"
 
 #. text
-#: ../src/gourmand/shopgui.py:139
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr "<Ctrl>B"
 
 #. name
 #. stock
-#: ../src/gourmand/shopgui.py:148
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr "Flytta till _skafferit"
 
 #. text
-#: ../src/gourmand/shopgui.py:149
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr "<Ctrl>D"
 
 #. key-command
-#: ../src/gourmand/shopgui.py:150
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr "Flytta från inköpslistan"
 
-#: ../src/gourmand/shopgui.py:171
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr "Flytta valda artiklar till %s"
 
-#: ../src/gourmand/shopgui.py:209 ../src/gourmand/main.py:1050
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Inköpslista"
 
-#: ../src/gourmand/shopgui.py:210
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Har redan (_skafferivaror)"
 
-#: ../src/gourmand/shopgui.py:473
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Ange kategori"
 
-#: ../src/gourmand/shopgui.py:474
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Kategori att lägga till %s till"
 
-#: ../src/gourmand/shopgui.py:475
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Kategori:"
 
-#: ../src/gourmand/shopgui.py:579
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Recept"
 
-#: ../src/gourmand/shopgui.py:603
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr "Lägg till _artiklar:"
 
-#: ../src/gourmand/shopgui.py:642
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Ta bort recept"
 
-#: ../src/gourmand/shopgui.py:643
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Ta bort recept från inköpslista"
 
-#: ../src/gourmand/shopgui.py:647 ../src/gourmand/reccard.py:227
-#: ../src/gourmand/reccard.py:866 ../src/gourmand/main.py:1048
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "Re_digera"
 
-#: ../src/gourmand/shopgui.py:670 ../src/gourmand/shopgui.py:673
-#: ../src/gourmand/reccard.py:229 ../src/gourmand/reccard.py:240
-#: ../src/gourmand/reccard.py:868 ../src/gourmand/main.py:1062
-#: ../src/gourmand/main.py:1065
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "_Hjälp"
 
-#: ../src/gourmand/shopgui.py:678
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr "Lägg till artiklar"
 
-#: ../src/gourmand/shopgui.py:680
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr "Lägg till andra produkter till inköpslistan"
 
-#: ../src/gourmand/shopgui.py:746
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmand/shopgui.py:831
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Inga recept är valda. Du kanske vill tömma hela listan?"
 
-#: ../src/gourmand/shopgui.py:842
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Spara inköpslista som..."
 
-#: ../src/gourmand/shopgui.py:898
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr "Välj valfria ingredienser"
 
-#: ../src/gourmand/shopgui.py:899
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1052,56 +1050,56 @@ msgstr ""
 "inköpslista."
 
 #. menus
-#: ../src/gourmand/reccard.py:226 ../src/gourmand/reccard.py:865
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Recept"
 
-#: ../src/gourmand/reccard.py:228 ../src/gourmand/main.py:212
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Visa"
 
-#: ../src/gourmand/reccard.py:230
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Exportera receptet"
 
-#: ../src/gourmand/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr "Exportera valda receptet (spara till fil)"
 
-#: ../src/gourmand/reccard.py:233
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "Ra_dera recept"
 
-#: ../src/gourmand/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr "Radera det här receptet"
 
-#: ../src/gourmand/reccard.py:248
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr "Justera enheter vid mångfaldigande"
 
-#: ../src/gourmand/reccard.py:250
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr "Ändra på enheter för att göra dem mer läsbara vid mångfaldigande."
 
-#: ../src/gourmand/reccard.py:256
+#: ../src/gourmand/reccard.py:246
 msgid "Copy to clipboard"
 msgstr "Kopiera till urklipp"
 
-#: ../src/gourmand/reccard.py:258
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Skriv ut recept"
 
-#: ../src/gourmand/reccard.py:260 ../src/gourmand/main.py:1029
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 msgid "Add to Shopping List"
 msgstr "Lägg till på inköpslistan"
 
-#: ../src/gourmand/reccard.py:262
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr "Rensa lagrade valfria ingredienser"
 
-#: ../src/gourmand/reccard.py:263
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
@@ -1109,142 +1107,142 @@ msgstr ""
 "Innan produkten läggs till på inköpslistan, fråga om alla valfria "
 "ingredienser, även de som tidigare lagrats"
 
-#: ../src/gourmand/reccard.py:265
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr "Exportera recept"
 
-#: ../src/gourmand/reccard.py:551
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr "Receptet exorterades till <a href=\"file:///%s\">%s</a>"
 
-#: ../src/gourmand/reccard.py:575 ../src/gourmand/reccard.py:588
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Du har osparade ändringar."
 
-#: ../src/gourmand/reccard.py:576
+#: ../src/gourmand/reccard.py:547
 msgid "Save changes before copying?"
 msgstr "Spara ändringar innan kopiering?"
 
-#: ../src/gourmand/reccard.py:589
+#: ../src/gourmand/reccard.py:559
 msgid "Save changes before printing?"
 msgstr "Spara ändringar innan utskrift?"
 
-#: ../src/gourmand/reccard.py:701 ../src/gourmand/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(alternativ)"
 
-#: ../src/gourmand/reccard.py:753
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Kan inte hitta recept %s i databasen."
 
-#: ../src/gourmand/reccard.py:849
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Redigera recept:"
 
-#: ../src/gourmand/reccard.py:870
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr "Spara ändrigar till databas"
 
 #. show_pref_dialog
-#: ../src/gourmand/reccard.py:879
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Visa receptkort"
 
-#: ../src/gourmand/reccard.py:942
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Ändra"
 
-#: ../src/gourmand/reccard.py:1040 ../src/gourmand/reccard.py:1041
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr "Spara ändringar till %s"
 
-#: ../src/gourmand/reccard.py:1131
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "Lägg ingrediens"
 
-#: ../src/gourmand/reccard.py:1136
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Lägg till grupp"
 
-#: ../src/gourmand/reccard.py:1138
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr "Lägg till _recept"
 
-#: ../src/gourmand/reccard.py:1139
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "Lägg ett annat recept som ingrediens i detta recept"
 
-#: ../src/gourmand/reccard.py:1144
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Radera"
 
-#: ../src/gourmand/reccard.py:1150
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr "Upp"
 
-#: ../src/gourmand/reccard.py:1152
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Ner"
 
-#: ../src/gourmand/reccard.py:1308
-#: ../src/gourmand/importers/interactive_importer.py:53
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Beskrivning"
 
-#: ../src/gourmand/reccard.py:1656 ../src/gourmand/gglobals.py:42
-#: ../src/gourmand/gglobals.py:47
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Instruktioner"
 
-#: ../src/gourmand/reccard.py:1662 ../src/gourmand/gglobals.py:43
-#: ../src/gourmand/gglobals.py:48
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Kommentarer"
 
-#: ../src/gourmand/reccard.py:2135 ../src/gourmand/reccard.py:2165
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Mängd"
 
-#: ../src/gourmand/reccard.py:2136 ../src/gourmand/reccard.py:2166
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Enhet"
 
-#: ../src/gourmand/reccard.py:2137 ../src/gourmand/reccard.py:2167
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:108
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Produkt"
 
-#: ../src/gourmand/reccard.py:2139 ../src/gourmand/reccard.py:2168
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Valbar"
 
-#: ../src/gourmand/reccard.py:2280
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Receptet %s (ID %s) finns inte i vår databas."
 
-#: ../src/gourmand/reccard.py:2598
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Omvandlat: %(amt)s %(unit)s"
 
-#: ../src/gourmand/reccard.py:2600
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Ej konverterat: %(amt)s %(unit)s"
 
-#: ../src/gourmand/reccard.py:2604
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Ändrade enhet."
 
-#: ../src/gourmand/reccard.py:2605
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1253,229 +1251,229 @@ msgstr ""
 "Du har bytt enhet för %(item)s från %(old)s till %(new)s. Vill du att "
 "mängden skall konverteras också?"
 
-#: ../src/gourmand/reccard.py:2616
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Konverterade %(old_amt)s %(old_unit)s till %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmand/reccard.py:2628
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Kunde inte konvertera från %(old_unit)s till %(new_unit)s"
 
-#: ../src/gourmand/reccard.py:2683
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Lägger till ingrediensgrupp"
 
-#: ../src/gourmand/reccard.py:2684
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Ge ett namn åt denna undergrupp av ingredienser"
 
-#: ../src/gourmand/reccard.py:2685
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Namn på grupp:"
 
-#: ../src/gourmand/reccard.py:2948
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr "Välj recept"
 
-#: ../src/gourmand/reccard.py:2985
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Recept kan inte räknas som ingrediens!"
 
-#: ../src/gourmand/reccard.py:2986 ../src/gourmand/shopping.py:298
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Oändliga rekursioner är inte tillåtna i recept!"
 
-#: ../src/gourmand/reccard.py:3004
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Du har inte valt något recept!"
 
-#: ../src/gourmand/reccard.py:3016
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr "Hur mycket av %(title)s kräver ditt recept?"
 
-#: ../src/gourmand/reccard.py:3026
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmand/exporters/recipe_emailer.py:65
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Recept"
 
-#: ../src/gourmand/timer.py:147 ../src/gourmand/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Ringande ljud"
 
-#: ../src/gourmand/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Varningsljud"
 
-#: ../src/gourmand/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Ljud vid fel"
 
-#: ../src/gourmand/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Stoppa tidtagarur?"
 
-#: ../src/gourmand/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Stoppa _timer"
 
-#: ../src/gourmand/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Fortsätt timer"
 
-#: ../src/gourmand/plugin_gui.py:35
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Tillägg"
 
-#: ../src/gourmand/plugin_gui.py:38
+#: ../src/gourmand/plugin_gui.py:39
 msgid "Plugins add extra functionality to Gourmand."
 msgstr "Tillägg ger extra funktioner till Gourmand."
 
-#: ../src/gourmand/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr "Detta tillägg behövs för andra tillägg. Deaktivera tillägget ändå?"
 
-#: ../src/gourmand/plugin_gui.py:126
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr "Följande tillägg kräver %s:"
 
-#: ../src/gourmand/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr "Deaktivera ändå"
 
-#: ../src/gourmand/plugin_gui.py:130
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr "Behåll tillägget aktivt"
 
-#: ../src/gourmand/plugin_gui.py:144 ../src/gourmand/recindex.py:463
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "eller"
 
-#: ../src/gourmand/plugin_gui.py:148
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr "Ett fel inträffade när tillägget aktiverades."
 
-#: ../src/gourmand/plugin_gui.py:152
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr "Ett fel inträffade när tillägget deaktiverades."
 
-#: ../src/gourmand/gglobals.py:30
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Matkultur"
 
-#: ../src/gourmand/gglobals.py:31
-#: ../src/gourmand/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Gradering"
 
-#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Källa"
 
-#: ../src/gourmand/gglobals.py:33
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Webbsida"
 
-#: ../src/gourmand/gglobals.py:36
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Förberedelsetid"
 
-#: ../src/gourmand/gglobals.py:37
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Tillagningstid"
 
-#: ../src/gourmand/gglobals.py:49
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Ändringar"
 
-#: ../src/gourmand/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr "Tid måste bestå av ett nummer och en enhet."
 
-#: ../src/gourmand/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Ogiltig inmatning."
 
-#: ../src/gourmand/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Inte ett nummer."
 
 #. setup pause button
-#: ../src/gourmand/gtk_extras/dialog_extras.py:424
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Pausa"
 
 #. setup stop button
-#: ../src/gourmand/gtk_extras/dialog_extras.py:437
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Stoppa"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:508
-#: ../src/gourmand/gtk_extras/dialog_extras.py:602
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Fråga mig inte igen."
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:565
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Vill du verkligen göra detta"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:786
-#: ../src/gourmand/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "suverän"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:787
-#: ../src/gourmand/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "kanon"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:788
-#: ../src/gourmand/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "bra"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:789
-#: ../src/gourmand/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "skaplig"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:790
-#: ../src/gourmand/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "dålig"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:802
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Konvertera bedömning till 5 stjärnors skala."
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:803
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Omvandla graderingar."
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:805
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 "Var god och ange varje gradering en motsvarighet på en skala från 1 till 5"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:819
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Nuvarande gradering"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:824
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Gradering av 5 stjärnor"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1226
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
 msgid "Select File(s)"
 msgstr "Välj fil(er)"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1284
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1484,14 +1482,14 @@ msgstr ""
 "Jag är ledsen, jag kan inte förstå\n"
 "mängden \"%s\"."
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1287
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 "Mängder måste vara nummer (bråk- eller decimaltal), ett nummerområdet (tex. "
 "1-5) eller tomt."
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1289
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1511,83 +1509,83 @@ msgstr ""
 "För att skriva in en rad numror, använd ett \"-\" för att skilja dem åt.\n"
 "Till exempel, kan du skriva in 2-4 eller 1 1/2 - 3 1/2.\n"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1304
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr "Användarnamn"
 
-#: ../src/gourmand/gtk_extras/dialog_extras.py:1304
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr "Lösenord"
 
-#: ../src/gourmand/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "mjöl, (generellt)"
 
-#: ../src/gourmand/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "socker"
 
-#: ../src/gourmand/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "salt"
 
-#: ../src/gourmand/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "svart peppar, malet"
 
-#: ../src/gourmand/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "is"
 
-#: ../src/gourmand/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "vatten"
 
-#: ../src/gourmand/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "olja, vegetabilisk"
 
-#: ../src/gourmand/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "olja, oliv"
 
-#: ../src/gourmand/shopping.py:144 ../src/gourmand/shopping.py:164
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Okänd"
 
-#: ../src/gourmand/shopping.py:297
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Receptet anropar sigsjälv som en ingrediens."
 
-#: ../src/gourmand/shopping.py:298
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Ingrediensen %s ignoreras."
 
-#: ../src/gourmand/shopping.py:344 ../src/gourmand/shopping.py:358
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Spara inköpslista för %s"
 
-#: ../src/gourmand/shopping.py:345
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr "För följande recept:\n"
 
-#: ../src/gourmand/shopping.py:350 ../src/gourmand/shopping.py:363
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmand/shopping.py:359
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "För följande recept:"
 
-#: ../src/gourmand/check_encodings.py:104
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Välj teckenkodning"
 
-#: ../src/gourmand/check_encodings.py:105
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1595,27 +1593,28 @@ msgstr ""
 "Kan inte definiera teckenkodningen rätt. Välj den rätta teckenkodningen från "
 "listan."
 
-#: ../src/gourmand/check_encodings.py:106
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Se _fil med teckenkodning"
 
-#: ../src/gourmand/main.py:112
+#. Convenience method for showing progress dialogs for import/export/deletion
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Import pausad"
 
-#: ../src/gourmand/main.py:113
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Stoppa import"
 
-#: ../src/gourmand/main.py:192 ../src/gourmand/main.py:1077
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Recept_index"
 
-#: ../src/gourmand/main.py:193
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Inköps_lista"
 
-#: ../src/gourmand/main.py:340
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1637,313 +1636,315 @@ msgstr ""
 "  boxar https://launchpad.net/~martin-boxar\n"
 "  jens persson https://github.com/MrShark"
 
-#: ../src/gourmand/main.py:391
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Sparad!"
 
-#: ../src/gourmand/main.py:402
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Spara dina ändringar till %s"
 
-#: ../src/gourmand/main.py:413
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Import pågår."
 
-#: ../src/gourmand/main.py:414
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "En exportering pågår."
 
-#: ../src/gourmand/main.py:415
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Radering pågår."
 
-#: ../src/gourmand/main.py:417
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Avsluta programmet i alla fall?"
 
-#: ../src/gourmand/main.py:419
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Avsluta inte!"
 
-#: ../src/gourmand/main.py:465
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "Permanent raderat %s av %s recept"
 
-#: ../src/gourmand/main.py:486 ../src/gourmand/main.py:501
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Papperskorg"
 
-#: ../src/gourmand/main.py:502
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Bläddra, permanent radera eller återställa raderade recept"
 
-#: ../src/gourmand/main.py:556
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Återställer recept "
 
-#: ../src/gourmand/main.py:695
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr "Antal %(unit)s av %(title)s att köpa"
 
-#: ../src/gourmand/main.py:707
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Multiplicera %s med:"
 
-#: ../src/gourmand/main.py:740
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] "Sätt %(attributes)s för %(num)s valt recept?"
 msgstr[1] "Sätt %(attributes)s för %(num)s valda recept?"
 
-#: ../src/gourmand/main.py:747
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "Inga tidigare existerande värden kommer att ändras."
 
-#: ../src/gourmand/main.py:749
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "De nya värdena kommer att skriva över alla tidigare värden."
 
-#: ../src/gourmand/main.py:750
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr "Denna förändring kan inte ångras."
 
-#: ../src/gourmand/main.py:751
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Ställ in värden för utvalda recept"
 
-#: ../src/gourmand/main.py:980
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "Sök recept"
 
-#: ../src/gourmand/main.py:1013
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "Öppna receptet"
 
-#: ../src/gourmand/main.py:1014
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Öppna valt recept"
 
-#: ../src/gourmand/main.py:1015
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Radera receptet"
 
-#: ../src/gourmand/main.py:1016
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Ta bort markerade recept"
 
-#: ../src/gourmand/main.py:1017
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr "Ändra receptet"
 
-#: ../src/gourmand/main.py:1018
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr "Öppna utvalda recept i receptet redigeringsvyn"
 
-#: ../src/gourmand/main.py:1020
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "E_xportera valda recept"
 
-#: ../src/gourmand/main.py:1021
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr "Exportera valda recept till fil"
 
-#: ../src/gourmand/main.py:1023
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Skriv ut"
 
-#: ../src/gourmand/main.py:1025
+#: ../src/gourmand/main.py:1000
 msgid "_Copy recipes"
 msgstr "_Kopiera recept"
 
-#: ../src/gourmand/main.py:1027
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "_Batchredigera recept"
 
-#: ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Ny"
 
-#: ../src/gourmand/main.py:1038
+#: ../src/gourmand/main.py:1011
 msgid "_Import Recipe"
 msgstr "_Importera recept"
 
-#: ../src/gourmand/main.py:1039
+#: ../src/gourmand/main.py:1011
 msgid "Import recipe from file or page"
 msgstr "Importera recept från fil eller sida"
 
-#: ../src/gourmand/main.py:1040
+#: ../src/gourmand/main.py:1012
 msgid "Paste recipe"
 msgstr "Klistra in recept"
 
-#: ../src/gourmand/main.py:1042
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "Exportera _alla recept"
 
-#: ../src/gourmand/main.py:1043
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr "Exportera alla recept till fil"
 
-#: ../src/gourmand/main.py:1044
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Avsluta"
 
-#: ../src/gourmand/main.py:1047
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Åtgärder"
 
-#: ../src/gourmand/main.py:1052
+#: ../src/gourmand/main.py:1025
 msgid "_Trash"
 msgstr "_Papperskorg"
 
-#: ../src/gourmand/main.py:1055
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Inställningar"
 
-#: ../src/gourmand/main.py:1057
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Tillägg"
 
-#: ../src/gourmand/main.py:1058
+#: ../src/gourmand/main.py:1032
 msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Hantera tillägg som ger extra funktioner för Gourmand."
 
-#: ../src/gourmand/main.py:1060
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "I_nställningar"
 
-#: ../src/gourmand/main.py:1063
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Om"
 
-#: ../src/gourmand/main.py:1071
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "V_erktyg"
 
-#: ../src/gourmand/main.py:1072
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Tidtagarur"
 
-#: ../src/gourmand/main.py:1073
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Visa timer"
 
-#: ../src/gourmand/main.py:1078
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr "Sökbart index över recept i databasen."
 
-#: ../src/gourmand/main.py:1187
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Ta bort %s?"
 
-#: ../src/gourmand/main.py:1188
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Du har osparade ändringar till %s. Är du säker på att du vill radera?"
 
-#: ../src/gourmand/main.py:1217
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Borttagen"
 
-#: ../src/gourmand/main.py:1217
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Namnlös"
 
-#: ../src/gourmand/main.py:1225
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Ta bort recept permanent?"
 
-#: ../src/gourmand/main.py:1227
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Ta bort recept permanent?"
 
-#: ../src/gourmand/main.py:1228
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Är du säker på att du vill tabort receptet <i>%s</i>"
 
-#: ../src/gourmand/main.py:1230
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Är du säker på att du vill ta bort följande recept?"
 
-#: ../src/gourmand/main.py:1234
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Är du säker på att du vill ta bort det %s valda recepten?"
 
-#: ../src/gourmand/main.py:1236
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Se recept"
 
-#: ../src/gourmand/main.py:1244
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Radera recepten"
 
-#: ../src/gourmand/main.py:1246
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr "Recept borttaget"
 
-#: ../src/gourmand/main.py:1271
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Tog bort recept %s"
 
-#: ../src/gourmand/main.py:1298
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr "Se papperskorgen nu"
 
-#: ../src/gourmand/main.py:1337
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Färdig!"
 
-#: ../src/gourmand/main.py:1345
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Importerar..."
 
-#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr "Ingrediens_nyckel redigerare"
 
-#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr "Redigera ingrediens nycklar i klump"
 
 #. to set our regexp_toggled variable
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "nyckel"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:265
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "sak"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Fält"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Värde"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Antal"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Ändra alla nycklar \"%s\" till \"%s\"?"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1954,12 +1955,12 @@ msgstr ""
 "nyckel \"%s\", kommer du inte att kunna skilja mellan dessa saker och de "
 "saker du ändrar nu."
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Byt alla saker \"%s\" till \"%s\"?"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1969,12 +1970,12 @@ msgstr ""
 "Du kan inte ångra enna åtgärd. Om det redan finns ingredienser med denna sak "
 "\"%s\", kan du inte skilja på dessa saker och de saker du ändrar just nu."
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Ändra _alla förekomster av \"%(unit)s\" till \"%(text)s\""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -1983,13 +1984,13 @@ msgstr ""
 "Ändra \"%(unit)s\" till \"%(text)s\" endast för _ingredienser \"%(item)s\" "
 "med nyckeln \"%(key)s\""
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 "Ändra  _alla förekomster av \"%(amount)s\" %(unit)s till %(text)s %(unit)s"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -1998,7 +1999,7 @@ msgstr ""
 "Ändra \"%(amount)s\" %(unit)s till \"%(text)s\" %(unit)s endast _där "
 "ingrediens nyckeln är %(key)s"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2007,7 +2008,7 @@ msgstr ""
 "Ändra \"%(amount)s\" %(unit)s till \"%(text)s\" %(unit)s ändast där "
 "ingrediens nyckeln är %(key)s _och där saken är %(item)s"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Ändra alla valda rader?"
 
@@ -2057,7 +2058,7 @@ msgstr ""
 "Antal att %s"
 
 #: ../src/gourmand/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2067,18 +2068,18 @@ msgstr[1] "%s ingredienser"
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
 #: ../src/gourmand/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Visar ingredienser %(bottom)s till %(top)s av %(total)s"
 
-#: ../src/gourmand/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Mängd"
 
 #: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr "Ingrediensnyckel"
 
@@ -2090,11 +2091,11 @@ msgstr ""
 "Ingrediensnycklar är normaliserade ingrediensnamn som används i inköpslistor "
 "och för beräkningar."
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr "Gissa nycklar"
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
@@ -2102,11 +2103,11 @@ msgstr ""
 "Gissa bästa värde på alla ingrediensnycklas baserat på innehållet i din "
 "databas"
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr "Redigera nyckelkopplingar"
 
-#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:98
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr "Redigera nyckelkopplingar och andra attribut i databasen"
 
@@ -2143,15 +2144,15 @@ msgstr "Visa alltid amerikanska enheter"
 msgid "Always display metric units"
 msgstr "Visa alltid SI-enheter"
 
-#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:20
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr "Justera enheter automatiskt"
 
-#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:30
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr "Inställningar _enhetsvisning"
 
-#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
@@ -2159,42 +2160,42 @@ msgstr ""
 "Konvertera automatiskt enheter till föredraget system (SI-systemet, Engelska "
 "enheter, osv.) när möjligt."
 
-#: ../src/gourmand/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr "Obedömd"
 
-#: ../src/gourmand/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Stjärnor"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr "%s sedan"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr "Sammanfoga recept automatiskt"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr "Använd alltid senaste recepten"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr "Använd alltid äldsta recepten"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmand/plugins/unit_converter/convertGui.py:161
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
 #: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Ingen"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:25
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:61
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
@@ -2202,11 +2203,11 @@ msgstr ""
 "Några av de importerade recept verkar vara dubbletter. Du kan sammanfoga dem "
 "här, eller stänga denna dialogruta att lämna dem som de är."
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:68
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr "Hitta _dubbletter av recept"
 
-#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr "Hitta och ta bort dubblerade recept"
 
@@ -2247,37 +2248,37 @@ msgid "_Auto-merge"
 msgstr "Slå samman _automatiskt"
 
 #. len(vals)==0
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr "För varje valt värde"
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr "Där %(field)s är %(value)s"
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:168
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] "Ändringarna kommer att påverka %s recept"
 msgstr[1] "Ändringarna kommer att påverka %s recept"
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr "Radera %s när det är %s?"
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:175
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr "Ändra %s från %s till %s?"
 
-#: ../src/gourmand/plugins/field_editor/fieldEditor.py:181
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr "<i>Denna ändring går inte att ångra.</i>"
 
-#: ../src/gourmand/plugins/field_editor/__init__.py:19
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr "Fältredigerare"
@@ -2287,41 +2288,41 @@ msgstr "Fältredigerare"
 msgid "Edit fields across multiple recipes at a time."
 msgstr "Redigera fält i flera recept samtidigt."
 
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:25
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:45
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr "E-posta recept"
 
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:26
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr "E-posta alla utvalda recept (eller alla recept om inga recept välts"
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:49
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr "Vill du verkligen e-posta alla %s utvalda recept?"
 
-#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr "Ja, _e-posta dom"
 
-#: ../src/gourmand/plugins/unit_converter/convertGui.py:115
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Kan inte konvertera %s till %s"
 
-#: ../src/gourmand/plugins/unit_converter/convertGui.py:117
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Behöver uppgift om densitet."
 
-#: ../src/gourmand/plugins/unit_converter/__init__.py:17
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "_Enhetskonverterare"
 
-#: ../src/gourmand/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr "Beräkna enhets-omvandlingar"
 
@@ -2366,32 +2367,32 @@ msgstr "?"
 msgid "HTML Web Page"
 msgstr "HTML-sida"
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Exporterar webbsida"
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Exporterar recept till HTML filer i katalogen %(file)s"
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Receptet sparat som HTML-fil i katalogen %(file)s"
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr "Orginals sida från %s"
 
-#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:645
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:658
-#: ../src/gourmand/exporters/exporter.py:384
-#: ../src/gourmand/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "alternativ"
 
@@ -2399,49 +2400,49 @@ msgstr "alternativ"
 msgid "Epub File"
 msgstr "Epubfil"
 
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr "Exporterar epub"
 
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Exporterar recept som en epub-fil i katalogen %(file)s"
 
-#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Recept sparat som epub %(file)s"
 
 #: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:42
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr "Ren textfil"
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Text export"
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr "Exporterar recept till textfil %(file)s."
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr "Receptet sparat som ren textfil %(file)s"
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:25
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr "Stor fil"
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr "Filen %s är för stor för att importera"
 
-#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2454,25 +2455,25 @@ msgstr ""
 "försök importera igen."
 
 #: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML Fil"
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML Export"
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Exporterar recept till Gourmet XML fil %(file)s."
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Recept sparat i Gourmet XML fil %(file)s."
 
-#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr "Gourmet XML Fil (Föråldrad)"
 
@@ -2488,19 +2489,19 @@ msgstr "Mastercook Text-file"
 msgid "Mastercook import finished."
 msgstr "Mastercook import avslutades."
 
-#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Städar upp XML"
 
-#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr "KRecipe XML Fil"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:60
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr "Kunde inte hitta Adobe Reader på ditt system."
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:61
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2513,11 +2514,11 @@ msgstr ""
 "Installera Adobe Reader från http://get.adobe.com/reader/. \n"
 "Eller ecportera dina recept som PDF och skriv ut dem med en annan PDF-visare."
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:84
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Sidlayout"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:178
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Skriv ut recept"
 
@@ -2525,156 +2526,154 @@ msgstr "Skriv ut recept"
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (Portable Document Format)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF export"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Exporterar recept till PDF %(file)s."
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Recept sparat som PDF %(file)s"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:743
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:762
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:763
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr "poäng"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:837
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:838
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Indexkort (3.5x5\")"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:839
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Indexkort (4x6\")"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Indexkort(5x8\")"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Indexkort (A7)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
 msgid "Letter"
 msgstr "Letter"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:843
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:872
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:885
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Indexkort (9x13 cm)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:873
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:886
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Indexkort (10x15 cm)"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:887
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Indexkort (A7)"
 
-#. These two dictionaries are here to be able to store the preferences in the persistent toml file.
-#. This allows us to have a locale-agnostic GUI.
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:880
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1021
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
 msgid "Plain"
 msgstr "Normal"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
 msgid "2 Columns"
 msgstr "2 spalter"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
 msgid "3 Columns"
 msgstr "3 spalter"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:870
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
 msgid "4 Columns"
 msgstr "4 spalter"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:871
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:884
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
 msgid "5 Columns"
 msgstr "5 spalter"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:876
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] "%s Spalt"
 msgstr[1] "%s Spalter"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:891
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1025
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1056
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
 msgid "Portrait"
 msgstr "Stående"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:892
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1007
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1054
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
 msgid "Landscape"
 msgstr "Liggande"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:920
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr "Pappers_storlek"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:926
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Orientering"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:932
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "_Sidutkast"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:938
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
 msgid "_Font Size"
 msgstr "_Typsnittsstorlek"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:941
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Vänstermarginal"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:942
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Högermarginal"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:943
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Övre marginal"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:944
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Nedre marginal"
 
-#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:957
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr "PDF inställningar"
 
@@ -2683,22 +2682,22 @@ msgstr "PDF inställningar"
 msgid "MealMaster file"
 msgstr "MealMaster fil"
 
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster export"
 
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Exporterar recept till MealMaster fil %(file)s."
 
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Recept sparat som MealMaster fil %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr "%s portion"
@@ -2707,7 +2706,7 @@ msgstr "%s portion"
 msgid "MCB File"
 msgstr "MCB-fil"
 
-#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr "My CookBook MCB-fil"
 
@@ -2732,31 +2731,31 @@ msgstr "Inköpslistspararen"
 
 #. name
 #. stock
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr "Spara listan som recept"
 
 #. text
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr "<Ctrl><Shift>S"
 
 #. key-command
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr "Spara inköpslistan som recept för använding i framtiden"
 
 #. print rr
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr "Meny för %s (%s)"
 
-#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Meny"
 
-#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:35
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr "Näringsvärde reflekterar mängd per %s."
@@ -2765,29 +2764,25 @@ msgstr "Näringsvärde reflekterar mängd per %s."
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr "Näringsvärde speglar mängden för hela receptet"
 
-#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:41
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr "Näringsinformation saknas för %s ingredienser: %s"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Vilken somhelst matgrupp"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "val"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "ml"
-
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Konvertera enhet för %s"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
 "In order to calculate nutritional information, Gourmand needs you to help it "
@@ -2796,12 +2791,12 @@ msgstr ""
 "För att beräkna näringsvärdet behöver Gourmand din hjälp för att konvertera "
 "\"%s\" till en enhet den förstår."
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr "Ändra ingrediensnyckel"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2810,28 +2805,28 @@ msgstr ""
 "Ändra ingrediensnyckel från %(old_key)s till %(new_key)s på alla ställen i "
 "detta recept %(title)s?"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Ändra _överallt"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Bara i recept %s"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 "Ändra ingrediensnyckel från %(old_key)s till %(new_key)s på alla ställen?"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Byt enhet"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2840,7 +2835,7 @@ msgstr ""
 "Ändra enhet från %(old_unit)s till %(new_unit)s för alla ingredienser "
 "%(ingkey)s eller bara i detta recept %(title)s?"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
@@ -2853,29 +2848,29 @@ msgstr ""
 "fler beskrivningar för denna mat med olika densiteter. Vänligen välj det "
 "korrekta alternativet nedan."
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
 "To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "För att lägga till näringsvärden, behöver Gourmand en giltig mängd och enhet."
 
-#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr "Näring"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Ingrediens"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "USDA databas motsvarighet"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 gram"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalorier"
 
@@ -2883,167 +2878,167 @@ msgstr "Kalorier"
 msgid "Total Fat"
 msgstr "Total mängd fett"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Mättat fet"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Kolesterol"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Natrium"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:23
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Totala kolhydrater"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:25
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Kostfiber"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Socker"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Protein"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfakaroten"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "Kol"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Betakaroten"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "beta crytptoxanthin"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Kalcium"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Koppar"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "Vitamin B9 Totalt"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Folsyra"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "Vitamin B9 i mat"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "Motsvarighet till kostrelaterad folsyra"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Järn"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Lykopen"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:58
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "Lutein + Zeaxantin"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:60
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnesium"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:62
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangan"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:64
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Nikotinsyra"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:66
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Pantotensyra"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:68
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfor"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Kalium"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:72
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "A vitamin"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:74
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Retinol"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:76
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Riboflavin"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:78
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selen"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:80
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Tiamin"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:82
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Vitamin A (IU)"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Vitamin A (RAE)"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:86
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Vitamin B6"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:88
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Vitamin B12"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:90
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Vitamin C"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:92
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Vitamin E"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:94
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Vitamin K"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Zink"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:205
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitaminer och mineraler"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:314
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3052,11 +3047,11 @@ msgstr ""
 "Saknar information om näringsvärden\n"
 "för %(missing)s av %(total)s ingredienser."
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:330
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Dagligt intag"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:374
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3065,19 +3060,19 @@ msgstr ""
 "Procent av rekommenderat dagligt intag baserat på %i kalorier per dag. "
 "Klicka för att ändra antalet kalorier per dag."
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:464
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr "Belopp per %s"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:466
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Mängd per recept"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
@@ -3088,344 +3083,344 @@ msgstr "Mängd per recept"
 msgid "Loading Nutritional Data"
 msgstr "Laddar näringsdata"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Färdig med Import av näringsdatabas!"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Hämtar näringsdatabas från zip-arkiv %s"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Extraherar %s från zip-arkiv."
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Går igenom näringsvärden..."
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Läser näringsvärden: importerat %s of %s poster."
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Går igenom viktvärden..."
 
-#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr "Läser vikt data för närings-saker: importerat %s av %s värden"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Vatten"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalorier"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "g protein"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "g lipid"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "g natriumkarbonat"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g kolhydrater"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "g fibrer"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g socker"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg kalcium"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg järn"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnesium"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosfor"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg kalium"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg natrium"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg zink"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg koppar"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg mangan"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mikrogram selen"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "mg vitamin c"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "mg tiamin"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "mg riboflavin"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "mg niacin"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "mg vitamin B5"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "mg vitamin B6"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "mikrogram folat sammanlagt"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "mikrogram folsyra"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "mg vitamin B9"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "mikrogram folsyra"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr "Kolin"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "mikrogram Vitamin B12"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "Vitamin A IU"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Vitamin A (mikrogram Retinol)"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "mikrogram retinol"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "migrogram alfakaroten"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "mikrogram betakaroten"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "mikrogram beta cryptoxanthin"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "mikrogram lykopen"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "mikrogram lutein+zeaxantin"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "mg Vitamin E"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "mg Vitamin K"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "g mättade fettsyror"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "g omättade fettsyror"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "g fleromättade fettsyror"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg kolesterol"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Procent avfall"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Mjölk och äggprodukter"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Kryddor & Örter"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Barnmat"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Fett och oljor"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Höns"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Soppor och såser"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Korvar & Kött till lunch"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Frukostflingor"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Frukter och fruktjuicer"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "Fläsk"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Grönsaker"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Nötter & Frön"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Nöt"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Drycker"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Fisk & Skaldjur"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Ärtväxter"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Lamm, Kalvkött & Vildt"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Bakat"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Sötsaker"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Spannmål & Pasta"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Snabbmat"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Måltider, Förrätter, och Sidorätter"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Tilltugg"
 
-#: ../src/gourmand/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Etniska maträtter"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr "hela databasen"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr "ingrediensnyckel"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr "USDA idnummer"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr "USDA Beskrivning"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr "Densitet motsvarande"
 
-#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr "USDA idnummer"
 
-#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3443,7 +3438,7 @@ msgstr "Verktyg"
 msgid "Get nutritional information for current list"
 msgstr "Få näringsinformation för aktuell lista"
 
-#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr "Belopp för inköpslista"
 
@@ -3451,85 +3446,85 @@ msgstr "Belopp för inköpslista"
 msgid "Edit _nutritional info"
 msgstr "Redigera _näringsinformation"
 
-#: ../src/gourmand/exporters/exporter.py:211
-#: ../src/gourmand/exporters/exporter.py:213
-#: ../src/gourmand/exporters/exporter.py:532
-#: ../src/gourmand/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "stjärnor"
 
-#: ../src/gourmand/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Exporterade %(number)s av %(total)s recept"
 
-#: ../src/gourmand/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Export klar."
 
-#: ../src/gourmand/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Inkludera receptet i själva meddelandet."
 
-#: ../src/gourmand/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Skicka receptet per e-post som en HTML-bilaga"
 
-#: ../src/gourmand/exporters/recipe_emailer.py:131
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr "Skicka recept som PDF-bilaga med Epost"
 
-#: ../src/gourmand/exporters/recipe_emailer.py:148
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Epostinställningar"
 
-#: ../src/gourmand/exporters/recipe_emailer.py:151
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Fråga inte före e-post skickas."
 
-#: ../src/gourmand/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Eposten skickades inte"
 
-#: ../src/gourmand/exporters/recipe_emailer.py:171
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 "Du har inte valt att inkludera receptet i meddelandet eller som bilaga."
 
-#: ../src/gourmand/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Spara recept som..."
 
-#: ../src/gourmand/exporters/exportManager.py:62
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet kan inte exportera filer av typen \"%s\""
 
-#: ../src/gourmand/exporters/exportManager.py:105
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Exportera recept"
 
-#: ../src/gourmand/exporters/exportManager.py:108
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "recept"
 
-#: ../src/gourmand/exporters/exportManager.py:122
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Kan inte exportera: okänd filtyp \"%s\""
 
-#: ../src/gourmand/exporters/exportManager.py:123
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr "Se till att välja en filtyp i rullgardinsmenyn när du sparar."
 
-#: ../src/gourmand/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Exportera"
 
-#: ../src/gourmand/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr "Recepten exporterades till <a href=\"file:///%s\">%s</a>"
@@ -3539,143 +3534,143 @@ msgstr "Recepten exporterades till <a href=\"file:///%s\">%s</a>"
 msgid "Unable to print: no print plugins are active!"
 msgstr "Det går inte att skriva ut: inga utskriftstillägg är aktiva!"
 
-#: ../src/gourmand/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "Skriv ut %s recept"
 msgstr[1] "Skriv ut %s recept"
 
-#: ../src/gourmand/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr "avkastning"
 
-#: ../src/gourmand/importers/importManager.py:63
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Öppna recept..."
 
-#: ../src/gourmand/importers/importManager.py:64
+#: ../src/gourmand/importers/importManager.py:61
 msgid "Enter a recipe file path or website address."
 msgstr "Ange adressen till receptfil eller hemsidan."
 
-#: ../src/gourmand/importers/importManager.py:65
+#: ../src/gourmand/importers/importManager.py:62
 msgid "Location:"
 msgstr "Plats:"
 
-#: ../src/gourmand/importers/importManager.py:66
+#: ../src/gourmand/importers/importManager.py:63
 msgid "Enter the address of a website or recipe archive."
 msgstr "Ange adressen till hemsidan eller receptarkiv."
 
-#: ../src/gourmand/importers/importManager.py:140
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "Importera"
 
-#: ../src/gourmand/importers/importManager.py:191
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Alla importerade filer"
 
-#: ../src/gourmand/importers/plaintext_importer.py:43
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Importerade %s recept."
 
-#: ../src/gourmand/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] "portion"
 msgstr[1] "portioner"
 
-#: ../src/gourmand/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Importerade %s av %s recept."
 
-#: ../src/gourmand/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "okej"
 
-#: ../src/gourmand/importers/interactive_importer.py:44
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Portioner"
 
-#: ../src/gourmand/importers/interactive_importer.py:46
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr "Undergrupp av ingredienser"
 
-#: ../src/gourmand/importers/interactive_importer.py:47
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Dölj"
 
-#: ../src/gourmand/importers/interactive_importer.py:59
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr "Text"
 
-#: ../src/gourmand/importers/interactive_importer.py:61
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr "Åtgärder"
 
-#: ../src/gourmand/importers/interactive_importer.py:107
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr "Importera recept"
 
-#: ../src/gourmand/importers/interactive_importer.py:153
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr "Rensa _taggar"
 
-#: ../src/gourmand/importers/interactive_importer.py:194
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr "Importera recept"
 
-#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:55
-#: ../src/gourmand/recindex.py:492
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr "alltid"
 
-#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:56
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "titel"
 
-#: ../src/gourmand/recindex.py:48 ../src/gourmand/recindex.py:57
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "ingrediens"
 
-#: ../src/gourmand/recindex.py:49 ../src/gourmand/recindex.py:61
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "instruktioner"
 
-#: ../src/gourmand/recindex.py:50 ../src/gourmand/recindex.py:62
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "anteckningar"
 
-#: ../src/gourmand/recindex.py:52 ../src/gourmand/recindex.py:59
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "matkultur"
 
-#: ../src/gourmand/recindex.py:53 ../src/gourmand/recindex.py:60
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "källa"
 
-#: ../src/gourmand/recindex.py:102
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr "Använd reguljära uttryck i sökningen"
 
-#: ../src/gourmand/recindex.py:103
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr "Använd reguljära uttryck (ett avancerat sökspråk) i textsökningen"
 
-#: ../src/gourmand/recindex.py:108
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr "Sök medans du skriver (stäng av om sökningen är för långsam)."
 
-#: ../src/gourmand/recindex.py:112
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr "Visa sök_inställningar"
 
-#: ../src/gourmand/recindex.py:113
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr "Visa avancerade sökinställningar"
 
-#: ../src/gourmand/recindex.py:282
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3684,48 +3679,48 @@ msgstr[1] "%s recept"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmand/recindex.py:290
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Visar recept %(bottom)s till %(top)s av %(total)s"
 
-#: ../src/gourmand/recindex.py:493
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr "%s i %s"
 
-#: ../src/gourmand/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr "Pausad"
 
-#: ../src/gourmand/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] "Receptet importerades lyckligt"
 msgstr[1] "Recepteten importerades lyckligt"
 
-#: ../src/gourmand/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr "Importen misslyckades"
 
-#: ../src/gourmand/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr "Pausa"
 
-#: ../src/gourmand/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr "Klar"
 
-#: ../src/gourmand/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr "Fel: %s"
 
-#: ../src/gourmand/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr "Fel"
 
-#: ../src/gourmand/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr "Fel %s: %s"
@@ -3734,53 +3729,47 @@ msgstr "Fel %s: %s"
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmand/convert.py:106 ../src/gourmand/convert.py:605
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "sekund"
 msgstr[1] "sekunder"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmand/convert.py:108
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "min"
 
-#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:604
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
 msgstr[1] "minuter"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmand/convert.py:110
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "tim."
 
-#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:603
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "timme"
 msgstr[1] "timmar"
 
-#: ../src/gourmand/convert.py:111 ../src/gourmand/convert.py:602
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
 msgstr[1] "dagar"
 
-#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:601
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "vecka"
 msgstr[1] "veckor"
 
-#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:600
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "månad"
@@ -3789,7 +3778,7 @@ msgstr[1] "månader"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:599
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "år"
@@ -3801,26 +3790,26 @@ msgstr[1] "år"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmand/convert.py:649
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " och "
 
-#: ../src/gourmand/convert.py:649
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmand/convert.py:651
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmand/convert.py:782
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "och"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmand/convert.py:804
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "till"
 
@@ -4001,6 +3990,9 @@ msgstr ""
 "Använd detta om dina utf-16 textfiler inte importeras rent i Gourmand. Stäng "
 "av om du inte använder utf-16 och du ständigt irriteras av \"kodning\"s "
 "dialogen när du importerar filer."
+
+#~ msgid "ml"
+#~ msgstr "ml"
 
 #~ msgid "Open _Trash"
 #~ msgstr "Öppna papperskorgen"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-08 06:21+0000\n"
 "Last-Translator: Manatsawin Hanmongkolchai <Unknown>\n"
 "Language-Team: Thai <th@li.org>\n"
@@ -19,506 +19,508 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "ส่วนผสมใหม่"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "เพิ่มไปยังรายการซื้อของ"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "ไฟล์"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "สูตร"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "รายละเอียด"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "รายการซื้อของ"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "ลบสูตร"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "ลบสูตรที่เลือก"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "สูตร"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -526,31 +528,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -559,285 +561,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -852,651 +855,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "รายการซื้อของ"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "แก้ไข"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "ช่วยเหลือ"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "เพิ่มไปยังรายการซื้อของ"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1508,445 +1462,428 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Manatsawin Hanmongkolchai https://launchpad.net/~whs\n"
 "  Peerumporn Jiranantanagorn https://launchpad.net/~peerumporn"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "ลบสูตรที่เลือก"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "พิมพ์"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "สูตร"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "ลบสูตร"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "สูตร"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "การกระทำ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "เกี่ยวกับ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "เครื่องมือ"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "ตัวจับเวลา"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1954,12 +1891,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1967,78 +1904,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2047,386 +1984,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "ไม่มี"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "ตัวแปลงหน่วย"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2434,81 +2359,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2517,881 +2415,898 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "ไฟล์"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3405,288 +3320,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3695,102 +3564,96 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3799,7 +3662,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3811,69 +3674,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3883,7 +3707,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3896,44 +3719,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3944,14 +3747,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4005,22 +3800,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-04-09 13:53+0000\n"
 "Last-Translator: Hasan Yılmaz <iletisim@hasanyilmaz.net>\n"
 "Language-Team: Turkish <tr@li.org>\n"
@@ -20,507 +20,510 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Yeni Tarif"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "_Alışveriş listesine ekle"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "Dosya"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "tarif"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Ayrıntılar"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gourmet Tarif Yöneticisi"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "Zamanlayıcıyı göster"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Alış veriş Listesi"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Başlık"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "kategori"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Yemek Tarifi"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Malzeme"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "_Tarifi Sil"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Seçili yemek tarifini Aç"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "tarif"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -528,31 +531,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Kategori"
 
@@ -561,285 +564,287 @@ msgstr "Kategori"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Anahtar"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Kronometre"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "birim"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet Tarif Yöneticisi"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -854,205 +859,165 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Windows'a taşıma yardımcısı)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (Birim Çevirici ara yüzünde iyileştirmeler)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born ( Mealmaster dışa aktarmada iyileştirmeler)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "Veritabanı güncelleniyor"
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr "Ayrıntılar"
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Yeni Tarif"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr "Ayrıntılar"
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "Alışveriş listesi"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Kategori giriniz"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "%s'ye eklenecek kategori"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "_Değiştir"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "Yardım"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 "Hiçbir tarif seçilmedi. Tüm listeyi temizlemek istediğinizten emin misiniz?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Alışveriş listesini farklı kaydet..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1061,204 +1026,200 @@ msgstr ""
 "eklemek istediğinizi belirleyiniz."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Yemek tarifi"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "_Git"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr "Yemek tarifi dışarı çıkar"
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr "Yemek tarifi _sil"
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "_Alışveriş listesine ekle"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "Değişiklikleri kaydetmediniz."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Yazdırmadan önce değişiklikler uygulansın mı?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Yazdırmadan önce değişiklikler uygulansın mı?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Seçimlik)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr "Düzenle"
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr "Grup ekle"
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr "Dosyadan içeri aktar"
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr "Sil"
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr "Aşağı"
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "İç malzemelistenizi içeren dosyayı seçiniz."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr "Açıklama"
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Talimatlar"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Notlar"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Mik"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Birim"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Madde"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Seçmeli (Zorunlu değil)"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Tarif %s (ID %s) veri tabanında yok."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "%(amt) %(unit) çevrildi"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Çevrilmedi: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Değişmiş birim."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1267,244 +1228,243 @@ msgstr ""
 "%(kalem)s için %(eski)s den %(yeni)ye kadar birimi değiştirdiniz. Miktarın "
 "çevrilmesini istiyor veya istemiyor musunuz?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 "%(eski_mik)s %(eski_birim)s den %(yeni_mik)s %(yeni_birim)s'e kadar çevrildi"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "%(eski_birim den)s %(yeni_birim e)s çevirme yapılamadı"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Malzeme grubu ekleniyor"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Malzemenin yeni alt grubu için bir isim giriniz"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Tarif kendisini malzeme olarak alamaz!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Tariflerde sonsuz döngüye izin verilmez!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Hiçbir tarif seçmediniz!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Tarifler"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr "Eklentiler"
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
-msgstr ""
+#: ../src/gourmand/plugin_gui.py:39
+#, fuzzy
+msgid "Plugins add extra functionality to Gourmand."
+msgstr "Gourmet'ye ek özellikler katan eklentileri yönet"
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "veya"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Yemek"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Değerleme"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Kaynak"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "Web sitesi"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Hazırlama süresi"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Pişirme süresi"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Değişiklikler"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Geçesiz giriş."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Durakla"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Dur"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Bunu bana tekrar sorma."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Bunu yapmayı gerçekten istiyor musunuz?"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "iyi"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Hiçbir dosya seçilmedi"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Dosya _tipi seç"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Hiçbir dosya seçilmediği için eylem iptal edildi"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr "Özür dilerim, \"%s\" miktarı anlaşılamadı."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1516,84 +1476,84 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "un, genel amaçlı"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "şeker"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "tuz"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "karabiber, çekilmiş"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "buz"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "su"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "yağ, bitkisel"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "yağ, zeytin"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Tarif kend kendini iç malzeme olarak dahil ediyor."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "İç malzemesi %s göz  önüne alınmadı."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "%s için alış veriş listesi"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Aşağıdaki tarifler için:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Aşağıdaki tarifler için:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Karakter seti seç"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1601,29 +1561,28 @@ msgstr ""
 "Uygun karakter seti belirlenemedi. Lütfen aşağıdaki listeden doğru karakter "
 "setini seçiniz."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "_Dosyayı karakter seti ile gör"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Dıştan alma durakladı"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "İçe aktarmayı durdur"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Yemek Tarif _Fihiristi"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "Alış veriş _Listesi"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "çevirmenler\n"
@@ -1636,335 +1595,322 @@ msgstr ""
 "  kayya https://launchpad.net/~kayya\n"
 "  linuxseven https://launchpad.net/~linuxseven"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Kaydedildi!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Değişiklikleri %s kaydet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Dışarıdan alma sürüyor"
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Dışarı verme sürüyor"
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Bir silme işlemi sürüyor"
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Yine de programdan çıkılsın mı?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Çıkmayınız!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "%s tarif (toplam %s tarif içinden) kalıcı olarak silindi"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "Çöp Kutusu"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "Silinmiş tarifleri incele, kalıcı olarak sil ya da geri getir"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Silinmemiş tarifler "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "Seçili tarifler için değer gir"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "Seçili yemek tarifini Aç"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "Yemek tarifini Sil"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Seçili tarifleri sil"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr "Yemek tarifini _dışarı çıkar"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Yazdır"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "tarifler"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "_Yeni"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
-msgstr ""
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Yemek tarifi dışarı çıkar"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "Import recipe from file or page"
 msgstr "Dosyadan içeri al"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr "Websitesi _içeri al"
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "Yemek tarifini Sil"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr "Web sitesinden yemek tarifi al"
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "_Tüm yemek tariflerini dışarı çıkar"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "_Çıkış"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "_Eylemler"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr ""
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "Çöp Kutusu"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "_Tercihler"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "_Eklentiler"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+#, fuzzy
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr "Gourmet'ye ek özellikler katan eklentileri yönet"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Hakkında"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "_Araçlar"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Saat Tutucu"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "Zamanlayıcıyı göster"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Sil %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Silindi"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Başlıksız"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Tarifler temelli silinsin mi?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Tarif temelli silinsin mi?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "<i>%s</i>Tarifi silmek istiyor musunuz?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Aşağıdaki tarifleri silmek istediğinize emin misiniz?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Seçtiğiniz %s tarifleri silmek istediğinize emin misiniz?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Yemek tariflerine bakınız"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "Yemek tarifi Sil"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Yemek Tarif _Fihiristi"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Silinmiş tarif %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Yapıldı!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "İçeriye aktarılıyor..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "anahtar"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "kalem"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Alan"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Değer"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Sayı"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1972,12 +1918,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1985,78 +1931,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2065,387 +2011,375 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Miktar"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Alış veriş kategorisi"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr "Yıldızlar"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Hiç yok"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "%s %s'ye çevrilemedi"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Yoğunluk bilgisine ihtiyaç var"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Birim Çevi_rici"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "zip arşivi yükleniyor"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "zip arşivi açılıyor"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML Web Sayfası"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Web sayfası dışa veriliyor"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Dizindeki %(file) HTML dosyaları olarak dışa aktarılıyor."
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "%(file) Tarif HTML dosyası olarak kaydedildi"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "Seçmeli"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Web sayfası dışa veriliyor"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Dizindeki %(file) HTML dosyaları olarak dışa aktarılıyor."
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "%(file) Tarif HTML dosyası olarak kaydedildi"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Düz metin olarak dışarı ver"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2453,81 +2387,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr "Web sayfası"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr "%s indiriliyor"
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "%s için alış veriş listesi"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML Dosyası"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML olarak dışarı ver."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Tarifler Gourmet XML dosyası olarak dışarı veriliyor."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Tarif Gourmet XML dosyası olarak kaydedildi."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "MasterCook içe aktarımı tamamlandı."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "XML düzenleniyor."
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2536,882 +2443,899 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr "Sayfa Yerleşimi"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Yemek tariflerini yazdır"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "PDF olarak dışarı aktar"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Dikey"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Düz"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr "cm"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Yasal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Yatay"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Düz"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Dikey"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Yatay"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "_Yazıtipi Boyutu"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Sayfa _Düzeni"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "_Yazıtipi Boyutu"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Sol Kenar Boşluğu"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Sağ Kenar Boşluğu"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Üst Kenar Boşluğu:"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Alt Kenar Boşluğu:"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "Porsiyon"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "Dosya"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Dışarıya Aktar"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Tarifler Gourmet XML dosyası olarak dışarı veriliyor."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Tarif Gourmet XML dosyası olarak kaydedildi."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr "Menü"
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr "seçim"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr "mL"
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Birim değiştir"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Kalori"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Sodyum"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Toplam Karbonhidrat"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Şekerler"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Protein"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Alfa-karoten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Beta-karoten"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Kalsiyum"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Bakır"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Demir"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "Likopen"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Magnezyum"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Potasyum"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Selenyum"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Çinko"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Vitaminler ve mineraller"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Su"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Kilokalori"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "g karbonhidratlar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "g şeker"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "mg Kalsiyum"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "mg demir"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "mg magnezyum"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "mg fosfor"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "mg potasyum"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "mg sodyum"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "mg çinko"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "mg bakır"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "mg mangan"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "mikrogram selenyum"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "mg Kolesterol"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Baharatlar & Bitkiler"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Bebek Yemekleri"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Katı ve sıvı yağlar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Kümes hayvanları"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Çorbalar ve Soslar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Kahvaltı Tahıllar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Meyve & Meyve Suları"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Domuz eti"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Kuruyemiş & Tohumlar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Sığır eti"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Içkiler"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Balık & Kabuklu balık"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Bakliyat  Sözlük ad     1. Bakliyat"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Fırında Ürünler"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Şekerleme"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Tahıllar ve Pasta"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Hızlı Gıdalar"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Etnik Yemekler"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3425,289 +3349,244 @@ msgstr "Araçlar"
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "%(total) tarifin %(number)'ı dışa aktarıldı."
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Dışa aktarım tamamlandı."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 "Tarifi e-posta gövde metnine dahil et. (Ne olursa olsun, iyi bir fikir.)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Tarifi HTML Eklentisi olarak E-posta ile gönder"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "E-posta Seçenekleri"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "e-posta göndermeden önce sormayınız."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "e-posta gönderilmedi"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr "Tarifi mesaj gövdesinde eklemediniz veya eklenti olarak seçmediniz."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Tarifi farklı kaydet"
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet \"%s\" türü dosyayı dışarıya veremez"
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Tarifleri dışarı ver"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "tarifler"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr "Dosyaya kaydetme başarısız: bilinmeyen dosya türü \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "Dışarıya Aktar"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "%s tarifi bas"
 msgstr[1] "%s tarifi bas"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "URL Gir:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr "Yemek tarifi aç..."
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Değişiklikler"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr "İçeri al"
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Bütün içe aktarılabilir dosyalar"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "%s tarifin %s i içe aktarıldı."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Porsiyon"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr "Gizle"
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "başlık"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "iç malzeme"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "talimatlar"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "notlar"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "Yemekler"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "kaynak"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3716,98 +3595,92 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "saniye"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "dak."
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "dakika"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "saat"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "saat"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "gün"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hafta"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "ay"
@@ -3815,7 +3688,7 @@ msgstr[0] "ay"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "yıl"
@@ -3826,73 +3699,30 @@ msgstr[0] "yıl"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " ve "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "ve"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML Dosyası"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet Tarif Yöneticisi"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-"Tarifleri düzenle, alışveriş listeleri yarat, beslenmeye ait bilgileri "
-"hesapla, ve daha fazlası"
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3902,7 +3732,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3915,38 +3744,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -3954,6 +3751,18 @@ msgstr "PDF olarak dışarı aktar"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3964,14 +3773,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4025,22 +3826,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4100,6 +3885,74 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Windows'a taşıma yardımcısı)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (Birim Çevirici ara yüzünde iyileştirmeler)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born ( Mealmaster dışa aktarmada iyileştirmeler)"
+
+#~ msgid "Upgrading database"
+#~ msgstr "Veritabanı güncelleniyor"
+
+#~ msgid "Import from file"
+#~ msgstr "Dosyadan içeri aktar"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "İç malzemelistenizi içeren dosyayı seçiniz."
+
+#~ msgid "No file selected"
+#~ msgstr "Hiçbir dosya seçilmedi"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Hiçbir dosya seçilmediği için eylem iptal edildi"
+
+#~ msgid "Import _webpage"
+#~ msgstr "Websitesi _içeri al"
+
+#~ msgid "Import recipe from webpage"
+#~ msgstr "Web sitesinden yemek tarifi al"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "zip arşivi yükleniyor"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "zip arşivi açılıyor"
+
+#~ msgid "Webpage"
+#~ msgstr "Web sayfası"
+
+#, python-format
+#~ msgid "Downloading %s"
+#~ msgstr "%s indiriliyor"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "%s için alış veriş listesi"
+
+#~ msgid "ml"
+#~ msgstr "mL"
+
+#~ msgid "Enter URL:"
+#~ msgstr "URL Gir:"
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML Dosyası"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet Tarif Yöneticisi"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr ""
+#~ "Tarifleri düzenle, alışveriş listeleri yarat, beslenmeye ait bilgileri "
+#~ "hesapla, ve daha fazlası"
+
 #~ msgid "_Python Console"
 #~ msgstr "_Python Uçbirimi"
 
@@ -4123,9 +3976,6 @@ msgstr ""
 
 #~ msgid "There was an error launching the url: %s"
 #~ msgstr "URL açılırken bir hata oluştu: %s"
-
-#~ msgid "Select File_type"
-#~ msgstr "Dosya _tipi seç"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "%s isimli dosya zaten var"

--- a/po/uk.po
+++ b/po/uk.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-05-22 11:19+0000\n"
 "Last-Translator: Sergey Panasenko <Unknown>\n"
 "Language-Team: Russian <>\n"
@@ -18,511 +18,514 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "_Новий рецепт"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "Додати до _Списку покупок"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "_Файл"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "рецепт"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "_Детальніше"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gourmet менеджер рецептів"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "Список покупок"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "Назва"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "категорія"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "Рецепт"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "Інгредієнти"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "Ви_далити рецепт"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "Видалити вибрані рецепти"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "%s рецепт"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -530,31 +533,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "Категорія"
 
@@ -563,286 +566,288 @@ msgstr "Категорія"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "Ключ"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "Таймер"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "од.вим."
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet менеджер рецептів"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 #, fuzzy
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -865,206 +870,164 @@ msgstr ""
 "Гурман підтримує причеплення зображень до рецепту, може розраховувати "
 "харчову інформацію для рецепту, базуючись на інформації про інгредієнти."
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Windows-версія)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows установщик)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (покращення для інтерфейсу конвертера величин)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (покращення для експорту в Mealmaster)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (логотип і заставка)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (іконки харчів та додати-у-лист-покупок)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-"Simon Darlington <simon.darlington@gmx.net> (вдосконалення  "
-"інтернаціоналізації, багато виправлень)"
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "Новий рецепт"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "Перемістити до _списку покупок"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "_Список покупок"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "Вже маєм (з _комори)"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "Введіть категорію"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr "Категоря для додавання %s"
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "Категорія:"
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "_Рецепти"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "Видалити рецепт"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "Видалити рецепти з списку покупок"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "Р_едагувати"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "До_помога"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "Жодного рецепту не вибрано. Ви хочете очистити весь список?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "Зберегти список покупок як..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
@@ -1073,204 +1036,200 @@ msgstr ""
 "включити до списку покупок."
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "_Рецепт"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "Роздрукувати рецепт"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "Додати до _Списку покупок"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "У вас є незбережені зміни."
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "Зберегти зміни, перед роздрукуванням?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "Зберегти зміни, перед роздрукуванням?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(Необов'язково)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "Не можу знайти рецепт %s у базі даних."
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "Редагувати рецепт"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "Показати рецепт"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "Оберіть файл який містить список інгредієнтів."
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "Вказівки"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "Нотатки"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Клк."
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "Од. вим."
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "Елемент"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "Необов'язково"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "Рецепт %s (ID %s) не знайдено в нашій базі даних."
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "Перераховано: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "Не перераховано: %(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "Змінено од.вим."
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
@@ -1279,231 +1238,229 @@ msgstr ""
 "Ви змінили одиниці вимірювання для %(item)s з %(old)s на %(new)s. Ви хочете "
 "перерахувати кількість?"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "Пререховано %(old_amt)s %(old_unit)s на %(new_amt)s %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "Не можу перерахувати з %(old_unit)s до %(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "Додавання групи інгредієнтів"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "Введіть ім'я для нової підгрупи інгредієнтів"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr "Ім'я групи:"
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "Рецепт не може включати сам себе як інгредієнт."
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "Бескінечна рекурсія не припустиме в рецептах!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "Ви не вибрали жодного рецепту!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "Рецепти"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "Звук дзвоника"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "Звук попередження"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "Звук помилки"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "Зупинити таймер?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "Зупинити _таймер"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "_Притримати рахування"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "чи"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "Кухня"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "Джерело"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "Час приготування"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "Час готування"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "Варіації"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "Неправильний ввід."
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "Не є числом."
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "_Призупинити"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "_Зупинити"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "Більше про це мене не питати"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "Ви дійсно бажаєте це зробити"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "неперевершено"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "чудово"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "добре"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "середньо"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "погано"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "Перетворити рейтинг до 5 зіркової шкали."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "Конвертувати рейтинг."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "Будь ласка, дайте оцінку рейтингу за шкалою від 1 до 5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "Поточний рейтинг"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "Рейтинг більший за 5 зірок"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "Жодного файлу не вибрано"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "Виберіть _тип файлу"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "Жодного файлу не було вибрано, отже дія була скасована"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1512,12 +1469,12 @@ msgstr ""
 "Я перепрошую, я не розумію\n"
 "кількість \"%s\"."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr "Кількість повинна бути числом, діапазоном чисел, або пустим."
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1537,84 +1494,84 @@ msgstr ""
 "Для введення діапазону чисел, використовуйте знак \"-\".\n"
 "Як зразок, ви можете ввести 2-4 чи  1 1/2 - 3 1/2\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "мука, для всього"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "цукор"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "сіль"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "чорний перець, основа"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "лід"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "вода"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "олія, соняшникова"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "олія, оливкова"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "Невідомо"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "Рецепт включає себе, як інгредієнт."
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "Інгредієнт %s буде проігноровано."
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "Список покупок для %s"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "Для наступних рецептів:"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "Для наступних рецептів:"
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "Виберіть кодировку"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
@@ -1622,29 +1579,28 @@ msgstr ""
 "Неможу визничити правильну кодировку. Будьласка віберіть правильну кодировку "
 "зі списку."
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "Дивитися _файл з кодировкою"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "Імпорт призупинено"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "Зупинити імпорт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "Покажчик рецепт_ів"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "_Список покупок"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -1654,367 +1610,351 @@ msgstr ""
 "  ov3rseer https://launchpad.net/~ov3rseer\n"
 "  svv https://launchpad.net/~skrypnychuk"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "Збережено!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "Зберегти ваші зміни в %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "Йде процес імпорту."
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "Йде процес експорту."
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "Йде процес видалення."
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "Вий з програми в будь-якому разі?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "Не виходити!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "Відновлені рецепти "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr "Різні %s завдяки:"
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "Видалити вибрані рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "_Роздрукуати"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "рецепти"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "Імпортувати рецепт"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s рецепт"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "Дії"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "_Про програму"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "С_ервіс"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "_Таймер"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "Видалити %s?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "Ви маєте незбережені змвни для %s. Ви впевнені, що ви хочете видалити?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "Видалено"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "Без заголовка"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "Видалити рецепти назавжди?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "Видалити рецепт назавжди?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "Ви впевнені, що ви хочете видалити рецепт <i>%s</i>"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "Ви впевнені, що ви хочете видалити ці рецепти?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "Ви впевнені, що ви хочете видалити виділені (%s) рецепти?"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "Дивитися рецепти"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "Покажчик рецепт_ів"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "Видалені рецепти %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "Зроблено!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "Імпорт..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "ключ"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "елемент"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "Поле"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "Значення"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "Кількість"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "Змінити всі ключі з \"%s\" на \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
 "the key \"%s\", you won't be able to distinguish between those items and the "
 "items you are changing now."
 msgstr ""
-"Ви не зможете відмінити цю дію. Якщо вже існують інгредієнти з ключем \"%s"
-"\", Ви не зможете розподілити елементи, які були раніше та ті, що ви "
+"Ви не зможете відмінити цю дію. Якщо вже існують інгредієнти з ключем "
+"\"%s\", Ви не зможете розподілити елементи, які були раніше та ті, що ви "
 "змінюєте зараз."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "Змінити всі елементи з \"%s\" на \"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
 "the item \"%s\", you won't be able to distinguish between those items and "
 "the items you are changing now."
 msgstr ""
-"Ви не зможете відмінити цю дію. Якщо вже існують інгредієнти з елементом \"%s"
-"\", Ви не зможете розподілити елементи, які були раніше та ті, що ви "
+"Ви не зможете відмінити цю дію. Якщо вже існують інгредієнти з елементом "
+"\"%s\", Ви не зможете розподілити елементи, які були раніше та ті, що ви "
 "змінюєте зараз."
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "Змінити _всі приклади \"%(unit)s\" на \"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -2023,12 +1963,12 @@ msgstr ""
 "Змінити \"%(unit)s\" на \"%(text)s\" лише для _інгридіентів \"%(item)s\" з "
 "ключем \"%(key)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr "Змінити всі приклади \"%(amount)s\" %(unit)s на %(text)s %(unit)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2037,7 +1977,7 @@ msgstr ""
 "Змінити \"%(amount)s\" %(unit)s на \"%(text)s\" %(unit)s лише там, де є "
 "інгридіенти з ключем %(key)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2046,11 +1986,11 @@ msgstr ""
 "Змінити \"%(amount)s\" %(unit)s на \"%(text)s\" %(unit)s лише для "
 "інгредієнтів з ключем %(key)s та там, де пункти дорівнюють %(item)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "Змінити всі вибрані рядки?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
@@ -2059,7 +1999,7 @@ msgstr ""
 "Цю дію неможливо виконати. Ви впевнені, що для всіх %s обраних рядків "
 "бажаєте встановити наступні значення:"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2068,7 +2008,7 @@ msgstr ""
 "\n"
 "Ключі до %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2077,7 +2017,7 @@ msgstr ""
 "\n"
 "Елементи до %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2086,7 +2026,7 @@ msgstr ""
 "\n"
 "Одиниця до %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2095,8 +2035,8 @@ msgstr ""
 "\n"
 "Кількість до %s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2106,387 +2046,375 @@ msgstr[2] "%s інгредієнти"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "Показувати інгредієнти %(bottom)s до %(top)s з %(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "Кількість"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "Категорія покупок"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "Пусто"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "Неможу конвертувати %s в %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "Необхідна інформація про консистенцію."
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "Конвертер величин"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "Завантаження zip-архиву"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "Розпакування zip-архіву"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML веб-сторінка"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "Експортування веб-сторінки"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "Експортування рецептів до HTML-файлів у папці %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "Рецепт збережено як HTML-файл %(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "необов'язково"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "Експортування веб-сторінки"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "Експортування рецептів до HTML-файлів у папці %(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "Рецепт збережено як HTML-файл %(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "Експорт в текстовий файл"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2494,81 +2422,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "Список покупок для %s"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "Відновлення %s"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Файл Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Експорт в Gourmet XML"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "Експортування рецептів в Gourmet XML %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "Рецепт збережено в Gourmet XML %(file)s."
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Імпорт у формат Mastercook закінчено."
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "Впорядкування XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2577,106 +2478,119 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "Роздрукувати рецепти"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF (переносимий формат документів)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr "Експорт у PDF"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr "Рецепт експортовано у PDF %(file)s."
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr "Рецепт збережено як PDF %(file)s"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "Лист"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr "Книжкова"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr "Портрет"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Облікова картка (3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr "Облікова картка (4x6\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr "Облікова картка (5x8\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr "Облікова картка (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "Лист"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr "Legal"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr "Облікова картка (3.5x5)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr "Облікова картка (4x6)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr "Облікова картка (A7)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
-msgstr "Ланшафт"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
+msgstr "Портрет"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+#, fuzzy
+msgid "2 Columns"
+msgstr "%s стовпець"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+#, fuzzy
+msgid "3 Columns"
+msgstr "%s стовпець"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+#, fuzzy
+msgid "4 Columns"
+msgstr "%s стовпець"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+#, fuzzy
+msgid "5 Columns"
+msgstr "%s стовпець"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
@@ -2684,168 +2598,176 @@ msgstr[0] "%s стовпець"
 msgstr[1] "%s стовпця"
 msgstr[2] "%s стовпців"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr "Книжкова"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr "Ланшафт"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "_Оріентація"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "Розмір _шрифту"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr "Формат _сторінки"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "Розмір _шрифту"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "Поле зліва"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "Поле справа"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "Поле зверху"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "Поле знизу"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "Файл для MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "Експорт до MealMaster"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "Експортування рецептів до файлу для MealMaster %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "Рецепт збережено як файлу для MealMaster %(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "Порцій"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "_Файл"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "Експорт у PDF"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "Експортування рецептів в Gourmet XML %(file)s."
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "Рецепт збережено в Gourmet XML %(file)s."
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "Будь-яка група їжі"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "Змінити одиницю для %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "Для того, щоб підрахувати харчову інформацію, Гурману необхідно допомогти "
 "конвертувати \"%s\" у одиниці, які він розуміє."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2854,27 +2776,27 @@ msgstr ""
 "Змінити ключ інгредієнту з %(old_key)s на %(new_key)s для всіх, чи лише у "
 "рецепті %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "Змінити _всюди"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "_Лише у рецепті %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "Змінити одиницю"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
@@ -2883,11 +2805,11 @@ msgstr ""
 "Змінити одиницю з %(old_unit)s на %(new_unit)s для всіх інгредієнтів "
 "%(ingkey)s, чи лише у рецепті %(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2896,198 +2818,199 @@ msgstr ""
 "інформації має декілька варіантів густини (щільності) для цього продукту."
 "Будь ласка, оберіть вірний з запропонованих."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 "Для підрахунку дієтетичної інформації Гурману потрібні вірні кількість та "
 "одиниця."
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "Складові"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "Еквівалент бази даних USDA"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 грам"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "Кілокалорії"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "Всього жирів"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "Насичені жири"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "Холестерин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "Натрій"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "Всього вуглеводнів"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "Клітковина"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "Цукри"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "Білок"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "Альфакарротин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "Бетакарротин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "Бета Кріптоксантин"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "Кальцій"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "Мідь"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "Фолієва кислота"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "Залізо"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "Магній"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "Марганець"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "Нікотинова кислота"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "Пантотенова кислота"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "Фосфор"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "Калій"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "Вітамін А"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "Ретинол"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "Рибофлавін"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "Селен"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "Тиамін"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "Вітамін А (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "Вітамін А (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "Вітамін B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "Вітамін B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "Вітамін C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "Вітамін E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "Вітамін K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "Цинк"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "Вітаміни та мінерали"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3096,11 +3019,11 @@ msgstr ""
 "Відсутня харчова інформація\n"
 "для %(missing)s з %(total)s інгредієнтів."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "% _Денна норма"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
@@ -3109,368 +3032,368 @@ msgstr ""
 "Відсоток від рекомендованого значення денної норми у %i калорій на день. "
 "Натисніть. для того, щоб змінити кількість калорій на день."
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "Кількість на рецепт"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Завантажується харчова інформація"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "Імпорт дієтної бази даних завершено!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "Витяг харчової бази даних з zip-архіву %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "Витяг %s з zip-архіву."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "Аналіз харчової інформації..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "Читання харчової інформації: імпортовано %s з %s позицій."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "Аналіз вагової інформації..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 "Читання вагової інформації для харчових одиниць: імпортовано %s з %s записів"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "Вода"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "Кілокалорій"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "грам білка"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "грам ліпіду"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "грам поташу"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "грам вуглеводів"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "грам грубих волокон"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "грам цукру"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "мг кальцію"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "мг заліза"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "мг марганцю"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "мг фосфору"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "міліграм калія"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "міліграм натрія"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "міліграм цінку"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "міліграм міді"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "міліграм марганцу"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "міліграм селену"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "мг. вітаміну С"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "міліграм тіаміну"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "мг рибовлавіну"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "міліграм нікотинової кислоти"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "міліграм пантотенової кіслоти"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "міліграм вітаміну B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "мікрограм фолієвої кислоти"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "мікрограм харчового фолату"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "мікрограм дієтичного еквіваленту фолату"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "мікрограм вітаміну B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "вітаміну A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "Вітамін A (мікрограм RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "мікрограм ретинола"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "мікрограм Альфа-каротину"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "мікрограм Бета-каротину"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "мікрограм бета-кріптосаніну"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "мікрограм лікопіну"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "Мікрограм Лютеїну+Зезантину"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "міліграм вітаміну E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "міліграм вітаміну K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "грам насичених жирних кислот"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "грам мононасичених жирних кислот"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "грам полінасичених жирних кислот"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "міліграм холестерину"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "Відсоток відходів"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "Молочні продукти та яйця"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "Спеції та зелень"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "Дитяче харчування"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "Жири та Рослинні олії"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "Птиця"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "Супи та соуси"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "Ковбаси та бутербродне мясо"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "Хліб до сніданку"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "Фрукти та фруктові соки"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "свинина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "Овочі"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "Горіхи та насіння"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "Яловичина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "Напої"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "Риба та морепродукти"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "Боби"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "Баранина, телятина та дичина"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "Печені продукти"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "Солодощі"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "Крупи та макарони"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "Фастфуд"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "Їжа,закуски та блюда"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "Закуски"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "Національна кухня"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3484,107 +3407,107 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "зірок"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "Експортовано %(number)s з %(total)s рецептів"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "Експорт закінчено."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "Включити рецепт в текст ел. листа (найкращий варіант)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "Послати рецепт ел. поштою як HTML-прикріплення"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "Настроювання ел. пошти"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "Не питати перед відправкою ел. пошти."
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "Електронного листа не надіслано"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 "Ви не вказали як включити рецепт до листа, як текст листи чи як прикріплення."
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "Зберегти рецепт як..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet не може експортувати тип файлу \"%s\""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "Експорт рецептів"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "рецепти"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
@@ -3592,182 +3515,138 @@ msgstr[0] "Рздрукувати %s рецепт"
 msgstr[1] "Рздрукувати %s рецепти"
 msgstr[2] "Рздрукувати %s рецепти"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "Відновлення файлу"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "Введіть URL архіву рецептів або веб-сайт рецепту."
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "Введіть URL:"
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "Введіть URL архіву рецептів або веб-сайт рецепту."
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "Варіації"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "Всі файли з яких можливий імпорт"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "Імпортовано  %s рецептів."
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "Імпортовано %s з %s рецептів."
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "ОК"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr "Не розпізнав цю сторінку. Використовую стандартний майстер імпорту..."
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "Імпорт завершено."
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "Імпортувати рецепт"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "Обчислення інгредієнтів"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "Обчислення інгредієнтів."
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "Порцій"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "назва"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "інгредієнт"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "вказівки"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "нотатки"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "кухня"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "джерело"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3777,64 +3656,58 @@ msgstr[2] "%s рецепти"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "Показувати рецепти %(bottom)s до %(top)s з %(total)s"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "секунда"
@@ -3842,11 +3715,11 @@ msgstr[1] "секунд"
 msgstr[2] "секунди"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "хв."
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "хвилина"
@@ -3854,32 +3727,32 @@ msgstr[1] "хвилин"
 msgstr[2] "хвилини"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "год."
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "година"
 msgstr[1] "годин"
 msgstr[2] "години"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
 msgstr[1] "днів"
 msgstr[2] "дні"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "тиждень"
 msgstr[1] "тижні"
 msgstr[2] "тижні"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "місяць"
@@ -3889,7 +3762,7 @@ msgstr[2] "місяці"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "рік"
@@ -3902,71 +3775,30 @@ msgstr[2] "роки"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " та "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "і"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "до"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Файл Gourmet XML"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet менеджер рецептів"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3976,7 +3808,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3989,38 +3820,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -4028,6 +3827,18 @@ msgstr "Експорт у PDF"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -4038,14 +3849,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4099,22 +3902,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4174,6 +3961,81 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Windows-версія)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (Windows установщик)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (покращення для інтерфейсу конвертера величин)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (покращення для експорту в Mealmaster)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (логотип і заставка)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (іконки харчів та додати-у-лист-покупок)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (вдосконалення  "
+#~ "інтернаціоналізації, багато виправлень)"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "Оберіть файл який містить список інгредієнтів."
+
+#~ msgid "No file selected"
+#~ msgstr "Жодного файлу не вибрано"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "Жодного файлу не було вибрано, отже дія була скасована"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "Завантаження zip-архиву"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "Розпакування zip-архіву"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "Список покупок для %s"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "Відновлення %s"
+
+#~ msgid "Retrieving file"
+#~ msgstr "Відновлення файлу"
+
+#~ msgid "Enter URL:"
+#~ msgstr "Введіть URL:"
+
+#~ msgid "Don't recognize this webpage. Using generic importer..."
+#~ msgstr ""
+#~ "Не розпізнав цю сторінку. Використовую стандартний майстер імпорту..."
+
+#~ msgid "Import complete."
+#~ msgstr "Імпорт завершено."
+
+#~ msgid "Processing ingredients"
+#~ msgstr "Обчислення інгредієнтів"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "Обчислення інгредієнтів."
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Файл Gourmet XML"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet менеджер рецептів"
+
 #~ msgid "Select recipe image"
 #~ msgstr "Оберіть зображення"
 
@@ -4225,9 +4087,6 @@ msgstr ""
 #~ "Ви бажаєте закрити вікно з активним таймером. Ви можете зупинити таймер "
 #~ "або просто закрити вікно. Якщо Ви просто закроїте його, воно з'явиться "
 #~ "знов, коли закінчиться час таймеру."
-
-#~ msgid "Select File_type"
-#~ msgstr "Виберіть _тип файлу"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "Файл з ім'ям %s вже існує."

--- a/po/yi.po
+++ b/po/yi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-06 19:28+0000\n"
 "Last-Translator: Registry Administrators <Unknown>\n"
 "Language-Team: Yiddish <yi@li.org>\n"
@@ -20,506 +20,506 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+msgid "Copy selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +527,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +560,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,650 +854,601 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 msgid "Add to Shopping List"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1508,444 +1460,424 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Registry Administrators https://launchpad.net/~registry"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+msgid "_Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1953,12 +1885,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1966,78 +1898,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2046,386 +1978,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2433,81 +2353,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2516,880 +2409,897 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3403,288 +3313,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3693,103 +3557,97 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3798,7 +3656,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3810,69 +3668,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3882,7 +3701,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3895,44 +3713,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3943,14 +3741,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4004,22 +3794,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-06 19:29+0000\n"
 "Last-Translator: itsnotvalid <itsnotvalid@gmail.com>\n"
 "Language-Team: Chinese <zh@li.org>\n"
@@ -20,506 +20,508 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "新食譜"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "加到購物清單(_S)"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "文件"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "刪除食譜"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "刪除食譜"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "新食譜"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +529,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +562,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,651 +856,602 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "購物單"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "更改"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "加到購物清單(_S)"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1509,445 +1463,427 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Eddie Chan https://launchpad.net/~eddie-c\n"
 "  itsnotvalid https://launchpad.net/~itsnotvalid"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "刪除食譜"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "刪除食譜"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "執行"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "工具"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1955,12 +1891,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1968,78 +1904,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2048,386 +1984,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "單位轉換器"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2435,81 +2359,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2518,881 +2415,898 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "文件"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3406,288 +3320,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3696,102 +3564,96 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3800,7 +3662,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3812,69 +3674,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3884,7 +3707,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3897,44 +3719,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3945,14 +3747,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4006,22 +3800,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2010-12-14 16:04+0000\n"
 "Last-Translator: grampscn <Unknown>\n"
 "Language-Team: Chinese (China) <zh_CN@li.org>\n"
@@ -22,507 +22,510 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "新食谱(_N)"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "加入购物单"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "文件(_F)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "食谱"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "详细信息(_D)"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gourmet食谱管理软件"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 #, fuzzy
 msgid "Show _toolbar"
 msgstr "显示计时器"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "购物单"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "标题"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "种类"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "食谱"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "原料"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "删除食谱"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "打开选定的食谱"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "打开食谱"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -530,31 +533,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "种类"
 
@@ -563,285 +566,287 @@ msgstr "种类"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr "即时搜索"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "计时器"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "单位"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet食谱管理软件"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -856,639 +861,593 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (Windows porting assistance)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com>(微软视窗安装)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard·Ferguson·(improvements·to·Unit·Converter·interface)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S.·Born·(improvements·to·Mealmaster·export)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> （图标和启动界面）"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr "选择数据库文件"
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr "正在升级数据库"
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr "详细信息"
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "新食谱"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr "详细信息"
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "移动到购物清单(_S)"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "购物单(_S)"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "已经拥有（储物室条目(_P)）"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "输入类目"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr "类目："
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "食谱"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "移除食谱"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "从购物清单中移除食谱"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "编辑(_E)"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "帮助(_H)"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "没有选择食谱。您想清除整个目录吗？"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "令存购物清单为..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "食谱(_R)"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr "转到(_G)"
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "打印食谱"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "加入购物单"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "您有尚未保存的更改。"
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "在打印前应用更改吗？"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "在打印前应用更改吗？"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "（选项）"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "编辑食谱："
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "浏览食谱卡片"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr "添加原料"
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr "将另外一个食谱当原料添加到当前食谱中"
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "选择一个含有您原料列表的文件"
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "做法"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "备注"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "单位"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "条目"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "选项"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "已经改变单位。"
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "食谱不能够作为原料加载自己"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "您还没有选择任何食谱！"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "食谱"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "铃声"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "警告声音"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "声音错误"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "停止计时？"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "停止计时(_t)"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "继续时间(_K)"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "或者"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "烹调法"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "评价"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "源"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr "网址"
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "准备时间"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "烹调时间"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "修改"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "非法输入。"
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "不是一个数字。"
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "暂停"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "停止"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "不要再问我"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "您确认要这么做吗?"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "优秀"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "良好"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "好"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "可以"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "差"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "转换评价到5星级。"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "转换评价。"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "请给每个评价1到5"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "当前的评价"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "评价高出5颗星"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "没有选定文件"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "选择文件类型(_t)"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "没有选定文件，因此操作被取消"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1497,12 +1456,12 @@ msgstr ""
 "对不起，我不能理解\n"
 "这个数量“%s”。"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr "数量必须是数字（分数或者十进制），数字范围，或者空格。"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1514,112 +1473,111 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "糖"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "盐"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "黑胡椒，磨过的"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "冰"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "水"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "植物油"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "橄榄油"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "未知的"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "%s 的购物清单"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "如下的食谱："
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr "如下的食谱："
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "选择编码"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr "不能自动识别代码。请从以下列表中选择正确的代码。"
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "导入暂停"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "停止导入"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "食谱目录(_I)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "购物单"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "翻译人员\n"
@@ -1630,335 +1588,320 @@ msgstr ""
 "  Tao Wei https://launchpad.net/~weitao1979\n"
 "  grampscn https://launchpad.net/~grampscn"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "已经保存！"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "保存您的编辑到 %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "一个导入正在进行中。"
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "一个导出正在进行中。"
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "一个删除正在进行中。"
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "退出程序？"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "不退出！"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr "永久删除%s 从 %s 菜谱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr "垃圾箱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr "浏览、永久删除或取消删除的食谱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "未删除的食谱 "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr "任何现有的定值将不变。"
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr "所有现在的定值将被新的值代替。"
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr "给选定的食谱设值"
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr "寻找食谱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr "打开食谱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr "打开选定的食谱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr "删除食谱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "删除选定的食谱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "打印(_P)"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "食谱"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr "成批编辑食谱 (_e)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr "新建(_N)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
 msgstr "导入文件 (_I)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s 食谱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr "导出所有食谱 (_a)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr "退出 (_Q)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "操作"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
-msgstr "打开垃圾箱 (_T)"
+#: ../src/gourmand/main.py:1025
+#, fuzzy
+msgid "_Trash"
+msgstr "垃圾箱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr "首选项 (_P)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr "插件(_P)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr "设置 (_n)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "关于"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "工具(_T)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "计时器(_T)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr "显示计时器"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "删除 %s ？"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "删除"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "未命名"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "永久删除食谱？"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "永久删除食谱？"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "您确认要删除食谱 <i>%s</i> 吗？"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "您确认要删除一下食谱吗？"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "您确认要删除%s条选择的食谱吗？"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "观看食谱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr "删除食谱"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "食谱目录(_I)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "删除食谱 %s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "完成！"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "输入中..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "条目"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "值"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "计数"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1966,12 +1909,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1979,78 +1922,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2058,387 +2001,375 @@ msgstr[0] "%s 营养"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "数量"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "购物分类"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "没有"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "不能从 %s 转换到 %s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "需要密度信息。"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "单位转换(_U)"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML网页"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "导出网页"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "选项"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "导出网页"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "文本导出"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2446,81 +2377,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "%s 的购物清单"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML文件"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML导出"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Mastercook导入结束。"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "整理XML"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2529,882 +2433,899 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "打印食谱"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr "PDF（Portable 文档格式）"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr "信封"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr "11x17\""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr "Index Card·(3.5x5\")"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr "信封"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr "方向(_O)"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr "字体大小(F)"
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr "字体大小(F)"
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr "左边界"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr "右边界"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr "上边界"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr "下边界"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster文件"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster导出"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "一人份"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "文件(_F)"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "导出"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "任何食物组"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "转换单位为 %s"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "改变单位"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "原料"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100 克"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "卡路里"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "总脂肪"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "饱和脂肪"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "胆固醇"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "钠"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "总碳水化合物"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "食纤维质"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "糖"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "蛋白质"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "α-胡萝卜素"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "灰分"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "β-葫萝卜素"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "β-隐黄质"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "钙"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "铜"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "总叶酸盐"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "叶酸"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "食物叶酸盐"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "铁"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "番茄红素"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "叶黄素+Zeazanthin"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "镁"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "锰"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "烟酸"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "泛酸"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "磷"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "钾"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "维他命 A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "维生素A1"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "核黄素"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "硒"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "硫胺"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "维他命 A (IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "维他命 A (RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "维他命 B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "维他命 B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "维他命 C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "维他命 E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "维他命 K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "锌"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "维他命和矿物质"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "每个食谱的数量"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "营养数据库导入结束！"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "水"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "千卡"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "克蛋白质"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "克脂肪"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "克灰分"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "克炭水化合物"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "克纤维"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "克糖"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "克钙"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "毫克铁"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "毫克镁"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "维他命 A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "毫克维他命 E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "毫克维他命 K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "儿童食物"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "水果和水果汁"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "快餐"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3418,287 +3339,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "星"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "导出结束。"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "电子邮件选项"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "在发送电子邮件前不询问"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "电子邮件没有送出"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "食谱另存为..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "输出食谱"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "食谱"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr "导出"
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr "无法打印：没有打印插件！"
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "打印食谱 %s"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr "输入网址："
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "修改"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "所有可以导入的文件"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "导入了 %s 个食谱。"
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr "好"
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "一人份"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "标题"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "原料"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "做法"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "备注"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "烹调法"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "来源"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3706,97 +3582,91 @@ msgstr[0] "%s 食谱"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "秒"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr "分钟"
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "分钟"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "小时"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "小时"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "周"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "月"
@@ -3804,7 +3674,7 @@ msgstr[0] "月"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"
@@ -3815,71 +3685,30 @@ msgstr[0] "年"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " 和 "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr "， "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "和"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "到"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML文件"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet食谱管理软件"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr "整理食谱、创建购物单、计算营养信息、等等。"
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3889,7 +3718,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3902,38 +3730,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -3941,6 +3737,18 @@ msgstr "导出"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3951,14 +3759,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4012,22 +3812,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4087,6 +3871,56 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (Windows porting assistance)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com>(微软视窗安装)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard·Ferguson·(improvements·to·Unit·Converter·interface)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S.·Born·(improvements·to·Mealmaster·export)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> （图标和启动界面）"
+
+#~ msgid "Upgrading database"
+#~ msgstr "正在升级数据库"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "选择一个含有您原料列表的文件"
+
+#~ msgid "No file selected"
+#~ msgstr "没有选定文件"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "没有选定文件，因此操作被取消"
+
+#~ msgid "Open _Trash"
+#~ msgstr "打开垃圾箱 (_T)"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "%s 的购物清单"
+
+#~ msgid "Enter URL:"
+#~ msgstr "输入网址："
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML文件"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet食谱管理软件"
+
+#~ msgid ""
+#~ "Organize recipes, create shopping lists, calculate nutritional "
+#~ "information, and more."
+#~ msgstr "整理食谱、创建购物单、计算营养信息、等等。"
+
 #~ msgid "Select recipe image"
 #~ msgstr "选择食谱图片"
 
@@ -4110,9 +3944,6 @@ msgstr ""
 
 #~ msgid "There was an error launching the url: %s"
 #~ msgstr "当加载地址：%s时出现错误"
-
-#~ msgid "Select File_type"
-#~ msgstr "选择文件类型(_t)"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "文件名称 %s 已经存在。"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2012-05-10 19:11+0000\n"
 "Last-Translator: Daniel Cheung <daniel.2345@hotmail.com>\n"
 "Language-Team: Chinese (Hong Kong) <zh_HK@li.org>\n"
@@ -19,506 +19,509 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-06-02 11:52+0000\n"
 "X-Generator: Launchpad (build 17031)\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr "新增食譜(_N)"
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr "加入至購物清單(_S)"
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr "檔案(_F)"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr "食譜"
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr "詳細內容(_D)"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
-msgstr ""
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+#, fuzzy
+msgid "Gourmand Recipe Manager Preferences"
+msgstr "Gourmet食譜管理員"
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr "購物清單"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr "標題"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr "類別"
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr "食譜"
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr "材料"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr "刪除食譜(_D)"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+#, fuzzy
+msgid "Copy selected recipe"
+msgstr "刪除已選食譜"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
-msgstr ""
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+#, fuzzy
+msgid "_Copy recipe"
+msgstr "%s 食譜"
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -526,31 +529,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr "分類"
 
@@ -559,285 +562,287 @@ msgstr "分類"
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr "按鍵"
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr "計時器"
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr "單位"
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+#, fuzzy
+msgid "Gourmand Recipe Manager"
 msgstr "Gourmet食譜管理員"
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
+#: ../src/gourmand/__version__.py:4
+msgid ""
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
 msgstr ""
 
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:9
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -852,639 +857,593 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr "Roland Duhaime (視窗連接支援)"
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (視窗安裝)"
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr "Richard Ferguson (單位轉換器界面修飾)"
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr "R.S. Born (Mealmaster輸出改進)"
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr "ixat <ixat.deviantart.com> (標誌及載入圖示設計)"
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr "Yula Zubritsky (營養及購物清單顯示圖)"
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr "Simon Darlington <simon.darlington@gmx.net> (改進國際化及各種錯誤)"
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr "新增食譜"
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr "移動至購物清單(_S)"
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr "購物清單(_S)"
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr "已擁有(餐具室項目(_P))"
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr "輸入類別"
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr "食譜(_R)"
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr "移除食譜"
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr "從購物清單中移除食譜"
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr "編輯(_E)"
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr "說明(_H)"
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr "x"
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr "沒有選擇任何食譜。你要清除整個清單嗎?"
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr "另存購物清單..."
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr "請仔細說明"
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr "食譜(_R)"
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr "列印食譜"
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 #, fuzzy
 msgid "Add to Shopping List"
 msgstr "加入至購物清單(_S)"
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr "你有未儲存的變更。"
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+#, fuzzy
+msgid "Save changes before copying?"
 msgstr "要於列印前應用變更嗎?"
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+#, fuzzy
+msgid "Save changes before printing?"
+msgstr "要於列印前應用變更嗎?"
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr "(自選)"
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr "無法從資料庫尋找%s食譜。"
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr "編製食譜:"
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr "查看食譜卡片"
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr "選擇含有你的材料清單之檔案。"
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr "指示說明"
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr "備註"
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr "Amt"
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr "單位"
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr "項目"
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr "自選"
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr "食譜%s (ID %s)不存在於我們的資料庫。"
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr "已轉換:%(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr "沒被轉換:%(amt)s %(unit)s"
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr "已改變單位。"
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr "你已經把%(item)s的單位由%(old)s變更成%(new)s。你要不要將數量變更﹖"
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr "已把%(old_amt)s %(old_unit)s轉換成%(new_amt)s %(new_unit)s。"
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr "無法把%(old_unit)s轉換成%(new_unit)s"
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr "加入材料類別中"
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr "為新的材料類別輸入一個名稱"
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr "食譜不能將自己當作材料!"
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr "食譜不容許任何無限遞迴!"
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr "你沒有選擇任何食譜!"
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr "食譜"
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr "鬧響聲音"
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr "警告聲響"
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr "錯誤聲響"
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr "停止計時器?"
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr "停止計時器(_T)"
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr "繼續計時(_K)"
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr "或"
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr "菜餚/烹調法"
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr "評分"
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr "来源"
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr "准备时间"
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr "煮食時間"
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr "修改"
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr "不合法輸入。"
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr "不是一个数字。"
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr "暂停(_P)"
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr "停止(_S)"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr "不要再问我。"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr "您确认要这么做吗?"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr "幾乎完美!"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr "良好"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr "好"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr "還可以"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr "差"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr "转换評分準則到五星制度。"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr "转换评分。"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr "请以1至5給予評分。"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr "現時的評分"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr "以五星為最高的評分"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
-msgstr "沒有任何已選檔案"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+#, fuzzy
+msgid "Select File(s)"
+msgstr "選擇檔案類型(_T)"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr "由於沒有任何已選檔案﹐所以動作被取消。"
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
@@ -1493,12 +1452,12 @@ msgstr ""
 "对不起，無法理解\n"
 "这个数量“%s”。"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr "数量必须是数字(分数或者十进制),数字范围,或者空格。"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1518,447 +1477,430 @@ msgstr ""
 "要輸入一系列數字,用“-”來分隔它們。\n"
 "例如:你可以輸入2-4 或 1 1/2 - 3 1/2。\n"
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr "多用途麵粉"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr "糖"
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr "鹽"
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr "黑胡椒粒"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr "冰"
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr "水"
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr "植物油"
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr "橄欖油"
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr "未知"
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr "食譜以自己作為一個材料。"
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr "材料%s將被忽視。"
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr "%s的購物清單"
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 #, fuzzy
 msgid "For the following recipes:\n"
 msgstr "載入食譜中"
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr " x%s"
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr "選擇編碼"
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr "沒法分辨適當編碼。請從下列清單選擇正確的編碼。"
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr "以編碼閱讀檔案(_F)"
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr "載入暫停中"
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr "停止載入"
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr "食譜索引(_I)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr "購物清單(_L)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Daniel Cheung https://launchpad.net/~daniel-2345\n"
 "  rachaiii https://launchpad.net/~rockgirlx13"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr "已儲存!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr "把編輯項目儲存到%s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr "一個載入指令正在进行中。"
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr "一个輸出指令正在进行中。"
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr "一个删除指令正在进行中。"
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr "退出程式？"
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr "不退出！"
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr "取消刪除的食譜 "
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr "刪除已選食譜"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr "列印(_P)"
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+#, fuzzy
+msgid "_Copy recipes"
+msgstr "食譜"
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+#, fuzzy
+msgid "_Import Recipe"
+msgstr "載入食譜中"
+
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
-msgstr ""
+#: ../src/gourmand/main.py:1012
+#, fuzzy
+msgid "Paste recipe"
+msgstr "%s 食譜"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr "操作(_A)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr "關於(_A)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr "工具(_T)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr "計時器(_T)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr "删除%s ？"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr "你有未儲存的變更至%s, 你確定你要刪除﹖"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr "已刪除"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr "未標題"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr "永久刪除食譜﹖"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr "永久刪除食譜﹖"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr "你確定你要刪除食譜<i>%s</i>﹖"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr "你確定你要刪除以下食譜﹖"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr "你確定你要刪除%s的已選食譜﹖"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr "查看食譜"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 #, fuzzy
 msgid "Recipes deleted"
 msgstr "食譜索引(_I)"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr "刪除食譜%s"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr "完成!"
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr "載入中..."
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr "key"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr "項目"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr "範疇"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr "價值"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr "次數"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr "將所有按鍵由\"%s\" 變更成\"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1968,12 +1910,12 @@ msgstr ""
 "你將無法復原此動作。如果其他材料已經有\"%s\"按鍵﹐你將無法識辨那些材料以及你"
 "現在更改的項目。"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr "將所有項目由\"%s\" 變更成\"%s\"?"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1983,12 +1925,12 @@ msgstr ""
 "你將無法復原此動作。如果其他材料已經有\"%s\"項目﹐你將無法識辨那些項目以及你"
 "現在更改的項目。"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr "將所有\"%(unit)s\"的情況 變更至 \"%(text)s\"(_A)"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
@@ -1996,12 +1938,12 @@ msgid ""
 msgstr ""
 "只將擁有按鍵\"%(key)s\"的材料\"%(item)s\" 從\"%(unit)s\" 變更至\"%(text)s\""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr "將所有\"%(amount)s\" %(unit)s的情況變更至%(text)s %(unit)s(_A)"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
@@ -2010,7 +1952,7 @@ msgstr ""
 "只將擁有按鍵\"%(key)s\"的材料從\"%(amount)s\" %(unit)s 變更至\"%(text)s\" "
 "%(unit)s (_W)"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
@@ -2019,18 +1961,18 @@ msgstr ""
 "只將材料按鍵是\"%(key)s\"及項目是從%(item)s從\"%(amount)s\" %(unit)s 變更至"
 "\"%(text)s\" %(unit)s (_A)"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr "變更所有已選橫列﹖"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr "此動作將無法復原。你確定要為已選的%s橫列作出以下的設定﹖"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
@@ -2039,7 +1981,7 @@ msgstr ""
 "\n"
 "按鍵至%s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
@@ -2048,7 +1990,7 @@ msgstr ""
 "\n"
 "項目至%s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
@@ -2057,7 +1999,7 @@ msgstr ""
 "\n"
 "單位至%s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
@@ -2066,8 +2008,8 @@ msgstr ""
 "\n"
 "數量至%s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2075,387 +2017,375 @@ msgstr[0] "%s材料"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr "正顯示材料%(bottom)s 至 %(top)s,總數為%(total)s"
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr "數量"
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr "購物分類"
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr "無"
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr "沒法把%s轉換成%s"
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr "需要密度資料。"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr "單位轉換器(_U)"
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr "進入壓縮檔案中"
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr "解壓壓縮檔案中"
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr "HTML網頁"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr "輸出網頁中"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr "匯出食譜至HTML檔案到%(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr "已將食譜儲存成HTML檔%(file)s"
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr "自選"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 #, fuzzy
 msgid "Exporting epub"
 msgstr "輸出網頁中"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, fuzzy, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr "匯出食譜至HTML檔案到%(file)s"
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr "已將食譜儲存成HTML檔%(file)s"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr "文字輸出"
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2463,81 +2393,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, fuzzy, python-format
-msgid "Logging into %s"
-msgstr "%s的購物清單"
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr "檢索%s中"
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr "Gourmet XML 檔案"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr "Gourmet XML 輸出"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr "輸出食譜至Gourmet XML%(file)s檔案中。"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr "食譜已被儲存在Gourmet XML%(file)s檔案。"
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr "Mastercook 載入完成。"
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr "整理XML中"
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2546,273 +2449,290 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr "列印食譜"
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr "MealMaster 檔案"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr "MealMaster輸出"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr "正在將食譜輸出成MealMaster檔案%(file)s。"
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr "已將食譜儲存成MealMaster檔%(file)s"
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, fuzzy, python-format
 msgid "%s serving"
 msgstr "份量"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 #, fuzzy
 msgid "MCB File"
 msgstr "檔案(_F)"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 #, fuzzy
 msgid "MCB Export"
 msgstr "文字輸出"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, fuzzy, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr "輸出食譜至Gourmet XML%(file)s檔案中。"
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, fuzzy, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr "食譜已被儲存在Gourmet XML%(file)s檔案。"
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr "任何食物類別"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr "轉換%s的單位"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
+#, fuzzy, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 "為計算營養資料,Gourmet需要你幫助把\"%s\" 轉換成一個Gourmet能理解的單位。"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
@@ -2820,38 +2740,38 @@ msgid ""
 msgstr ""
 "把所有地方的材料按鍵由%(old_key)s 變更成 %(new_key)s,或只是於食譜%(title)s?"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr "於所有地方進行變更(_E)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr "只是食譜%s(_J)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr "變更單位"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
-#, python-format
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
+#, fuzzy, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
@@ -2859,196 +2779,197 @@ msgstr ""
 "料。現存的資料庫有數個屬於這個項目的描述,各有不同的密度。請從下列項目選擇正確"
 "的。"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
+#, fuzzy
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr "如要應用營養資料,Gourmet需要一個合法化的數量及單位。"
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr "材料"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr "美国农业部"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr "100克"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr "卡路里"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr "總脂肪"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr "飽和脂肪"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr "膽固醇"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr "鈉"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr "總碳水化合物"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr "膳食纖維"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr "糖"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr "蛋白質"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr "α-胡蘿蔔素"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr "灰質"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr "β-胡蘿蔔素"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr "β-隱黃質"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr "鈣"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr "銅"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr "總葉酸量"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr "叶酸"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr "食物叶酸含量"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr "膳食叶酸当量"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr "鐵"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr "茄紅素"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr "葉黃素+玉米黃素"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr "鎂"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr "錳"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr "菸鹼酸"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr "泛酸"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr "磷"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr "鉀"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr "維他命A"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr "維他命A醛"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr "核黃素"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr "硒"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr "硫胺素(維他命B1)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr "維他命A(IU)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr "維他命A(RAE)"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr "維他命B6"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr "維他命B12"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr "維他命C"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr "維他命E"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr "維他命K"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr "鋅"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr "維他命及礦物質"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
@@ -3057,378 +2978,378 @@ msgstr ""
 "缺乏的營養資料\n"
 "包括%(missing)s ,屬於%(total)s 材料。"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr "%每日需求量"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr "每個食譜含量"
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr "Loading Nutritional Data"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr "營養資料庫載入完成!"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr "正從壓縮檔案%s讀取營養資料"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr "從壓縮檔案提取%s中。"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr "正分析營養資料的語法..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr "正閱讀營養資料:已載入%s項目,總數為%s。"
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr "正分析重量數據..."
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr "正閱讀重量數據:已載入%s項目,總數為%s。"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr "水"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr "卡路里(kcal)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr "克 蛋白"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr "克 脂質"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr "克 灰質"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr "克 碳水化合物"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr "克 纖維"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr "克 糖"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr "毫克 鈣"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr "毫克 鐵"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr "毫克 鎂"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr "毫克 磷"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr "毫克 鉀"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr "毫克 鈉"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr "毫克 鋅"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr "毫克 銅"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr "毫克 錳"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr "微克 硒"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr "毫克 維他命C"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr "毫克 硫胺素(維他命B1)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr "毫克 核黃素"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr "毫克 菸鹼酸"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr "毫克 泛酸"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr "毫克 維他命B6"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr "微克 總葉酸量"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr "微克 葉酸"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr "微克 食物葉酸含量"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr "微克 膳食叶酸当量"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr "微克 維他命B12"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr "維他命A IU"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr "維他命A (微克視網醇活性當量)"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr "微克 維他命A醛"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr "微克 α-胡蘿蔔素"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr "微克 β-胡蘿蔔素"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr "微克 β-隱黃質"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr "微克 茄紅素"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr "微克 葉黃素+玉米黃素"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr "毫克 維他命E"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr "毫克 維他命K"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr "克 飽和脂肪酸"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr "克 单不饱和脂肪酸"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr "克 多元不飽和脂肪酸"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr "毫克 膽固醇"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr "渣滓百分比"
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr "奶乳類及蛋類食品"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr "香料及調味品"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr "嬰兒食品"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr "脂肪及食油"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr "家禽"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr "湯及醬汁"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr "香腸及午餐肉"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr "穀類營養早餐"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr "水果及果汁"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr "豬肉"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr "蔬菜"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr "果仁及種子"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr "牛肉"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr "飲品"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr "魚類及介殼類海產"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr "豆類"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr "羊肉, 小牛肉及野味"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr "烘烤食品"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr "甜食"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr "穀物及麵條"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr "快餐食品"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr "膳食,主菜,小菜"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr "零食"
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr "種族特色食品"
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3442,287 +3363,243 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr "星星"
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr "已輸出%(number)s個食譜,共%(total)s個"
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr "輸出完成。"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr "把食譜包含在電郵的內容裡(這經常是一個好主意)"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr "將食譜當作HTML附件並以電郵寄出"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr "電郵選項"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr "寄出電郵前不要再問我。"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr "電郵沒被寄出"
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr "你沒有選擇把食譜包含在電郵的內容裡或將食譜當作電郵的HTML附件。"
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr "另存食譜為..."
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr "Gourmet 無法輸出\"%s\"類型的檔案"
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr "輸出食譜"
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr "食譜"
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] "列印%s食譜"
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr "檢索檔案中"
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr "輸入食譜的URL或食譜的網站。"
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+#, fuzzy
+msgid "Enter a recipe file path or website address."
+msgstr "輸入食譜的URL或食譜的網站。"
+
+#: ../src/gourmand/importers/importManager.py:62
+#, fuzzy
+msgid "Location:"
+msgstr "修改"
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr "所有可載入檔案"
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr "已載入%s個食譜。"
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr "已載入%s個食譜,共%s個。"
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr "載入完成。"
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr "載入食譜中"
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr "處理材料中"
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr "處理材料中。"
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr "份量"
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr "標題"
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr "材料"
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr "指示說明"
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr "備註"
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr "菜餚/烹調法"
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr "來源"
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3730,97 +3607,91 @@ msgstr[0] "%s 食譜"
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr "正顯示食譜由%(bottom)s至%(top)s,共%(total)s個"
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] "秒"
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "分鐘"
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr "小時"
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "小時"
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "星期"
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] "月"
@@ -3828,7 +3699,7 @@ msgstr[0] "月"
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"
@@ -3839,71 +3710,30 @@ msgstr[0] "年"
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr " , "
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ", "
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr " "
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr "及"
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr "至"
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-#, fuzzy
-msgid "Gourmet"
-msgstr "Gourmet XML 檔案"
-
-#: ../data/gourmet.desktop.in.h:2
-#, fuzzy
-msgid "Recipe Manager"
-msgstr "Gourmet食譜管理員"
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3913,7 +3743,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3926,38 +3755,6 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 #, fuzzy
 msgid "EPub Export"
@@ -3965,6 +3762,18 @@ msgstr "文字輸出"
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3975,14 +3784,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4036,22 +3837,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2
@@ -4111,6 +3896,72 @@ msgid ""
 "the 'Encoding' dialog when you import files."
 msgstr ""
 
+#~ msgid "Roland Duhaime (Windows porting assistance)"
+#~ msgstr "Roland Duhaime (視窗連接支援)"
+
+#~ msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
+#~ msgstr "Daniel Folkinshteyn <nanotube@gmail.com> (視窗安裝)"
+
+#~ msgid "Richard Ferguson (improvements to Unit Converter interface)"
+#~ msgstr "Richard Ferguson (單位轉換器界面修飾)"
+
+#~ msgid "R.S. Born (improvements to Mealmaster export)"
+#~ msgstr "R.S. Born (Mealmaster輸出改進)"
+
+#~ msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
+#~ msgstr "ixat <ixat.deviantart.com> (標誌及載入圖示設計)"
+
+#~ msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
+#~ msgstr "Yula Zubritsky (營養及購物清單顯示圖)"
+
+#~ msgid ""
+#~ "Simon Darlington <simon.darlington@gmx.net> (improvements to "
+#~ "internationalization, assorted bugfixes)"
+#~ msgstr "Simon Darlington <simon.darlington@gmx.net> (改進國際化及各種錯誤)"
+
+#~ msgid "Choose a file containing your ingredient list."
+#~ msgstr "選擇含有你的材料清單之檔案。"
+
+#~ msgid "No file selected"
+#~ msgstr "沒有任何已選檔案"
+
+#~ msgid "No file was selected, so the action has been cancelled"
+#~ msgstr "由於沒有任何已選檔案﹐所以動作被取消。"
+
+#~ msgid "Loading zip archive"
+#~ msgstr "進入壓縮檔案中"
+
+#~ msgid "Unzipping zip archive"
+#~ msgstr "解壓壓縮檔案中"
+
+#, fuzzy, python-format
+#~ msgid "Logging into %s"
+#~ msgstr "%s的購物清單"
+
+#, python-format
+#~ msgid "Retrieving %s"
+#~ msgstr "檢索%s中"
+
+#~ msgid "Retrieving file"
+#~ msgstr "檢索檔案中"
+
+#~ msgid "Import complete."
+#~ msgstr "載入完成。"
+
+#~ msgid "Processing ingredients"
+#~ msgstr "處理材料中"
+
+#~ msgid "Processing ingredients."
+#~ msgstr "處理材料中。"
+
+#, fuzzy
+#~ msgid "Gourmet"
+#~ msgstr "Gourmet XML 檔案"
+
+#, fuzzy
+#~ msgid "Recipe Manager"
+#~ msgstr "Gourmet食譜管理員"
+
 #~ msgid "Select recipe image"
 #~ msgstr "選擇食譜圖片"
 
@@ -4159,9 +4010,6 @@ msgstr ""
 #~ msgstr ""
 #~ "你要求關上一個附有活動中的計時器的視窗。你可以停止計時器,或直接關上視窗。"
 #~ "如果你直接關上視窗,它會於計時完成時重新出現。"
-
-#~ msgid "Select File_type"
-#~ msgstr "選擇檔案類型(_T)"
 
 #~ msgid "A file named %s already exists."
 #~ msgstr "檔案名称 %s 已经存在。"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: grecipe-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 15:46-0600\n"
+"POT-Creation-Date: 2025-09-05 14:04+0200\n"
 "PO-Revision-Date: 2009-11-06 19:29+0000\n"
 "Last-Translator: smingko <smingko@gmail.com>\n"
 "Language-Team: Chinese (Taiwan) <zh_TW@li.org>\n"
@@ -20,506 +20,506 @@ msgstr ""
 "X-Generator: Launchpad (build 17031)\n"
 "X-Rosetta-Version: 0.1\n"
 
-#: ../src/gourmet/ui/app.ui.h:1
+#: ../src/gourmand/ui/app.ui.h:1
 msgid "Recipe Index"
 msgstr ""
 
 #. Set up hard-coded functional buttons...
-#: ../src/gourmet/ui/app.ui.h:2
-#: ../src/gourmet/importers/interactive_importer.py:145
+#: ../src/gourmand/ui/app.ui.h:2
+#: ../src/gourmand/importers/interactive_importer.py:142
 msgid "_New Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:3 ../src/gourmet/gglobals.py:108
+#: ../src/gourmand/ui/app.ui.h:3 ../src/gourmand/gglobals.py:102
 msgid "Add to _Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:4 ../src/gourmet/ui/recipe_index.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:4 ../src/gourmand/ui/recipe_index.ui.h:4
 msgid "View Re_cipe"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:5 ../src/gourmet/ui/recipe_index.ui.h:15
-#: ../src/gourmet/ui/nutritionDruid.ui.h:31
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:2
+#: ../src/gourmand/ui/app.ui.h:5 ../src/gourmand/ui/recipe_index.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:31
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:2
 msgid "_Search for:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:6 ../src/gourmet/ui/recipe_index.ui.h:16
-#: ../src/gourmet/ui/shopCatEditor.ui.h:5
-#: ../src/gourmet/ui/nutritionDruid.ui.h:32
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:3
+#: ../src/gourmand/ui/app.ui.h:6 ../src/gourmand/ui/recipe_index.ui.h:16
+#: ../src/gourmand/ui/shopCatEditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:32
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:3
 msgid "Search for recipes as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:7 ../src/gourmet/ui/nutritionDruid.ui.h:30
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:4
+#: ../src/gourmand/ui/app.ui.h:7 ../src/gourmand/ui/nutritionDruid.ui.h:30
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:4
 msgid "_in"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:8 ../src/gourmet/ui/recipe_index.ui.h:19
+#: ../src/gourmand/ui/app.ui.h:8 ../src/gourmand/ui/recipe_index.ui.h:19
 msgid "Search by other critera within the current search results."
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:9 ../src/gourmet/ui/recipe_index.ui.h:20
+#: ../src/gourmand/ui/app.ui.h:9 ../src/gourmand/ui/recipe_index.ui.h:20
 msgid "A_dd Search Criteria"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:10 ../src/gourmet/ui/recipe_index.ui.h:24
+#: ../src/gourmand/ui/app.ui.h:10 ../src/gourmand/ui/recipe_index.ui.h:24
 msgid "Limiting Search to:"
 msgstr ""
 
-#: ../src/gourmet/ui/app.ui.h:11 ../src/gourmet/ui/recipe_index.ui.h:25
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:8
+#: ../src/gourmand/ui/app.ui.h:11 ../src/gourmand/ui/recipe_index.ui.h:25
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:8
 msgid "Search _Results"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:1
+#: ../src/gourmand/ui/batchEditor.ui.h:1
 msgid "Set Fields for Selected Recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:2
 msgid ""
 "<span size=\"large\" weight=\"bold\">Set Recipe Fields for selected recipes</"
 "span>"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:3
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:3
+#: ../src/gourmand/ui/batchEditor.ui.h:3
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:3
 msgid "_Add Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:4
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:5
+#: ../src/gourmand/ui/batchEditor.ui.h:4
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:5
 msgid "_Remove Image"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:5
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:5
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:14
 msgid "S_ource:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:6
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:13
+#: ../src/gourmand/ui/batchEditor.ui.h:6
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:13
 msgid "_Rating:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:7
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:12
+#: ../src/gourmand/ui/batchEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:12
 msgid "C_uisine:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:8
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:8
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:9
 msgid "_Category:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:9
+#: ../src/gourmand/ui/batchEditor.ui.h:9
 msgid "_Preparation Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:10
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:11
+#: ../src/gourmand/ui/batchEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:11
 msgid "Coo_king Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:11
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:2
+#: ../src/gourmand/ui/batchEditor.ui.h:11
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:2
 msgid "_Webpage:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:12
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:4
+#: ../src/gourmand/ui/batchEditor.ui.h:12
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:4
 msgid "Image:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:13
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:8
+#: ../src/gourmand/ui/batchEditor.ui.h:13
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:8
 msgid "_Yield:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:14
+#: ../src/gourmand/ui/batchEditor.ui.h:14
 msgid "Yield U_nit:"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:15
+#: ../src/gourmand/ui/batchEditor.ui.h:15
 msgid "_Only set values where field is currently blank"
 msgstr ""
 
-#: ../src/gourmet/ui/batchEditor.ui.h:16
+#: ../src/gourmand/ui/batchEditor.ui.h:16
 msgid "Set all values for _all selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:1
+#: ../src/gourmand/ui/databaseChooser.ui.h:1
 msgid "Metakit (default, stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:2
+#: ../src/gourmand/ui/databaseChooser.ui.h:2
 msgid "SQLite (stored in a local file)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:3
+#: ../src/gourmand/ui/databaseChooser.ui.h:3
 msgid "MySQL (requires connection to a database)"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:4
+#: ../src/gourmand/ui/databaseChooser.ui.h:4
 msgid "Choose Database"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:5
+#: ../src/gourmand/ui/databaseChooser.ui.h:5
 msgid "<b>Choose Database System for Gourmet to Use</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:6
+#: ../src/gourmand/ui/databaseChooser.ui.h:6
 msgid "_Database System"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:7
 msgid "_Host:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:8
+#: ../src/gourmand/ui/databaseChooser.ui.h:8
 msgid "_Username:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:9
+#: ../src/gourmand/ui/databaseChooser.ui.h:9
 msgid "_Password:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:10
+#: ../src/gourmand/ui/databaseChooser.ui.h:10
 msgid "Password for your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:11
-#: ../src/gourmet/ui/shopCatEditor.ui.h:6
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:7
+#: ../src/gourmand/ui/databaseChooser.ui.h:11
+#: ../src/gourmand/ui/shopCatEditor.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:7
 msgid "*"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:12
+#: ../src/gourmand/ui/databaseChooser.ui.h:12
 msgid "Database _Name:"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:13 ../src/gourmet/shopgui.py:684
-#: ../src/gourmet/GourmetRecipeManager.py:1025
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#. name  # stock  # text  # key-command  # tooltip  # callback
+#: ../src/gourmand/ui/databaseChooser.ui.h:13 ../src/gourmand/shopgui.py:681
+#: ../src/gourmand/main.py:1009
 msgid "_File"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:14
+#: ../src/gourmand/ui/databaseChooser.ui.h:14
 msgid ""
 "Hostname of the system where your database server is running. If your "
 "database server is running on your local system, use localhost."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:15
+#: ../src/gourmand/ui/databaseChooser.ui.h:15
 msgid "localhost"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:16
+#: ../src/gourmand/ui/databaseChooser.ui.h:16
 msgid ""
 "Save the password for next time. This means the password will be stored "
 "insecurely in your configuration file."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:17
+#: ../src/gourmand/ui/databaseChooser.ui.h:17
 msgid "_Save Password"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:18
+#: ../src/gourmand/ui/databaseChooser.ui.h:18
 msgid ""
 "Name of the database in which Gourmet should store its information. Gourmet "
 "will try to create this database if it does not already exist."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:19
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:18
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:60
+#: ../src/gourmand/ui/databaseChooser.ui.h:19
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:72
 msgid "recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:20
+#: ../src/gourmand/ui/databaseChooser.ui.h:20
 msgid "Your username on the database."
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:21
+#: ../src/gourmand/ui/databaseChooser.ui.h:21
 msgid "_Browse"
 msgstr ""
 
-#: ../src/gourmet/ui/databaseChooser.ui.h:22
-#: ../src/gourmet/gtk_extras/dialog_extras.py:863
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1229
+#: ../src/gourmand/ui/databaseChooser.ui.h:22
+#: ../src/gourmand/gtk_extras/dialog_extras.py:838
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1253
 msgid "_Details"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:1
-msgid "Gourmet Recipe Manager Preferences"
+#: ../src/gourmand/ui/preferenceDialog.ui.h:1
+msgid "Gourmand Recipe Manager Preferences"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:2
+#: ../src/gourmand/ui/preferenceDialog.ui.h:2
 msgid "<b>Index View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:3
+#: ../src/gourmand/ui/preferenceDialog.ui.h:3
 msgid "Show _toolbar"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:4
+#: ../src/gourmand/ui/preferenceDialog.ui.h:4
 msgid "_Recipes per page:"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:5
+#: ../src/gourmand/ui/preferenceDialog.ui.h:5
 msgid "<i>Configure which columns are included in the recipe index view.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:6
+#: ../src/gourmand/ui/preferenceDialog.ui.h:6
 msgid "Index View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:7
+#: ../src/gourmand/ui/preferenceDialog.ui.h:7
 msgid "<b>Card View Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:8
+#: ../src/gourmand/ui/preferenceDialog.ui.h:8
 msgid "_Allow units to change when multiplying"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:9
+#: ../src/gourmand/ui/preferenceDialog.ui.h:9
 msgid "_Use fractions"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:10
+#: ../src/gourmand/ui/preferenceDialog.ui.h:10
 msgid "Use fractions when possible for display"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:11
+#: ../src/gourmand/ui/preferenceDialog.ui.h:11
 msgid "<i>Remove items you don't use from the Recipe Card interface.</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:12
+#: ../src/gourmand/ui/preferenceDialog.ui.h:12
 msgid "Card View"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:13
+#: ../src/gourmand/ui/preferenceDialog.ui.h:13
 msgid "<b>Shopping List Preferences</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:14
+#: ../src/gourmand/ui/preferenceDialog.ui.h:14
 msgid ""
-"<i>What should Gourmet do with Optional Ingredients when adding recipes to "
+"<i>What should Gourmand do with Optional Ingredients when adding recipes to "
 "the shopping list?</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:15
+#: ../src/gourmand/ui/preferenceDialog.ui.h:15
 msgid "As_k whether to include optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:16
+#: ../src/gourmand/ui/preferenceDialog.ui.h:16
 msgid "_Remember user selections by default"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:17
+#: ../src/gourmand/ui/preferenceDialog.ui.h:17
 msgid "_Clear remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:18
+#: ../src/gourmand/ui/preferenceDialog.ui.h:18
 msgid "_Always add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:19
+#: ../src/gourmand/ui/preferenceDialog.ui.h:19
 msgid "_Never add optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/preferenceDialog.ui.h:20 ../src/gourmet/shopgui.py:151
-#: ../src/gourmet/shopgui.py:550 ../src/gourmet/shopgui.py:859
-#: ../src/gourmet/shopgui.py:1009
+#: ../src/gourmand/ui/preferenceDialog.ui.h:20 ../src/gourmand/shopgui.py:157
+#: ../src/gourmand/shopgui.py:552 ../src/gourmand/shopgui.py:858
+#: ../src/gourmand/shopgui.py:1014
 msgid "Shopping List"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:1
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:1
 msgid "servings"
 msgstr ""
 
 #. renderer.set_property('editable',True)
 #. renderer.connect('edited',tst)
-#. Uncomment the below to test FauxThreads
-#. use_threads = False
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:6
-#: ../src/gourmet/shopgui.py:760 ../src/gourmet/gglobals.py:31
-#: ../src/gourmet/exporters/rtf_exporter.py:86
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:6
+#: ../src/gourmand/shopgui.py:754 ../src/gourmand/gglobals.py:29
+#: ../src/gourmand/exporters/rtf_exporter.py:93
 msgid "Title"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:7
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:7
 msgid "_Title:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:10
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:10
 msgid "Pre_paration Time:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:15
-#: ../src/gourmet/recindex.py:49 ../src/gourmet/recindex.py:56
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:15
+#: ../src/gourmand/recindex.py:45 ../src/gourmand/recindex.py:53
 msgid "category"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:16
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:16
 msgid "rating"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:17
-#: ../src/gourmet/gglobals.py:37
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:17
+#: ../src/gourmand/gglobals.py:35
 msgid "Yield"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDescriptionEditor.ui.h:18
-#: ../src/gourmet/gglobals.py:38
+#: ../src/gourmand/ui/recCardDescriptionEditor.ui.h:18
+#: ../src/gourmand/gglobals.py:36
 msgid "Yield Unit"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:1
+#: ../src/gourmand/ui/recCardDisplay.ui.h:1
 msgid "_Shop"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:2
+#: ../src/gourmand/ui/recCardDisplay.ui.h:2
 msgid "Edit _description"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:3
+#: ../src/gourmand/ui/recCardDisplay.ui.h:3
 msgid "<b>Cooking Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:4
+#: ../src/gourmand/ui/recCardDisplay.ui.h:4
 msgid "<b>Preparation Time:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:5
+#: ../src/gourmand/ui/recCardDisplay.ui.h:5
 msgid "<b>Cuisine:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:6
+#: ../src/gourmand/ui/recCardDisplay.ui.h:6
 msgid "<b>Category:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:7
+#: ../src/gourmand/ui/recCardDisplay.ui.h:7
 msgid "<b>Webpage:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:8
+#: ../src/gourmand/ui/recCardDisplay.ui.h:8
 msgid "<b>_Yields:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:9
+#: ../src/gourmand/ui/recCardDisplay.ui.h:9
 msgid "<span underline=\"single\" color=\"blue\">Link</span>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:10
+#: ../src/gourmand/ui/recCardDisplay.ui.h:10
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:11
+#: ../src/gourmand/ui/recCardDisplay.ui.h:11
 msgid "<b>Rating:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:12
+#: ../src/gourmand/ui/recCardDisplay.ui.h:12
 msgid "<b>_Multiply by:</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:13
+#: ../src/gourmand/ui/recCardDisplay.ui.h:13
 msgid "<b>Instructions</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:14
+#: ../src/gourmand/ui/recCardDisplay.ui.h:14
 msgid "Edit _instructions"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:15
+#: ../src/gourmand/ui/recCardDisplay.ui.h:15
 msgid "<b>Notes</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:16
+#: ../src/gourmand/ui/recCardDisplay.ui.h:16
 msgid "Edit _notes"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:17
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:482
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:77
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:171
-#: ../src/gourmet/exporters/exporter.py:620
+#: ../src/gourmand/ui/recCardDisplay.ui.h:17
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:507
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:83
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:168
+#: ../src/gourmand/exporters/exporter.py:625
 msgid "Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:18
+#: ../src/gourmand/ui/recCardDisplay.ui.h:18
 msgid "<b>Ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardDisplay.ui.h:19
+#: ../src/gourmand/ui/recCardDisplay.ui.h:19
 msgid "Edit _ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:1
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:1
 msgid "Add _ingredient:"
 msgstr ""
 
-#: ../src/gourmet/ui/recCardIngredientsEditor.ui.h:2
-#: ../src/gourmet/reccard.py:1080
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:477
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:479
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:507
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:117
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:185
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:603
-#: ../src/gourmet/exporters/exporter.py:248
-#: ../src/gourmet/importers/interactive_importer.py:39
-#: ../src/gourmet/importers/interactive_importer.py:54
+#: ../src/gourmand/ui/recCardIngredientsEditor.ui.h:2
+#: ../src/gourmand/reccard.py:1008
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:504
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:545
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:117
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:180
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:598
+#: ../src/gourmand/exporters/exporter.py:251
+#: ../src/gourmand/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:47
 msgid "Ingredients"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:1
+#: ../src/gourmand/ui/recipe_index.ui.h:1
 msgid "Add recipe to shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:2
+#: ../src/gourmand/ui/recipe_index.ui.h:2
 msgid "Add to _shopping list"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:3
+#: ../src/gourmand/ui/recipe_index.ui.h:3
 msgid "Jump to recipe in Recipe Card vew"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:5
+#: ../src/gourmand/ui/recipe_index.ui.h:5
 msgid "Delete selected recipe"
 msgstr ""
 
 #. saveEdits
-#: ../src/gourmet/ui/recipe_index.ui.h:6 ../src/gourmet/reccard.py:886
+#: ../src/gourmand/ui/recipe_index.ui.h:6 ../src/gourmand/reccard.py:819
 msgid "_Delete Recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:7
+#: ../src/gourmand/ui/recipe_index.ui.h:7
 msgid "Edit attributes of selected recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:8
+#: ../src/gourmand/ui/recipe_index.ui.h:8
 msgid "_Batch edit recipes"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:9
-msgid "E-mail selected recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:9
+msgid "Copy selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:10
-msgid "_E-Mail recipe"
+#: ../src/gourmand/ui/recipe_index.ui.h:10
+msgid "_Copy recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:11
+#: ../src/gourmand/ui/recipe_index.ui.h:11
 msgid "Print selected recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:12
+#: ../src/gourmand/ui/recipe_index.ui.h:12
 msgid "_Print recipe"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:13
+#: ../src/gourmand/ui/recipe_index.ui.h:13
 msgid ""
 "Never buy this item. When called for in a recipe, it will show up in a "
 "\"pantry\" section of the list as a reminder that you need it, but it won't "
@@ -527,31 +527,31 @@ msgid ""
 "buy it."
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:14
+#: ../src/gourmand/ui/recipe_index.ui.h:14
 msgid "Add to _Pantry"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:17
+#: ../src/gourmand/ui/recipe_index.ui.h:17
 msgid "Show _Options"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:18
+#: ../src/gourmand/ui/recipe_index.ui.h:18
 msgid "Search _in"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:21
+#: ../src/gourmand/ui/recipe_index.ui.h:21
 msgid "_Use regular expressions (advanced searching)"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:22
+#: ../src/gourmand/ui/recipe_index.ui.h:22
 msgid "Search as you _type"
 msgstr ""
 
-#: ../src/gourmet/ui/recipe_index.ui.h:23
+#: ../src/gourmand/ui/recipe_index.ui.h:23
 msgid "<i>Search Options</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:1 ../src/gourmet/gglobals.py:32
+#: ../src/gourmand/ui/shopCatEditor.ui.h:1 ../src/gourmand/gglobals.py:30
 msgid "Category"
 msgstr ""
 
@@ -560,285 +560,286 @@ msgstr ""
 #. None,
 #. ()),
 #. }
-#: ../src/gourmet/ui/shopCatEditor.ui.h:2 ../src/gourmet/reccard.py:2170
-#: ../src/gourmet/reccard.py:2230
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:510
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:115
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:192
+#: ../src/gourmand/ui/shopCatEditor.ui.h:2 ../src/gourmand/reccard.py:2039
+#: ../src/gourmand/reccard.py:2100
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:508
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:128
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:209
 msgid "Key"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:3
+#: ../src/gourmand/ui/shopCatEditor.ui.h:3
 msgid "Category Editor"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:4
+#: ../src/gourmand/ui/shopCatEditor.ui.h:4
 msgid "Search by"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:7 ../src/gourmet/recindex.py:105
+#: ../src/gourmand/ui/shopCatEditor.ui.h:7 ../src/gourmand/recindex.py:104
 msgid "Search as you type"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:8
-#: ../src/gourmet/ui/nutritionDruid.ui.h:33
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:7
+#: ../src/gourmand/ui/shopCatEditor.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:33
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:7
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:9
+#: ../src/gourmand/ui/shopCatEditor.ui.h:9
 msgid "Advanced Search"
 msgstr ""
 
-#: ../src/gourmet/ui/shopCatEditor.ui.h:10
+#: ../src/gourmand/ui/shopCatEditor.ui.h:10
 msgid "Add Category: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:1 ../src/gourmet/timer.py:190
-#: ../src/gourmet/timer.py:192
+#: ../src/gourmand/ui/timerDialog.ui.h:1 ../src/gourmand/timer.py:184
+#: ../src/gourmand/timer.py:186
 msgid "Timer"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:2
+#: ../src/gourmand/ui/timerDialog.ui.h:2
 msgid "<b><span size=\"larger\">Timer</span></b>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:3
+#: ../src/gourmand/ui/timerDialog.ui.h:3
 msgid "<i>Timer Finished!</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:4
+#: ../src/gourmand/ui/timerDialog.ui.h:4
 msgid ""
 "Timer will continue to go off until you close this dialog or reset the timer."
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:5
+#: ../src/gourmand/ui/timerDialog.ui.h:5
 msgid "Set _Timer: "
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:6
+#: ../src/gourmand/ui/timerDialog.ui.h:6
 msgid "_Reset"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:7
+#: ../src/gourmand/ui/timerDialog.ui.h:7
 msgid "_Start"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:8
+#: ../src/gourmand/ui/timerDialog.ui.h:8
 msgid "S_ound"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:9
+#: ../src/gourmand/ui/timerDialog.ui.h:9
 msgid "_Note"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:10
+#: ../src/gourmand/ui/timerDialog.ui.h:10
 msgid "Re_peat alarm until I turn it off"
 msgstr ""
 
-#: ../src/gourmet/ui/timerDialog.ui.h:11
+#: ../src/gourmand/ui/timerDialog.ui.h:11
 msgid "_Settings"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:1
+#: ../src/gourmand/ui/valueEditor.ui.h:1
 msgid "<b>Edit fields throughout database</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:2
+#: ../src/gourmand/ui/valueEditor.ui.h:2
 msgid "Field to _Edit:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:3
+#: ../src/gourmand/ui/valueEditor.ui.h:3
 msgid "For each selected value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:4
+#: ../src/gourmand/ui/valueEditor.ui.h:4
 msgid "_Leave value as is"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:5
+#: ../src/gourmand/ui/valueEditor.ui.h:5
 msgid "<i>New value will be added to the end of any existing text</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:6
+#: ../src/gourmand/ui/valueEditor.ui.h:6
 msgid "<i>New value will replace any existing value</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:7
+#: ../src/gourmand/ui/valueEditor.ui.h:7
 msgid "_Field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:8
+#: ../src/gourmand/ui/valueEditor.ui.h:8
 msgid "_Value:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:9
+#: ../src/gourmand/ui/valueEditor.ui.h:9
 msgid "Change _other field:"
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:10
+#: ../src/gourmand/ui/valueEditor.ui.h:10
 msgid "C_hange value to: "
 msgstr ""
 
-#: ../src/gourmet/ui/valueEditor.ui.h:11
+#: ../src/gourmand/ui/valueEditor.ui.h:11
 msgid "_Delete value"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:1
 msgid "<i>Select equivalent of</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:2
+#: ../src/gourmand/ui/nutritionDruid.ui.h:2
 msgid "<i>from USDA database</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:3
+#: ../src/gourmand/ui/nutritionDruid.ui.h:3
 msgid "_Change ingredient"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:4
 msgid "<i>or</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:5
 msgid "_Search USDA Ingredient Database:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:6
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:6
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:5
 msgid "Search as you t_ype"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:7
+#: ../src/gourmand/ui/nutritionDruid.ui.h:7
 msgid "Show only food in _group:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:8
+#: ../src/gourmand/ui/nutritionDruid.ui.h:8
 msgid "<i>Search _results:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:9
+#: ../src/gourmand/ui/nutritionDruid.ui.h:9
 msgid "<i>From:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:10
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:9
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:4
+#: ../src/gourmand/ui/nutritionDruid.ui.h:10
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:4
 msgid "_Amount:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:11
+#: ../src/gourmand/ui/nutritionDruid.ui.h:11
 msgid "Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:12
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
+#: ../src/gourmand/ui/nutritionDruid.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
 msgid "unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:13
+#: ../src/gourmand/ui/nutritionDruid.ui.h:13
 msgid "_Change unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:14
+#: ../src/gourmand/ui/nutritionDruid.ui.h:14
 msgid "_Save new unit"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:15
+#: ../src/gourmand/ui/nutritionDruid.ui.h:15
 msgid "<i>To:</i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:16
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:10
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:5
+#: ../src/gourmand/ui/nutritionDruid.ui.h:16
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:5
 msgid "_Unit:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:17
+#: ../src/gourmand/ui/nutritionDruid.ui.h:17
 msgid "<i>Enter nutritional information for </i>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:18
+#: ../src/gourmand/ui/nutritionDruid.ui.h:18
 msgid "<b>Choose a Density</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:19
+#: ../src/gourmand/ui/nutritionDruid.ui.h:19
 msgid "<b>Ingredient Key: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:20
+#: ../src/gourmand/ui/nutritionDruid.ui.h:20
 msgid "<b>USDA Item: </b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:21
+#: ../src/gourmand/ui/nutritionDruid.ui.h:21
 msgid "Edit _USDA Association"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:22
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
+#: ../src/gourmand/ui/nutritionDruid.ui.h:22
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:1
 msgid "<b>Nutritional Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:23
+#: ../src/gourmand/ui/nutritionDruid.ui.h:23
 msgid "Edit _information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:24
+#: ../src/gourmand/ui/nutritionDruid.ui.h:24
 msgid "_Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:25
+#: ../src/gourmand/ui/nutritionDruid.ui.h:25
 msgid "Density:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:26
+#: ../src/gourmand/ui/nutritionDruid.ui.h:26
 msgid "USDA equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:27
+#: ../src/gourmand/ui/nutritionDruid.ui.h:27
 msgid "Custom equivalents:"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:28
+#: ../src/gourmand/ui/nutritionDruid.ui.h:28
 msgid "_Density Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:29
+#: ../src/gourmand/ui/nutritionDruid.ui.h:29
 msgid "<b>Known Nutritonal Information</b>"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:34
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:6
+#: ../src/gourmand/ui/nutritionDruid.ui.h:34
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:6
 msgid "_Advanced Search"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/ui/nutritionDruid.ui.h:35
-#: ../src/gourmet/plugins/nutritional_information/nutPrefsPlugin.py:13
-#: ../src/gourmet/plugins/nutritional_information/main_plugin.py:15
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:36
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:72
+#: ../src/gourmand/ui/nutritionDruid.ui.h:35
+#: ../src/gourmand/plugins/nutritional_information/nutPrefsPlugin.py:13
+#: ../src/gourmand/plugins/nutritional_information/main_plugin.py:14
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:71
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:1
 msgid "Nutritional Information"
 msgstr ""
 
-#: ../src/gourmet/ui/nutritionDruid.ui.h:36
+#: ../src/gourmand/ui/nutritionDruid.ui.h:36
 msgid "I_gnore"
 msgstr ""
 
-#: ../src/gourmet/version.py:4 ../data/gourmet.desktop.in.h:3
-msgid "Gourmet Recipe Manager"
+#: ../src/gourmand/__version__.py:3
+msgid "Gourmand Recipe Manager"
 msgstr ""
 
-#: ../src/gourmet/version.py:5
-msgid "Copyright (c) 2004-2014 Thomas M. Hinkle and Contributors. GNU GPL v2"
-msgstr ""
-
-#: ../src/gourmet/version.py:9
+#: ../src/gourmand/__version__.py:4
 msgid ""
-"Gourmet Recipe Manager is an application to store, organize and search "
-"recipes.\n"
+"Copyright (c) 2004-2021 Thomas M. Hinkle and Contributors.\n"
+"Copyright (c) 2021 The Gourmand Team and Contributors"
+msgstr ""
+
+#: ../src/gourmand/__version__.py:9
+msgid ""
+"Gourmand is an application to store, organize and search recipes.\n"
 "\n"
 "Features:\n"
 "* Makes it easy to create shopping lists from recipes.\n"
@@ -853,650 +854,601 @@ msgid ""
 "ingredients.\n"
 msgstr ""
 
-#: ../src/gourmet/version.py:26
-msgid "Roland Duhaime (Windows porting assistance)"
-msgstr ""
-
-#: ../src/gourmet/version.py:27
-msgid "Daniel Folkinshteyn <nanotube@gmail.com> (Windows installer)"
-msgstr ""
-
-#: ../src/gourmet/version.py:28
-msgid "Richard Ferguson (improvements to Unit Converter interface)"
-msgstr ""
-
-#: ../src/gourmet/version.py:29
-msgid "R.S. Born (improvements to Mealmaster export)"
-msgstr ""
-
-#: ../src/gourmet/version.py:30
-msgid "ixat <ixat.deviantart.com> (logo and splash screen)"
-msgstr ""
-
-#: ../src/gourmet/version.py:31
-msgid "Yula Zubritsky (nutrition and add-to-shopping list icons)"
-msgstr ""
-
-#: ../src/gourmet/version.py:32
-msgid ""
-"Simon Darlington <simon.darlington@gmx.net> (improvements to "
-"internationalization, assorted bugfixes)"
-msgstr ""
-
-#: ../src/gourmet/version.py:33
-msgid ""
-"Bernhard Reiter <ockham@raz.or.at> (maintenance since 0.16.0, website re-"
-"design)"
-msgstr ""
-
-#: ../src/gourmet/version.py:35
+#: ../src/gourmand/__version__.py:26
 msgid "Nyall Dawson (cookie icon)"
 msgstr ""
 
-#: ../src/gourmet/version.py:36
+#: ../src/gourmand/__version__.py:26
 msgid "Kati Pregartner (splash screen image)"
 msgstr ""
 
-#: ../src/gourmet/backends/DatabaseChooser.py:108
+#: ../src/gourmand/backends/DatabaseChooser.py:99
 msgid "Choose Database File"
 msgstr ""
 
-#: ../src/gourmet/backends/db.py:471 ../src/gourmet/backends/db.py:472
-msgid "Upgrading database"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:473
-msgid ""
-"Depending on the size of your database, this may be an intensive process and "
-"may take  some time. Your data has been automatically backed up in case "
-"something goes wrong."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:474 ../src/gourmet/threadManager.py:351
-msgid "Details"
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:475
-#, python-format
-msgid ""
-"A backup has been made in %s in case something goes wrong. If this upgrade "
-"fails, you can manually rename your backup file recipes.db to recover it for "
-"use with older Gourmet."
-msgstr ""
-
-#: ../src/gourmet/backends/db.py:1505 ../src/gourmet/reccard.py:956
-#: ../src/gourmet/importers/interactive_importer.py:94
+#: ../src/gourmand/backends/db.py:1514 ../src/gourmand/reccard.py:887
+#: ../src/gourmand/importers/interactive_importer.py:88
 msgid "New Recipe"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:126 ../src/gourmet/shopgui.py:133
+#: ../src/gourmand/backends/db.py:2182 ../src/gourmand/backends/db.py:2183
+msgid "Database Backup"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2184
+msgid "Depending on the size of your database, this may take some time."
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2186 ../src/gourmand/threadManager.py:354
+msgid "Details"
+msgstr ""
+
+#: ../src/gourmand/backends/db.py:2188
+#, python-format
+msgid ""
+"A backup will be made as %s in case something goes wrong. If this upgrade "
+"fails, you can manually rename the backup file to recipes.db to recover it."
+msgstr ""
+
+#: ../src/gourmand/shopgui.py:125 ../src/gourmand/shopgui.py:138
 msgid "Change _Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:127
+#: ../src/gourmand/shopgui.py:129
 msgid "Create new category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:135
+#: ../src/gourmand/shopgui.py:138
 msgid "Change the category of the currently selected item"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:141
+#: ../src/gourmand/shopgui.py:144
 msgid "Pantry"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:144
+#: ../src/gourmand/shopgui.py:148
 msgid "Move to _Shopping List"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:145
+#: ../src/gourmand/shopgui.py:149
 msgid "<Ctrl>B"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/shopgui.py:154
+#: ../src/gourmand/shopgui.py:161
 msgid "Move to _pantry"
 msgstr ""
 
 #. text
-#: ../src/gourmet/shopgui.py:155
+#: ../src/gourmand/shopgui.py:162
 msgid "<Ctrl>D"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/shopgui.py:156
+#: ../src/gourmand/shopgui.py:163
 msgid "Remove from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:177
+#: ../src/gourmand/shopgui.py:185
 #, python-format
 msgid "Move selected items into %s"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:215
+#: ../src/gourmand/shopgui.py:223 ../src/gourmand/main.py:1024
 msgid "_Shopping List"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:216
+#: ../src/gourmand/shopgui.py:224
 msgid "Already Have (_Pantry Items)"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:478
+#: ../src/gourmand/shopgui.py:490
 msgid "Enter Category"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:479
+#: ../src/gourmand/shopgui.py:490
 #, python-format
 msgid "Category to add %s to"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:480
+#: ../src/gourmand/shopgui.py:490
 msgid "Category:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:595
+#: ../src/gourmand/shopgui.py:588
 msgid "_Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:619
+#: ../src/gourmand/shopgui.py:616
 msgid "_Add items:"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:657
+#: ../src/gourmand/shopgui.py:668
 msgid "Remove Recipes"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:658
+#: ../src/gourmand/shopgui.py:670
 msgid "Remove recipes from shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:662 ../src/gourmet/reccard.py:228
-#: ../src/gourmet/reccard.py:881 ../src/gourmet/GourmetRecipeManager.py:1038
+#: ../src/gourmand/shopgui.py:677 ../src/gourmand/reccard.py:221
+#: ../src/gourmand/reccard.py:815 ../src/gourmand/main.py:1023
 msgid "_Edit"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:685 ../src/gourmet/shopgui.py:688
-#: ../src/gourmet/reccard.py:230 ../src/gourmet/reccard.py:241
-#: ../src/gourmet/reccard.py:883 ../src/gourmet/GourmetRecipeManager.py:1050
-#: ../src/gourmet/GourmetRecipeManager.py:1053
+#: ../src/gourmand/shopgui.py:682 ../src/gourmand/shopgui.py:683
+#: ../src/gourmand/reccard.py:223 ../src/gourmand/reccard.py:228
+#: ../src/gourmand/reccard.py:817 ../src/gourmand/main.py:1036
+#: ../src/gourmand/main.py:1038
 msgid "_Help"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:693
+#: ../src/gourmand/shopgui.py:688
 msgid "Add items"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:695
+#: ../src/gourmand/shopgui.py:688
 msgid "Add arbitrary items to shopping list"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:761
+#: ../src/gourmand/shopgui.py:755
 msgid "x"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:846
+#: ../src/gourmand/shopgui.py:843
 msgid "No recipes selected. Do you want to clear the entire list?"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:857
+#: ../src/gourmand/shopgui.py:853
 msgid "Save Shopping List As..."
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:911
+#: ../src/gourmand/shopgui.py:917
 msgid "Select optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/shopgui.py:912
+#: ../src/gourmand/shopgui.py:918
 msgid ""
 "Please specify which of the following optional ingredients you'd like to "
 "include on your shopping list."
 msgstr ""
 
 #. menus
-#: ../src/gourmet/reccard.py:227 ../src/gourmet/reccard.py:880
+#: ../src/gourmand/reccard.py:220 ../src/gourmand/reccard.py:814
 msgid "_Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:229 ../src/gourmet/GourmetRecipeManager.py:210
+#: ../src/gourmand/reccard.py:222 ../src/gourmand/main.py:199
 msgid "_Go"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:231
+#: ../src/gourmand/reccard.py:224
 msgid "Export recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:232
+#: ../src/gourmand/reccard.py:224
 msgid "Export selected recipe (save to file)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:234
+#: ../src/gourmand/reccard.py:225
 msgid "_Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:235
+#: ../src/gourmand/reccard.py:225
 msgid "Delete this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:249
+#: ../src/gourmand/reccard.py:236
 msgid "Adjust units when multiplying"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:251
+#: ../src/gourmand/reccard.py:238
 msgid ""
 "Change units to make them more readable where possible when multiplying."
 msgstr ""
 
-#. ('Email',None,_('E-_mail recipe'),
-#. None,None,self.email_cb),
-#: ../src/gourmet/reccard.py:259
+#: ../src/gourmand/reccard.py:246
+msgid "Copy to clipboard"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:247
 msgid "Print recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:261 ../src/gourmet/GourmetRecipeManager.py:1019
+#: ../src/gourmand/reccard.py:248 ../src/gourmand/main.py:1002
 msgid "Add to Shopping List"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:263
+#: ../src/gourmand/reccard.py:252
 msgid "Forget remembered optional ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:264
+#: ../src/gourmand/reccard.py:254
 msgid ""
 "Before adding to shopping list, ask about all optional ingredients, even "
 "ones you previously wanted remembered"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:266
+#: ../src/gourmand/reccard.py:259
 msgid "Export Recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:565
+#: ../src/gourmand/reccard.py:526
 #, python-format
 msgid "Recipe successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:600
+#: ../src/gourmand/reccard.py:547 ../src/gourmand/reccard.py:559
 msgid "You have unsaved changes."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:601
-msgid "Apply changes before printing?"
+#: ../src/gourmand/reccard.py:547
+msgid "Save changes before copying?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:715 ../src/gourmet/recipeIdentifier.py:101
+#: ../src/gourmand/reccard.py:559
+msgid "Save changes before printing?"
+msgstr ""
+
+#: ../src/gourmand/reccard.py:658 ../src/gourmand/recipeIdentifier.py:115
 msgid "(Optional)"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:770
+#: ../src/gourmand/reccard.py:703
 #, python-format
 msgid "Unable to find recipe %s in database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:864
+#: ../src/gourmand/reccard.py:797
 msgid "Edit Recipe:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:885
+#: ../src/gourmand/reccard.py:818
 msgid "Save edits to database"
 msgstr ""
 
 #. show_pref_dialog
-#: ../src/gourmet/reccard.py:894
+#: ../src/gourmand/reccard.py:823
 msgid "View Recipe Card"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:956
+#: ../src/gourmand/reccard.py:887
 msgid "Edit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1050 ../src/gourmet/reccard.py:1051
+#: ../src/gourmand/reccard.py:978 ../src/gourmand/reccard.py:979
 #, python-format
 msgid "Save changes to %s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1143
+#: ../src/gourmand/reccard.py:1065
 msgid "Add ingredient"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1145
+#: ../src/gourmand/reccard.py:1067
 msgid "Add group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1147
-msgid "Paste ingredients"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1149
-msgid "Import from file"
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1151
+#: ../src/gourmand/reccard.py:1071
 msgid "Add _recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1152
+#: ../src/gourmand/reccard.py:1073
 msgid "Add another recipe as an ingredient in this recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1156
+#: ../src/gourmand/reccard.py:1085
 msgid "Delete"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1162
+#: ../src/gourmand/reccard.py:1093
 msgid "Up"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1164
+#: ../src/gourmand/reccard.py:1094
 msgid "Down"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1208
-msgid "Choose a file containing your ingredient list."
-msgstr ""
-
-#: ../src/gourmet/reccard.py:1319
-#: ../src/gourmet/importers/interactive_importer.py:47
+#: ../src/gourmand/reccard.py:1228
+#: ../src/gourmand/importers/interactive_importer.py:45
 msgid "Description"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1683 ../src/gourmet/gglobals.py:45
-#: ../src/gourmet/gglobals.py:50
+#: ../src/gourmand/reccard.py:1565 ../src/gourmand/gglobals.py:44
+#: ../src/gourmand/gglobals.py:50
 msgid "Instructions"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:1689 ../src/gourmet/gglobals.py:46
-#: ../src/gourmet/gglobals.py:51
+#: ../src/gourmand/reccard.py:1572 ../src/gourmand/gglobals.py:45
+#: ../src/gourmand/gglobals.py:51
 msgid "Notes"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2167 ../src/gourmet/reccard.py:2197
+#: ../src/gourmand/reccard.py:2036 ../src/gourmand/reccard.py:2067
 msgid "Amt"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2168 ../src/gourmet/reccard.py:2198
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:512
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:10
+#: ../src/gourmand/reccard.py:2037 ../src/gourmand/reccard.py:2068
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:510
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:11
 msgid "Unit"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2169 ../src/gourmet/reccard.py:2199
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:511
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:107
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:193
+#: ../src/gourmand/reccard.py:2038 ../src/gourmand/reccard.py:2069
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:509
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:120
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:210
 msgid "Item"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2171 ../src/gourmet/reccard.py:2200
+#: ../src/gourmand/reccard.py:2040 ../src/gourmand/reccard.py:2070
 msgid "Optional"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2312
+#: ../src/gourmand/reccard.py:2175
 #, python-format
 msgid "The recipe %s (ID %s) is not in our database."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2634
+#: ../src/gourmand/reccard.py:2485
 #, python-format
 msgid "Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2636
+#: ../src/gourmand/reccard.py:2486
 #, python-format
 msgid "Not Converted: %(amt)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2640
+#: ../src/gourmand/reccard.py:2490
 msgid "Changed unit."
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2641
+#: ../src/gourmand/reccard.py:2491
 #, python-format
 msgid ""
 "You have changed the unit for %(item)s from %(old)s to %(new)s. Would you "
 "like the amount converted or not?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2652
+#: ../src/gourmand/reccard.py:2504
 #, python-format
 msgid "Converted %(old_amt)s %(old_unit)s to %(new_amt)s %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2664
+#: ../src/gourmand/reccard.py:2517
 #, python-format
 msgid "Unable to convert from %(old_unit)s to %(new_unit)s"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2719
+#: ../src/gourmand/reccard.py:2568
 msgid "Adding Ingredient Group"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2720
+#: ../src/gourmand/reccard.py:2569
 msgid "Enter a name for new subgroup of ingredients"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2721
+#: ../src/gourmand/reccard.py:2570
 msgid "Name of group:"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:2992
+#: ../src/gourmand/reccard.py:2837
 msgid "Choose recipe"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3029
+#: ../src/gourmand/reccard.py:2869
 msgid "Recipe cannot call itself as an ingredient!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3030 ../src/gourmet/shopping.py:335
+#: ../src/gourmand/reccard.py:2869 ../src/gourmand/shopping.py:304
 msgid "Infinite recursion is not allowed in recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3051
+#: ../src/gourmand/reccard.py:2884
 msgid "You haven't selected any recipes!"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3063
+#: ../src/gourmand/reccard.py:2893
 #, python-format
 msgid "How much of %(title)s does your recipe call for?"
 msgstr ""
 
-#: ../src/gourmet/reccard.py:3071
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:116
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:32
-#: ../src/gourmet/plugins/email_plugin/recipe_emailer.py:51
-#: ../src/gourmet/exporters/recipe_emailer.py:64
+#: ../src/gourmand/reccard.py:2899
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:121
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:34
+#: ../src/gourmand/plugins/email_plugin/recipe_emailer.py:50
+#: ../src/gourmand/exporters/recipe_emailer.py:68
 msgid "Recipes"
 msgstr ""
 
-#: ../src/gourmet/timer.py:147 ../src/gourmet/timer.py:170
+#: ../src/gourmand/timer.py:141 ../src/gourmand/timer.py:163
 msgid "Ringing Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:148
+#: ../src/gourmand/timer.py:141
 msgid "Warning Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:149
+#: ../src/gourmand/timer.py:141
 msgid "Error Sound"
 msgstr ""
 
-#: ../src/gourmet/timer.py:270
+#: ../src/gourmand/timer.py:262
 msgid "Stop timer?"
 msgstr ""
 
-#: ../src/gourmet/timer.py:272
+#: ../src/gourmand/timer.py:262
 msgid "Stop _timer"
 msgstr ""
 
-#: ../src/gourmet/timer.py:273
+#: ../src/gourmand/timer.py:262
 msgid "_Keep timing"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:34
+#: ../src/gourmand/plugin_gui.py:37
 msgid "Plugins"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:37
-msgid "Plugins add extra functionality to Gourmet."
+#: ../src/gourmand/plugin_gui.py:39
+msgid "Plugins add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:124
+#: ../src/gourmand/plugin_gui.py:121
 msgid "Plugin is needed for other plugins. Deactivate plugin anyway?"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:125
+#: ../src/gourmand/plugin_gui.py:122
 #, python-format
 msgid "The following plugins require %s:"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:128
+#: ../src/gourmand/plugin_gui.py:123
 msgid "Deactivate anyway"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:129
+#: ../src/gourmand/plugin_gui.py:124
 msgid "Keep plugin active"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:143 ../src/gourmet/recindex.py:467
+#: ../src/gourmand/plugin_gui.py:139 ../src/gourmand/recindex.py:450
 msgid "or"
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:147
+#: ../src/gourmand/plugin_gui.py:145
 msgid "An error occurred activating plugin."
 msgstr ""
 
-#: ../src/gourmet/plugin_gui.py:151
+#: ../src/gourmand/plugin_gui.py:147
 msgid "An error occurred deactivating plugin."
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:33
+#: ../src/gourmand/gglobals.py:31
 msgid "Cuisine"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:34 ../src/gourmet/gtk_extras/ratingWidget.py:324
+#: ../src/gourmand/gglobals.py:32
+#: ../src/gourmand/gtk_extras/ratingWidget.py:299
 msgid "Rating"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:35
+#: ../src/gourmand/gglobals.py:33
 msgid "Source"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:36
+#: ../src/gourmand/gglobals.py:34
 msgid "Website"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:39
+#: ../src/gourmand/gglobals.py:37
 msgid "Preparation Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:40
+#: ../src/gourmand/gglobals.py:38
 msgid "Cooking Time"
 msgstr ""
 
-#: ../src/gourmet/gglobals.py:52
+#: ../src/gourmand/gglobals.py:52
 msgid "Modifications"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:153
+#: ../src/gourmand/gtk_extras/validation.py:151
 msgid "Time must consist of a number and a unit."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Invalid input."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/validation.py:189
+#: ../src/gourmand/gtk_extras/validation.py:185
 msgid "Not a number."
 msgstr ""
 
 #. setup pause button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:434
+#: ../src/gourmand/gtk_extras/dialog_extras.py:415
 msgid "_Pause"
 msgstr ""
 
 #. setup stop button
-#: ../src/gourmet/gtk_extras/dialog_extras.py:447
+#: ../src/gourmand/gtk_extras/dialog_extras.py:427
 msgid "_Stop"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:518
-#: ../src/gourmet/gtk_extras/dialog_extras.py:612
+#: ../src/gourmand/gtk_extras/dialog_extras.py:502
+#: ../src/gourmand/gtk_extras/dialog_extras.py:607
 msgid "Don't ask me this again."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:575
+#: ../src/gourmand/gtk_extras/dialog_extras.py:563
 msgid "Do you really want to do this"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:796
-#: ../src/gourmet/importers/importer.py:496
+#: ../src/gourmand/gtk_extras/dialog_extras.py:771
+#: ../src/gourmand/importers/importer.py:488
 msgid "excellent"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:797
-#: ../src/gourmet/importers/importer.py:497
+#: ../src/gourmand/gtk_extras/dialog_extras.py:772
+#: ../src/gourmand/importers/importer.py:489
 msgid "great"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:798
-#: ../src/gourmet/importers/importer.py:498
+#: ../src/gourmand/gtk_extras/dialog_extras.py:773
+#: ../src/gourmand/importers/importer.py:490
 msgid "good"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:799
-#: ../src/gourmet/importers/importer.py:499
+#: ../src/gourmand/gtk_extras/dialog_extras.py:774
+#: ../src/gourmand/importers/importer.py:491
 msgid "fair"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:800
-#: ../src/gourmet/importers/importer.py:501
+#: ../src/gourmand/gtk_extras/dialog_extras.py:775
+#: ../src/gourmand/importers/importer.py:493
 msgid "poor"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:812
+#: ../src/gourmand/gtk_extras/dialog_extras.py:789
 msgid "Convert ratings to 5 star scale."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:813
+#: ../src/gourmand/gtk_extras/dialog_extras.py:790
 msgid "Convert ratings."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:815
+#: ../src/gourmand/gtk_extras/dialog_extras.py:791
 msgid "Please give each of the ratings an equivalent on a scale of 1 to 5"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:829
+#: ../src/gourmand/gtk_extras/dialog_extras.py:805
 msgid "Current Rating"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:834
+#: ../src/gourmand/gtk_extras/dialog_extras.py:811
 msgid "Rating out of 5 Stars"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1105
-msgid "No file selected"
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1188
+msgid "Select File(s)"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1107
-msgid "No file was selected, so the action has been cancelled"
-msgstr ""
-
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1225
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1247
 #, python-format
 msgid ""
 "I'm sorry, I can't understand\n"
 "the amount \"%s\"."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1228
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1251
 msgid ""
 "Amounts must be numbers (fractions or decimals), ranges of numbers, or blank."
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1230
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1255
 msgid ""
 "\n"
 "The \"unit\" must be in the \"unit\" field by itself.\n"
@@ -1508,444 +1460,424 @@ msgid ""
 "For example, you could enter 2-4 or 1 1/2 - 3 1/2.\n"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Username"
 msgstr ""
 
-#: ../src/gourmet/gtk_extras/dialog_extras.py:1245
+#: ../src/gourmand/gtk_extras/dialog_extras.py:1270
 msgid "Password"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:25
 msgid "flour, all purpose"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:26
 msgid "sugar"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:23
+#: ../src/gourmand/shopping.py:27
 msgid "salt"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:24
+#: ../src/gourmand/shopping.py:28
 msgid "black pepper, ground"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:29
 msgid "ice"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:25
+#: ../src/gourmand/shopping.py:30
 msgid "water"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:26
+#: ../src/gourmand/shopping.py:31
 msgid "oil, vegetable"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:27
+#: ../src/gourmand/shopping.py:32
 msgid "oil, olive"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:144 ../src/gourmet/shopping.py:164
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:13
+#: ../src/gourmand/shopping.py:142 ../src/gourmand/shopping.py:162
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:14
 msgid "Unknown"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:334
+#: ../src/gourmand/shopping.py:303
 msgid "Recipe calls for itself as an ingredient."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:335
+#: ../src/gourmand/shopping.py:304
 #, python-format
 msgid "Ingredient %s will be ignored."
 msgstr ""
 
-#: ../src/gourmet/shopping.py:381 ../src/gourmet/shopping.py:395
+#: ../src/gourmand/shopping.py:352 ../src/gourmand/shopping.py:371
 #, python-format
 msgid "Shopping list for %s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:382
+#: ../src/gourmand/shopping.py:353
 msgid "For the following recipes:\n"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:387 ../src/gourmet/shopping.py:400
+#: ../src/gourmand/shopping.py:358 ../src/gourmand/shopping.py:376
 #, python-format
 msgid " x%s"
 msgstr ""
 
-#: ../src/gourmet/shopping.py:396
+#: ../src/gourmand/shopping.py:372
 msgid "For the following recipes:"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:97
+#: ../src/gourmand/check_encodings.py:156
 msgid "Select encoding"
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:98
+#: ../src/gourmand/check_encodings.py:157
 msgid ""
 "Cannot determine proper encoding. Please select the correct encoding from "
 "the following list."
 msgstr ""
 
-#: ../src/gourmet/check_encodings.py:99
+#: ../src/gourmand/check_encodings.py:158
 msgid "See _file with encoding"
 msgstr ""
 
 #. Convenience method for showing progress dialogs for import/export/deletion
-#: ../src/gourmet/GourmetRecipeManager.py:107
+#: ../src/gourmand/main.py:99
 msgid "Import paused"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:108
+#: ../src/gourmand/main.py:99
 msgid "Stop import"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:190
-#: ../src/gourmet/GourmetRecipeManager.py:1065
+#: ../src/gourmand/main.py:179 ../src/gourmand/main.py:1050
 msgid "Recipe _Index"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:191
+#: ../src/gourmand/main.py:180
 msgid "Shopping _List"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:338
+#: ../src/gourmand/main.py:323
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  smingko https://launchpad.net/~smingko"
 
-#: ../src/gourmet/GourmetRecipeManager.py:380
-msgid ""
-"Please consider making a donation to support our continued effort to fix "
-"bugs, implement features, and help users!"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:385
-msgid "Donate via PayPal"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:387
-msgid "Micro-donate via Flattr"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:389
-msgid "Donate weekly via Gratipay"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:417
+#: ../src/gourmand/main.py:374
 msgid "Saved!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:427
+#: ../src/gourmand/main.py:384
 #, python-format
 msgid "Save your edits to %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:438
+#: ../src/gourmand/main.py:396
 msgid "An import is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:439
+#: ../src/gourmand/main.py:398
 msgid "An export is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:440
+#: ../src/gourmand/main.py:400
 msgid "A delete is in progress."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:442
+#: ../src/gourmand/main.py:401
 msgid "Exit program anyway?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:444
+#: ../src/gourmand/main.py:401
 msgid "Don't exit!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:490
+#: ../src/gourmand/main.py:447
 #, python-format
 msgid "Permanently deleted %s of %s recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:508
-#: ../src/gourmet/GourmetRecipeManager.py:524
+#: ../src/gourmand/main.py:470 ../src/gourmand/main.py:493
 msgid "Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:525
+#: ../src/gourmand/main.py:493
 msgid "Browse, permanently delete or undelete deleted recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:579
+#: ../src/gourmand/main.py:543
 msgid "Undeleted recipes "
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:719
+#: ../src/gourmand/main.py:678
 #, python-format
 msgid "Number of %(unit)s of %(title)s to shop for"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:731
+#: ../src/gourmand/main.py:691
 #, python-format
 msgid "Multiply %s by:"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:752
+#: ../src/gourmand/main.py:720
 #, python-format
 msgid "Set %(attributes)s for %(num)s selected recipe?"
 msgid_plural "Set %(attributes)s for %(num)s selected recipes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:759
+#: ../src/gourmand/main.py:726
 msgid "Any previously existing values will not be changed."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:761
+#: ../src/gourmand/main.py:728
 msgid "The new values will overwrite any previously existing values."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:762
+#: ../src/gourmand/main.py:729
 msgid "This change cannot be undone."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:763
+#: ../src/gourmand/main.py:731
 msgid "Set values for selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:976
+#: ../src/gourmand/main.py:956
 msgid "Search recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1003
+#: ../src/gourmand/main.py:988
 msgid "Open recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1004
+#: ../src/gourmand/main.py:988
 msgid "Open selected recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1005
+#: ../src/gourmand/main.py:989
 msgid "Delete recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1006
+#: ../src/gourmand/main.py:989
 msgid "Delete selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1007
+#: ../src/gourmand/main.py:990
 msgid "Edit recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1008
+#: ../src/gourmand/main.py:990
 msgid "Open selected recipes in recipe editor view"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1010
+#: ../src/gourmand/main.py:994
 msgid "E_xport selected recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1011
+#: ../src/gourmand/main.py:996
 msgid "Export selected recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1013
+#: ../src/gourmand/main.py:999
 msgid "_Print"
 msgstr ""
 
-#. ('Email', None, _('E-_mail recipes'),
-#. None,None,self.email_recs),
-#: ../src/gourmet/GourmetRecipeManager.py:1017
+#: ../src/gourmand/main.py:1000
+msgid "_Copy recipes"
+msgstr ""
+
+#: ../src/gourmand/main.py:1001
 msgid "Batch _edit recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1026
+#: ../src/gourmand/main.py:1010
 msgid "_New"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1028
-msgid "_Import file"
+#: ../src/gourmand/main.py:1011
+msgid "_Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1029
-msgid "Import recipe from file"
+#: ../src/gourmand/main.py:1011
+msgid "Import recipe from file or page"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1030
-msgid "Import _webpage"
+#: ../src/gourmand/main.py:1012
+msgid "Paste recipe"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1031
-msgid "Import recipe from webpage"
-msgstr ""
-
-#: ../src/gourmet/GourmetRecipeManager.py:1032
+#: ../src/gourmand/main.py:1016
 msgid "Export _all recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1033
+#: ../src/gourmand/main.py:1018
 msgid "Export all recipes to file"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1034
+#: ../src/gourmand/main.py:1021
 msgid "_Quit"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1037
+#: ../src/gourmand/main.py:1022
 msgid "_Actions"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1040
-msgid "Open _Trash"
+#: ../src/gourmand/main.py:1025
+msgid "_Trash"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1043
+#: ../src/gourmand/main.py:1026
 msgid "_Preferences"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1045
+#: ../src/gourmand/main.py:1030
 msgid "_Plugins"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1046
-msgid "Manage plugins which add extra functionality to Gourmet."
+#: ../src/gourmand/main.py:1032
+msgid "Manage plugins which add extra functionality to Gourmand."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1048
+#: ../src/gourmand/main.py:1035
 msgid "Setti_ngs"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1051
+#: ../src/gourmand/main.py:1037
 msgid "_About"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1059
+#: ../src/gourmand/main.py:1045
 msgid "_Tools"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1060
+#: ../src/gourmand/main.py:1046
 msgid "_Timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1061
+#: ../src/gourmand/main.py:1046
 msgid "Show timer"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1066
+#: ../src/gourmand/main.py:1050
 msgid "Searchable index of recipes in the database."
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1177
+#: ../src/gourmand/main.py:1160
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1178
+#: ../src/gourmand/main.py:1161
 #, python-format
 msgid "You have unsaved changes to %s. Are you sure you want to delete?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1207
+#: ../src/gourmand/main.py:1192
 msgid "Untitled"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1215
+#: ../src/gourmand/main.py:1201
 msgid "Permanently delete recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1217
+#: ../src/gourmand/main.py:1203
 msgid "Permanently delete recipe?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1218
+#: ../src/gourmand/main.py:1204
 #, python-format
 msgid "Are you sure you want to delete the recipe <i>%s</i>"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1220
+#: ../src/gourmand/main.py:1206
 msgid "Are you sure you want to delete the following recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1224
+#: ../src/gourmand/main.py:1210
 #, python-format
 msgid "Are you sure you want to delete the %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1226
+#: ../src/gourmand/main.py:1212
 msgid "See recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1234
+#: ../src/gourmand/main.py:1220
 msgid "Delete Recipes"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1236
+#: ../src/gourmand/main.py:1221
 msgid "Recipes deleted"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1261
+#. gt.gtk_enter()
+#: ../src/gourmand/main.py:1247
 #, python-format
 msgid "Deleted recipe %s"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1288
+#: ../src/gourmand/main.py:1274
 msgid "See Trash Now"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1327
+#: ../src/gourmand/main.py:1316
 msgid "Done!"
 msgstr ""
 
-#: ../src/gourmet/GourmetRecipeManager.py:1335
+#. gt.gtk_leave()
+#: ../src/gourmand/main.py:1324
 msgid "Importing..."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:21
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Ingredient _Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditorPlugin.py:22
+#: ../src/gourmand/plugins/key_editor/keyEditorPlugin.py:19
 msgid "Edit ingredient keys en masse"
 msgstr ""
 
 #. to set our regexp_toggled variable
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:66
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:74
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:269
 msgid "key"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:88
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:263
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:536
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:98
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:267
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:538
 msgid "item"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:113
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:118
 msgid "Field"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:114
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:119
 msgid "Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:115
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:120
 msgid "Count"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:160
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:167
 #, python-format
 msgid "Change all keys \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:161
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:169
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1953,12 +1885,12 @@ msgid ""
 "items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:173
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:177
 #, python-format
 msgid "Change all items \"%s\" to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:174
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:179
 #, python-format
 msgid ""
 "You won't be able to undo this action. If there are already ingredients with "
@@ -1966,78 +1898,78 @@ msgid ""
 "the items you are changing now."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:185
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:191
 #, python-format
 msgid "Change _all instances of \"%(unit)s\" to \"%(text)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:186
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:192
 #, python-format
 msgid ""
 "Change \"%(unit)s\" to \"%(text)s\" only for _ingredients \"%(item)s\" with "
 "key \"%(key)s\""
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:211
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:217
 #, python-format
 msgid "Change _all instances of \"%(amount)s\" %(unit)s to %(text)s %(unit)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:212
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:218
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only _where the "
 "ingredient key is %(key)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:213
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:220
 #, python-format
 msgid ""
 "Change \"%(amount)s\" %(unit)s to \"%(text)s\" %(unit)s only where the "
 "ingredient key is %(key)s _and where the item is %(item)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:361
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:360
 msgid "Change all selected rows?"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:362
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:362
 #, python-format
 msgid ""
 "This action will not be undoable. Are you that for all %s selected rows, you "
 "want to set the following values:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:363
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:363
 #, python-format
 msgid ""
 "\n"
 "Key to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:364
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:364
 #, python-format
 msgid ""
 "\n"
 "Item to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:365
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:365
 #, python-format
 msgid ""
 "\n"
 "Unit to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:366
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:366
 #, python-format
 msgid ""
 "\n"
 "Amount to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:493
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:168
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:493
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:183
 #, python-format
 msgid "%s ingredient"
 msgid_plural "%s ingredients"
@@ -2046,386 +1978,374 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:497
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:172
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:497
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:187
 #, python-format
 msgid "Showing ingredients %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyEditor.py:513
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:9
+#: ../src/gourmand/plugins/key_editor/keyEditor.py:511
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:10
 msgid "Amount"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:19
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:42
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:20
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid "Ingredient Keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:43
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:44
 msgid ""
 "Ingredient Keys are normalized ingredient names used for shopping lists and "
 "for calculations."
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:91
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:93
 msgid "Guess keys"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:92
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:95
 msgid ""
 "Guess best values for all ingredient keys based on values already in your "
 "database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:96
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:105
 msgid "Edit Key Associations"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/recipeEditorPlugin.py:97
+#: ../src/gourmand/plugins/key_editor/recipeEditorPlugin.py:107
 msgid "Edit associations with key and other attributes in database"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:1
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:1
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:1
 msgid "Key Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:11
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:11
 msgid "_Item:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:12
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:12
 msgid "_Key:"
 msgstr ""
 
-#: ../src/gourmet/plugins/key_editor/keyeditor.ui.h:13
+#: ../src/gourmand/plugins/key_editor/keyeditor.ui.h:13
 msgid "<b>_Change selected ingredients</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/shopping_associations/shopping_key_editor_plugin.py:12
+#: ../src/gourmand/plugins/shopping_associations/shopping_key_editor_plugin.py:11
 msgid "Shopping Category"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:10
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:9
 msgid "Display units as written for each recipe (no change)"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:11
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:10
 msgid "Always display U.S. units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:12
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:11
 msgid "Always display metric units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/unit_prefs_dialog.py:21
+#: ../src/gourmand/plugins/unit_display_prefs/unit_prefs_dialog.py:21
 msgid "Automatically adjust units"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:31
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:34
 msgid "Set _unit display preferences"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_display_prefs/__init__.py:32
+#: ../src/gourmand/plugins/unit_display_prefs/__init__.py:36
 msgid ""
 "Automatically convert units to preferred system (metric, imperial, etc.) "
 "where possible."
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:110
+#: ../src/gourmand/plugins/browse_recipes/browser.py:105
 msgid "Unrated"
 msgstr ""
 
-#: ../src/gourmet/plugins/browse_recipes/browser.py:116
+#: ../src/gourmand/plugins/browse_recipes/browser.py:111
 msgid "Stars"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:30
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:32
 #, python-format
 msgid "%s ago"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:231
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:218
 msgid "Auto-Merge recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:233
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:220
 msgid "Always use newest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:234
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:221
 msgid "Always use oldest recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:434
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:489
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:552
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.py:579
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:162
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:460
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:512
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:611
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.py:636
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:170
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:1
 msgid "None"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:26
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:62
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:26
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:59
 msgid ""
 "Some of the imported recipes appear to be duplicates. You can merge them "
 "here, or close this dialog to leave them as they are."
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:69
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find _duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMergerPlugin.py:70
+#: ../src/gourmand/plugins/duplicate_finder/recipeMergerPlugin.py:66
 msgid "Find and remove duplicate recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:1
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:1
 msgid "Recipes with similar recipe information"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:2
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:2
 msgid "Recipes with similar ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:3
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:3
 msgid "Recipes with similar recipe information and ingredients"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:4
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:4
 msgid "<b><span size=\"large\">Duplicate recipes</span></b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:5
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:5
 msgid "_Include recipes in trash"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:6
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:6
 msgid "<i>_Showing:</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:7
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:7
 msgid "Merge _all duplicates"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:8
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:8
 msgid "<b>Merge recipes</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/duplicate_finder/recipeMerger.ui.h:9
+#: ../src/gourmand/plugins/duplicate_finder/recipeMerger.ui.h:9
 msgid "_Auto-merge"
 msgstr ""
 
 #. len(vals)==0
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:103
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:99
 msgid "For each selected value"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:107
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:102
 #, python-format
 msgid "Where %(field)s is %(value)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:165
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:164
 #, python-format
 msgid "Change will affect %s recipe"
 msgid_plural "Change will affect %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:169
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:166
 #, python-format
 msgid "Delete %s where it is %s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:172
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:169
 #, python-format
 msgid "Change %s from %s to \"%s\"?"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/fieldEditor.py:178
+#: ../src/gourmand/plugins/field_editor/fieldEditor.py:173
 msgid "<i>This change is not reversable.</i>"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:20
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:1
 msgid "Field Editor"
 msgstr ""
 
-#: ../src/gourmet/plugins/field_editor/__init__.py:21
+#: ../src/gourmand/plugins/field_editor/__init__.py:20
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:2
 msgid "Edit fields across multiple recipes at a time."
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:26
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:46
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:29
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:53
 msgid "Email recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:27
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:31
 msgid "Email all selected recipes (or all recipes if no recipes are selected"
 msgstr ""
 
 #. only called for l>20, so fancy gettext methods
 #. shouldn't be necessary if my knowledge of
 #. linguistics serves me
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:50
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:57
 #, python-format
 msgid "Do you really want to email all %s selected recipes?"
 msgstr ""
 
-#: ../src/gourmet/plugins/email_plugin/emailer_plugin.py:51
+#: ../src/gourmand/plugins/email_plugin/emailer_plugin.py:58
 msgid "Yes, e_mail them"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:116
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:125
 #, python-format
 msgid "Cannot convert %s to %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/convertGui.py:118
+#: ../src/gourmand/plugins/unit_converter/convertGui.py:127
 msgid "Need density information."
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:18
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "_Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/__init__.py:19
+#: ../src/gourmand/plugins/unit_converter/__init__.py:16
 msgid "Calculate unit conversions"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:2
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:2
 #: ../data/plugins/unit_converter.gourmet-plugin.in.h:1
 msgid "Unit Converter"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:3
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:6
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:6
 msgid "1"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:8
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:8
 msgid "I_tem:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:9
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:9
 msgid "_Density:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:10
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:10
 msgid "Density _Information"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:11
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:11
 msgid "<b>To</b>"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:12
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:12
 msgid "_Result:"
 msgstr ""
 
-#: ../src/gourmet/plugins/unit_converter/converter.ui.h:13
+#: ../src/gourmand/plugins/unit_converter/converter.ui.h:13
 msgid "?"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_importer_plugin.py:13
-msgid "Archive (zip, tarball)"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:51
-msgid "Loading zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/archive_plugin/zip_readers.py:66
-msgid "Unzipping zip archive"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:6
 msgid "HTML Web Page"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:11
 msgid "Exporting Webpage"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to HTML files in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as HTML file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:138
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:207
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:142
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:208
 #, python-format
 msgid "Original Page from %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/html_plugin/html_exporter.py:194
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter.py:259
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:631
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:644
-#: ../src/gourmet/exporters/exporter.py:384
-#: ../src/gourmet/exporters/exporter.py:469
+#: ../src/gourmand/plugins/import_export/html_plugin/html_exporter.py:207
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter.py:270
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:625
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:638
+#: ../src/gourmand/exporters/exporter.py:383
+#: ../src/gourmand/exporters/exporter.py:479
 msgid "optional"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:6
 msgid "Epub File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:10
 msgid "Exporting epub"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes an epub file in directory %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/epub_plugin/epub_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as epub file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:6
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:39
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:5
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:48
 msgid "Plain Text file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:10
 msgid "Text Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:11
 #, python-format
 msgid "Exporting recipes to text file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_exporter_plugin.py:12
 #, python-format
 msgid "Recipe saved as plain text file %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:26
 msgid "Big File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:28
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:27
 #, python-format
 msgid "File %s is too big to import"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
+#: ../src/gourmand/plugins/import_export/plaintext_plugin/plaintext_importer_plugin.py:29
 #, python-format
 msgid ""
 "Your file exceeds the maximum length of %s characters. You probably didn't "
@@ -2433,81 +2353,54 @@ msgid ""
 "text editor to split it into smaller files and try importing again."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/web_import_plugin/generic_web_importer_plugin.py:14
-msgid "Webpage"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:26
-#: ../src/gourmet/importers/webextras.py:20
-#, python-format
-msgid "Downloading %s"
-msgstr ""
-
-#. Now get URL
-#. First log in...
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:60
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:82
-#, python-format
-msgid "Logging into %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:83
-#: ../src/gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py:85
-#: ../src/gourmet/importers/webextras.py:27
-#: ../src/gourmet/importers/webextras.py:89
-#: ../src/gourmet/importers/html_importer.py:48
-#, python-format
-msgid "Retrieving %s"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:63
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:9
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:59
 msgid "Gourmet XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:47
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:38
 msgid "Gourmet XML Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:48
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:39
 #, python-format
 msgid "Exporting recipes to Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:49
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_exporter_plugin.py:40
 #, python-format
 msgid "Recipe saved in Gourmet XML file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:76
+#: ../src/gourmand/plugins/import_export/gxml_plugin/gxml_importer_plugin.py:72
 msgid "Gourmet XML File (Obsolete)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:11
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:10
 msgid "Mastercook XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:24
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer_plugin.py:23
 msgid "Mastercook Text File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:121
 msgid "Mastercook import finished."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:255
+#: ../src/gourmand/plugins/import_export/mastercook_import_plugin/mastercook_importer.py:254
 msgid "Tidying up XML"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:12
+#: ../src/gourmand/plugins/import_export/krecipe_plugin/krecipe_importer_plugin.py:10
 msgid "KRecipe XML File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:56
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:64
 msgid "Could not find Adobe Reader on your system."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:57
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:66
 msgid ""
 "This version of Gourmet Recipe Manager requires Adobe Reader to be able to "
 "print; other PDF viewers will not work.\n"
@@ -2516,880 +2409,897 @@ msgid ""
 "viewer."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:80
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:92
 msgid "Page Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/print_plugin.py:172
+#: ../src/gourmand/plugins/import_export/pdf_plugin/print_plugin.py:188
 msgid "Print Recipes"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:7
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:6
 msgid "PDF (Portable Document Format)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:11
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to PDF %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved as PDF %(file)s"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:712
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:827
-msgid "Letter"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:713
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:846
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:966
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:997
-msgid "Portrait"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:715
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:839
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:958
-msgid "Plain"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:729
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:748
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:749
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:723
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:742
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:744
 msgid "cm"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:730
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:724
 msgid "points"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:822
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:821
 msgid "11x17\""
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:823
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:822
 msgid "Index Card (3.5x5\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:824
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:823
 msgid "Index Card (4x6\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:825
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:824
 msgid "Index Card (5x8\")"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:825
 msgid "Index Card (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:828
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:826
+msgid "Letter"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:827
 msgid "Legal"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:834
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:840
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:852
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:867
 msgid "Index Cards (3.5x5)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:835
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:841
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:853
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:868
 msgid "Index Cards (4x6)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:836
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:842
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:845
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:854
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:869
 msgid "Index Cards (A7)"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:847
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:944
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:995
-msgid "Landscape"
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:847
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:862
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1000
+msgid "Plain"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:858
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:848
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:863
+msgid "2 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:849
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:864
+msgid "3 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:850
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:865
+msgid "4 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:851
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:866
+msgid "5 Columns"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:857
 #, python-format
 msgid "%s Column"
 msgid_plural "%s Columns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:873
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1004
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1033
+msgid "Portrait"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:874
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:986
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:1031
+msgid "Landscape"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:901
 msgid "Paper _Size"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:875
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:905
 msgid "_Orientation"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:877
-msgid "_Font Size"
-msgstr ""
-
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:878
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:909
 msgid "Page _Layout"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:880
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:914
+msgid "_Font Size"
+msgstr ""
+
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:916
 msgid "Left Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:881
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:917
 msgid "Right Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:882
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:918
 msgid "Top Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:883
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:919
 msgid "Bottom Margin"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py:904
+#: ../src/gourmand/plugins/import_export/pdf_plugin/pdf_exporter.py:935
 msgid "PDF Options"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_importer_plugin.py:22
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:7
 msgid "MealMaster file"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:12
 msgid "MealMaster Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:13
 #, python-format
 msgid "Exporting recipes to MealMaster file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter_plugin.py:14
 #, python-format
 msgid "Recipe saved as MealMaster file %(file)s"
 msgstr ""
 
 #. MealMaster format mandates numeric yield information
-#: ../src/gourmet/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:51
+#: ../src/gourmand/plugins/import_export/mealmaster_plugin/mealmaster_exporter.py:48
 #, python-format
 msgid "%s serving"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py:16
 msgid "MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:8
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:6
 msgid "My CookBook MCB File"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:11
 msgid "MCB Export"
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:12
 #, python-format
 msgid "Exporting recipes to My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:14
+#: ../src/gourmand/plugins/import_export/mycookbook_plugin/mycookbook_exporter_plugin.py:13
 #, python-format
 msgid "Recipe saved in My CookBook MCB file %(file)s."
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:28
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:28
 #: ../data/plugins/listsaver.gourmet-plugin.in.h:1
 msgid "Shopping List Saver"
 msgstr ""
 
 #. name
 #. stock
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:35
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:37
 msgid "Save List as Recipe"
 msgstr ""
 
 #. text
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:36
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:38
 msgid "<Ctrl><Shift>S"
 msgstr ""
 
 #. key-command
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:37
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:39
 msgid "Save current shopping list as a recipe for future use"
 msgstr ""
 
 #. print rr
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:49
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 #, python-format
 msgid "Menu for %s (%s)"
 msgstr ""
 
-#: ../src/gourmet/plugins/listsaver/shoppingSaverPlugin.py:51
+#: ../src/gourmand/plugins/listsaver/shoppingSaverPlugin.py:52
 msgid "Menu"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:36
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:36
 #, python-format
 msgid "Nutritional information reflects amount per %s."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:37
 msgid "Nutritional information reflects amounts for entire recipe"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/export_plugin.py:42
+#: ../src/gourmand/plugins/nutritional_information/export_plugin.py:42
 #, python-format
 msgid "Nutritional information is missing for %s ingredients: %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:101
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:98
 msgid "Any food group"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:283
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:277
 msgid "selection"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:435
-msgid "ml"
-msgstr ""
-
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:684
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:670
 #, python-format
 msgid "Convert unit for %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:687
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:673
 #, python-format
 msgid ""
-"In order to calculate nutritional information, Gourmet needs you to help it "
+"In order to calculate nutritional information, Gourmand needs you to help it "
 "convert \"%s\" into a unit it understands."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:769
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:783
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:755
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:766
 msgid "Change ingredient key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:771
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:756
 #, python-format
 msgid ""
 "Change ingredient key from %(old_key)s to %(new_key)s everywhere or just in "
 "the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:776
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:829
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:758
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:801
 msgid "Change _everywhere"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:777
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:830
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:759
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:802
 #, python-format
 msgid "_Just in recipe %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:784
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:767
 #, python-format
 msgid "Change ingredient key from %(old_key)s to %(new_key)s everywhere?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:821
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:798
 msgid "Change unit"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:823
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:799
 #, python-format
 msgid ""
 "Change unit from %(old_unit)s to %(new_unit)s for all ingredients %(ingkey)s "
 "or just in the recipe %(title)s?"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:854
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:818
 #, python-format
 msgid ""
 "In order to calculate nutritional information for \"%(amount)s %(unit)s "
-"%(ingkey)s\", Gourmet needs to know its density. Our nutritional database "
+"%(ingkey)s\", Gourmand needs to know its density. Our nutritional database "
 "has several descriptions of this food with different densities. Please "
 "select the correct one below."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDruid.py:1027
+#: ../src/gourmand/plugins/nutritional_information/nutritionDruid.py:987
 msgid ""
-"To apply nutritional information, Gourmet needs a valid amount and unit."
+"To apply nutritional information, Gourmand needs a valid amount and unit."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/reccard_plugin.py:18
+#: ../src/gourmand/plugins/nutritional_information/reccard_plugin.py:21
 msgid "Nutrition"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:11
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:12
 msgid "Ingredient"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionModel.py:12
+#: ../src/gourmand/plugins/nutritional_information/nutritionModel.py:13
 msgid "USDA Database Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionDisplay.py:134
+#: ../src/gourmand/plugins/nutritional_information/nutritionDisplay.py:139
 msgid "100 grams"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:13
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:13
 msgid "Calories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:16
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:15
 msgid "Total Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:18
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:16
 msgid "Saturated Fat"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:20
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:17
 msgid "Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:22
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:18
 msgid "Sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:24
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:19
 msgid "Total Carbohydrate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:26
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:20
 msgid "Dietary Fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:28
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:21
 msgid "Sugars"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:30
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:22
 msgid "Protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:35
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:26
 msgid "Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:27
 msgid "Ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:39
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:28
 msgid "Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:41
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:29
 msgid "Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:43
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:30
 msgid "Calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:45
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:31
 msgid "Copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:47
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:32
 msgid "Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:49
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:33
 msgid "Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:51
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:34
 msgid "Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:53
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:35
 msgid "Dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:55
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:36
 msgid "Iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:57
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:37
 msgid "Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:59
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:38
 msgid "Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:39
 msgid "Magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:63
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:40
 msgid "Manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:41
 msgid "Niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:67
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:42
 msgid "Pantothenic Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:69
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:43
 msgid "Phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:71
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:44
 msgid "Potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:73
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:45
 msgid "Vitamin A"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:75
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:46
 msgid "Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:77
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:47
 msgid "Riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:79
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:48
 msgid "Selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:81
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:49
 msgid "Thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:83
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:50
 msgid "Vitamin A (IU)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:51
 msgid "Vitamin A (RAE)"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:87
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:52
 msgid "Vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:89
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:53
 msgid "Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:91
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:54
 msgid "Vitamin C"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:93
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:55
 msgid "Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:95
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:56
 msgid "Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:57
 msgid "Zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:206
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:164
 msgid "Vitamins and minerals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:315
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:273
 #, python-format
 msgid ""
 "Missing nutritional information\n"
 "for %(missing)s of %(total)s ingredients."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:331
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:290
 msgid "% _Daily Value"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:375
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:331
 #, python-format
 msgid ""
 "Percentage of recommended daily value based on %i calories per day. Click to "
 "edit number of calories per day."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:465
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:420
 #, python-format
 msgid "Amount per %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionLabel.py:467
+#: ../src/gourmand/plugins/nutritional_information/nutritionLabel.py:422
 msgid "Amount per recipe"
 msgstr ""
 
 #. filename=None
 #. if de.getBoolean(
 #. label=_('Load nutritional database.'),
-#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmet to the ABBREV.txt file now. If you are online, Gourmet can download the file automatically."),
+#. sublabel=_("It looks like you haven\'t yet initialized your nutritional database. To do so, you'll need to download the USDA nutritional database for use with your program. If you are not currently online, but have already downloaded the USDA sr17 database, you can point Gourmand to the ABBREV.txt file now. If you are online, Gourmand can download the file automatically."),  # noqa: E501
 #. custom_yes=_('Browse for ABBREV.txt file'),
 #. custom_no=_('Download file automatically')):
 #. filename=de.select_file(
 #. 'Find ABBREV.txt file',
 #. filters=[['Plain Text',['text/plain'],['*txt']]]
 #. )
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:37
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:37
 msgid "Loading Nutritional Data"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:42
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:40
 msgid "Nutritonal database import complete!"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:61
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:59
 #, python-format
 msgid "Fetching nutritional database from zip archive %s"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionGrabberGui.py:65
+#: ../src/gourmand/plugins/nutritional_information/nutritionGrabberGui.py:63
 #, python-format
 msgid "Extracting %s from zip archive."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:140
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:141
 msgid "Parsing nutritional data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:158
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:156
 #, python-format
 msgid "Reading nutritional data: imported %s of %s entries."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:181
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:180
 msgid "Parsing weight data..."
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/databaseGrabber.py:191
+#: ../src/gourmand/plugins/nutritional_information/databaseGrabber.py:188
 #, python-format
 msgid "Reading weight data for nutritional items: imported %s of %s entries"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:12
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:55
 msgid "Water"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:13
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:56
 msgid "Kilocalories"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:14
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:57
 msgid "g protein"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:15
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:58
 msgid "g lipid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:16
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:59
 msgid "g ash"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:17
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:60
 msgid "g carbohydrates"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:18
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:61
 msgid "g fiber"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:19
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:62
 msgid "g sugar"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:20
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:63
 msgid "mg calcium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:21
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:64
 msgid "mg iron"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:22
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:65
 msgid "mg magnesium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:23
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:66
 msgid "mg phosphorus"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:24
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:67
 msgid "mg potassium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:25
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:68
 msgid "mg sodium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:26
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:69
 msgid "mg zinc"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:27
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:70
 msgid "mg copper"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:28
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:71
 msgid "mg manganese"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:29
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:72
 msgid "microgram selenium"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:30
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:73
 msgid "mg vitamin c"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:31
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:74
 msgid "mg thiamin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:32
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:75
 msgid "mg riboflavin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:33
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:76
 msgid "mg niacin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:34
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:77
 msgid "mg pantothenic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:35
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:78
 msgid "mg vitamin B6"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:36
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:79
 msgid "microgram Folate Total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:37
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:80
 msgid "microgram Folic acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:38
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:81
 msgid "microgram Food Folate"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:39
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:82
 msgid "microgram dietary folate equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:40
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:83
 msgid "Choline, total"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:41
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:84
 msgid "microgram Vitamin B12"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:42
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:85
 msgid "Vitamin A IU"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:43
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:86
 msgid "Vitamin A (microgram Retinal Activity Equivalents"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:44
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:87
 msgid "microgram Retinol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:45
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:88
 msgid "microgram Alpha-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:46
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:89
 msgid "microgram Beta-carotene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:47
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:90
 msgid "microgram Beta Cryptoxanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:48
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:91
 msgid "microgram Lycopene"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:49
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:92
 msgid "microgram Lutein+Zeazanthin"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:50
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:93
 msgid "mg Vitamin E"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:51
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:94
 msgid "mg Vitamin K"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:52
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:95
 msgid "g Saturated Fatty Acid"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:53
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:96
 msgid "g Monounsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:54
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:97
 msgid "g Polyunsaturated Fatty Acids"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:55
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:98
 msgid "mg Cholesterol"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:60
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:103
 msgid "Percent refuse"
 msgstr ""
 
 #. the DB Food Group Numbers seem to be inline with the group IDs
 #. (numbers > 1000 are in group 100, etc.)
 #. Since that's true, we can use the following table to properly add groups.
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:338
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:394
 msgid "Dairy & Egg Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:339
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:395
 msgid "Spices & Herbs"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:340
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:396
 msgid "Baby Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:341
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:397
 msgid "Fats and Oils"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:342
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:398
 msgid "Poultry"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:343
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:399
 msgid "Soups & Sauces"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:344
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:400
 msgid "Sausages & Lunch Meats"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:345
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:401
 msgid "Breakfast Cereals"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:346
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:402
 msgid "Fruits & Fruit Juices"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:347
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:403
 msgid "Pork"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:348
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:404
 msgid "Vegetables"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:349
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:405
 msgid "Nuts & Seeds"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:350
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:406
 msgid "Beef"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:351
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:407
 msgid "Beverages"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:352
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:408
 msgid "Fish & Shellfish"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:353
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:409
 msgid "Legumes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:354
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:410
 msgid "Lamb, Veal & Game"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:355
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:411
 msgid "Baked Products"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:356
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:412
 msgid "Sweets"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:357
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:413
 msgid "Grains and Pasta"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:358
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:414
 msgid "Fast Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:359
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:415
 msgid "Meals, Entrees, and Sidedishes"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:360
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:416
 msgid "Snacks"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/parser_data.py:361
+#: ../src/gourmand/plugins/nutritional_information/parser_data.py:417
 msgid "Ethnic Foods"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:70
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:80
 msgid "entire database"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:84
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:94
 msgid "Ingredient Key"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:85
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:95
 msgid "USDA ID Number"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:86
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:195
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:96
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:212
 msgid "USDA Item Description"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:87
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:196
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:97
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:213
 msgid "Density Equivalent"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nutritionInfoEditor.py:194
+#: ../src/gourmand/plugins/nutritional_information/nutritionInfoEditor.py:211
 msgid "USDA ID#"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:33
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:32
 #: ../data/plugins/duplicate_finder.gourmet-plugin.in.h:3
 #: ../data/plugins/field_editor.gourmet-plugin.in.h:3
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:3
@@ -3403,288 +3313,242 @@ msgstr ""
 
 #. label
 #. key-command
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:38
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:38
 msgid "Get nutritional information for current list"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/shopping_plugin.py:87
+#: ../src/gourmand/plugins/nutritional_information/shopping_plugin.py:82
 msgid "Amount for Shopping List"
 msgstr ""
 
-#: ../src/gourmet/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
+#: ../src/gourmand/plugins/nutritional_information/nut_recipe_card_display.ui.h:2
 msgid "Edit _nutritional info"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:211
-#: ../src/gourmet/exporters/exporter.py:213
-#: ../src/gourmet/exporters/exporter.py:532
-#: ../src/gourmet/exporters/exporter.py:534
+#: ../src/gourmand/exporters/exporter.py:215
+#: ../src/gourmand/exporters/exporter.py:217
+#: ../src/gourmand/exporters/exporter.py:538
+#: ../src/gourmand/exporters/exporter.py:540
 msgid "stars"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:572
+#: ../src/gourmand/exporters/exporter.py:577
 #, python-format
 msgid "Exported %(number)s of %(total)s recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exporter.py:592
+#: ../src/gourmand/exporters/exporter.py:597
 msgid "Export complete."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:128
+#: ../src/gourmand/exporters/recipe_emailer.py:123
 msgid "Include Recipe in Body of E-mail (A good idea no matter what)"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:129
+#: ../src/gourmand/exporters/recipe_emailer.py:124
 msgid "E-mail Recipe as HTML Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:130
+#: ../src/gourmand/exporters/recipe_emailer.py:125
 msgid "E-mail Recipe as PDF Attachment"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:147
+#: ../src/gourmand/exporters/recipe_emailer.py:143
 msgid "Email Options"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:150
+#: ../src/gourmand/exporters/recipe_emailer.py:146
 msgid "Don't ask before sending e-mail."
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:169
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid "E-mail not sent"
 msgstr ""
 
-#: ../src/gourmet/exporters/recipe_emailer.py:170
+#: ../src/gourmand/exporters/recipe_emailer.py:167
 msgid ""
 "You have not chosen to include the recipe in the body of the message or as "
 "an attachment."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:50
+#: ../src/gourmand/exporters/exportManager.py:46
 msgid "Save recipe as..."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:61
+#: ../src/gourmand/exporters/exportManager.py:54
 #, python-format
 msgid "Gourmet cannot export file of type \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:104
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "Export recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:107
+#: ../src/gourmand/exporters/exportManager.py:96
 msgid "recipes"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:119
+#: ../src/gourmand/exporters/exportManager.py:108
 #, python-format
 msgid "Unable to export: unknown filetype \"%s\""
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:120
+#: ../src/gourmand/exporters/exportManager.py:109
 msgid ""
 "Please make sure to select a filetype from the dropdown menu when saving."
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:160
+#: ../src/gourmand/exporters/exportManager.py:147
 msgid "Export"
 msgstr ""
 
-#: ../src/gourmet/exporters/exportManager.py:163
+#: ../src/gourmand/exporters/exportManager.py:148
 #, python-format
 msgid "Recipes successfully exported to <a href=\"file:///%s\">%s</a>"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:16
-#: ../src/gourmet/exporters/printer.py:25
+#: ../src/gourmand/exporters/printer.py:16
+#: ../src/gourmand/exporters/printer.py:25
 msgid "Unable to print: no print plugins are active!"
 msgstr ""
 
-#: ../src/gourmet/exporters/printer.py:79
+#: ../src/gourmand/exporters/printer.py:70
 #, python-format
 msgid "Print %s recipe"
 msgid_plural "Print %s recipes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/webextras.py:92
-#: ../src/gourmet/importers/html_importer.py:51
-msgid "Retrieving file"
-msgstr ""
-
-#: ../src/gourmet/importers/generic_recipe_parser.py:131
+#: ../src/gourmand/importers/generic_recipe_parser.py:129
 msgid "yield"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:66
-msgid "Enter the URL of a recipe archive or recipe website."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:67
-msgid "Enter website address"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:69
-msgid "Enter URL:"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:70
-msgid "Enter the address of a website or recipe archive."
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:108
-msgid "Unable to import URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:109
-msgid "Gourmet does not have a plugin capable of importing URL"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:110
-#, python-format
-msgid ""
-"Unable to import URL %(url)s of mimetype %(type)s. File saved to temporary "
-"location %(fn)s"
-msgstr ""
-
-#: ../src/gourmet/importers/importManager.py:126
+#: ../src/gourmand/importers/importManager.py:60
 msgid "Open recipe..."
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:188
+#: ../src/gourmand/importers/importManager.py:61
+msgid "Enter a recipe file path or website address."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:62
+msgid "Location:"
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:63
+msgid "Enter the address of a website or recipe archive."
+msgstr ""
+
+#: ../src/gourmand/importers/importManager.py:135
 msgid "Import"
 msgstr ""
 
-#: ../src/gourmet/importers/importManager.py:273
+#: ../src/gourmand/importers/importManager.py:184
 msgid "All importable files"
 msgstr ""
 
-#: ../src/gourmet/importers/plaintext_importer.py:37
+#: ../src/gourmand/importers/plaintext_importer.py:44
 #, python-format
 msgid "Imported %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:190
+#: ../src/gourmand/importers/importer.py:188
 msgid "serving"
 msgid_plural "servings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/importers/importer.py:273
+#: ../src/gourmand/importers/importer.py:269
 #, python-format
 msgid "Imported %s of %s recipes."
 msgstr ""
 
-#: ../src/gourmet/importers/importer.py:500
+#: ../src/gourmand/importers/importer.py:492
 msgid "okay"
 msgstr ""
 
-#. Interactive we go...
-#: ../src/gourmet/importers/html_importer.py:500
-msgid "Don't recognize this webpage. Using generic importer..."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:511
-#: ../src/gourmet/importers/html_importer.py:584
-msgid "Import complete."
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:535
-msgid "Importing recipe"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:542
-msgid "Processing ingredients"
-msgstr ""
-
-#: ../src/gourmet/importers/html_importer.py:566
-msgid "Processing ingredients."
-msgstr ""
-
-#: ../src/gourmet/importers/interactive_importer.py:38
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Servings"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:40
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Ingredient Subgroup"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:41
+#: ../src/gourmand/importers/interactive_importer.py:40
 msgid "Hide"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:53
+#: ../src/gourmand/importers/interactive_importer.py:46
 msgid "Text"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:55
+#: ../src/gourmand/importers/interactive_importer.py:48
 msgid "Actions"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:101
+#: ../src/gourmand/importers/interactive_importer.py:90
 msgid "Import recipe"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:147
+#: ../src/gourmand/importers/interactive_importer.py:144
 msgid "Clear _Tags"
 msgstr ""
 
-#: ../src/gourmet/importers/interactive_importer.py:188
+#: ../src/gourmand/importers/interactive_importer.py:182
 msgid "Import Recipe"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:44 ../src/gourmet/recindex.py:53
-#: ../src/gourmet/recindex.py:496
+#: ../src/gourmand/recindex.py:40 ../src/gourmand/recindex.py:50
+#: ../src/gourmand/recindex.py:472
 msgid "anywhere"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:45 ../src/gourmet/recindex.py:54
+#: ../src/gourmand/recindex.py:41 ../src/gourmand/recindex.py:51
 msgid "title"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:46 ../src/gourmet/recindex.py:55
+#: ../src/gourmand/recindex.py:42 ../src/gourmand/recindex.py:52
 msgid "ingredient"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:47 ../src/gourmet/recindex.py:59
+#: ../src/gourmand/recindex.py:43 ../src/gourmand/recindex.py:56
 msgid "instructions"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:48 ../src/gourmet/recindex.py:60
+#: ../src/gourmand/recindex.py:44 ../src/gourmand/recindex.py:57
 msgid "notes"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:50 ../src/gourmet/recindex.py:57
+#: ../src/gourmand/recindex.py:46 ../src/gourmand/recindex.py:54
 msgid "cuisine"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:51 ../src/gourmet/recindex.py:58
+#: ../src/gourmand/recindex.py:47 ../src/gourmand/recindex.py:55
 msgid "source"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:100
+#: ../src/gourmand/recindex.py:95
 msgid "Use regular expressions in search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:101
+#: ../src/gourmand/recindex.py:97
 msgid "Use regular expressions (an advanced search language) in text search"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:106
+#: ../src/gourmand/recindex.py:106
 msgid "Search as you type (turn off if search is too slow)."
 msgstr ""
 
-#: ../src/gourmet/recindex.py:110
+#: ../src/gourmand/recindex.py:110
 msgid "Show Search _Options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:111
+#: ../src/gourmand/recindex.py:110
 msgid "Show advanced searching options"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:286
+#: ../src/gourmand/recindex.py:267
 #, python-format
 msgid "%s recipe"
 msgid_plural "%s recipes"
@@ -3693,102 +3557,96 @@ msgstr[1] ""
 
 #. Do not translate bottom, top and total -- I use these fancy formatting
 #. strings in case your language needs the order changed!
-#: ../src/gourmet/recindex.py:294
+#: ../src/gourmand/recindex.py:275
 #, python-format
 msgid "Showing recipes %(bottom)s to %(top)s of %(total)s"
 msgstr ""
 
-#: ../src/gourmet/recindex.py:497
+#: ../src/gourmand/recindex.py:473
 #, python-format
 msgid "%s in %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:232
+#: ../src/gourmand/threadManager.py:236
 msgid "Paused"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:264
+#: ../src/gourmand/threadManager.py:269
 msgid "Recipe successfully imported"
 msgid_plural "Recipes successfully imported"
 msgstr[0] ""
 
-#: ../src/gourmet/threadManager.py:268
+#: ../src/gourmand/threadManager.py:271
 msgid "Import Unsuccessful"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:291
+#: ../src/gourmand/threadManager.py:294
 msgid "Pause"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:331
+#: ../src/gourmand/threadManager.py:335
 msgid "Done"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:350
+#: ../src/gourmand/threadManager.py:353
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:389
+#: ../src/gourmand/threadManager.py:391
 msgid "Error"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:390
+#: ../src/gourmand/threadManager.py:391
 #, python-format
 msgid "Error %s: %s"
 msgstr ""
 
-#: ../src/gourmet/threadManager.py:391
+#: ../src/gourmand/threadManager.py:391
 msgid "Traceback"
 msgstr ""
 
-#. this is a bit of a hackish attempt to make a matcher for all
-#. plural forms of time units. We use range(5) since as far as I
-#. can see, enumerating the forms for 0 through 5 should give you
-#. all possible forms in all languages.
-#.
-#. See http://www.sbin.org/doc/glibc/libc_8.html
-#: ../src/gourmet/convert.py:105 ../src/gourmet/convert.py:604
+#: ../src/gourmand/convert.py:108 ../src/gourmand/convert.py:629
 msgid "second"
 msgid_plural "seconds"
 msgstr[0] ""
 msgstr[1] ""
 
 #. min. = abbreviation for minutes
-#: ../src/gourmet/convert.py:107
+#: ../src/gourmand/convert.py:110
 msgid "min"
 msgstr ""
 
-#: ../src/gourmet/convert.py:107 ../src/gourmet/convert.py:603
+#: ../src/gourmand/convert.py:110 ../src/gourmand/convert.py:628
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. hrs = abbreviation for hours
-#: ../src/gourmet/convert.py:109
+#: ../src/gourmand/convert.py:112
 msgid "hrs."
 msgstr ""
 
-#: ../src/gourmet/convert.py:109 ../src/gourmet/convert.py:602
+#: ../src/gourmand/convert.py:112 ../src/gourmand/convert.py:627
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:110 ../src/gourmet/convert.py:601
+#: ../src/gourmand/convert.py:113 ../src/gourmand/convert.py:626
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:111 ../src/gourmet/convert.py:600
+#: ../src/gourmand/convert.py:114 ../src/gourmand/convert.py:625
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/gourmet/convert.py:112 ../src/gourmet/convert.py:599
+#: ../src/gourmand/convert.py:115 ../src/gourmand/convert.py:624
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3797,7 +3655,7 @@ msgstr[1] ""
 #. 'millennia':lambda decades: ngettext("millenium","millenia",round(decades))
 #. 'centuries':lambda decades: ngettext("century","centuries",round(decades))
 #. 'decades':lambda decades: ngettext("decade","decades",round(decades))
-#: ../src/gourmet/convert.py:113 ../src/gourmet/convert.py:598
+#: ../src/gourmand/convert.py:116 ../src/gourmand/convert.py:623
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -3809,69 +3667,30 @@ msgstr[1] ""
 #. You can of course make your language only use commas or
 #. ands or spaces or whatever you like by translating both
 #. ", " and " and " with the same string.
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid " and "
 msgstr ""
 
-#: ../src/gourmet/convert.py:648
+#: ../src/gourmand/convert.py:681
 msgid ", "
 msgstr ""
 
-#: ../src/gourmet/convert.py:650
+#: ../src/gourmand/convert.py:683
 msgid " "
 msgstr ""
 
-#: ../src/gourmet/convert.py:781
+#: ../src/gourmand/convert.py:813
 msgid "and"
 msgstr ""
 
 #. Note: the order matters on this range regular expression in order
 #. for it to properly split things like 1 - to - 3, which really do
 #. show up sometimes.
-#: ../src/gourmet/convert.py:803
+#: ../src/gourmand/convert.py:836
 msgid "to"
 msgstr ""
 
 #. i=InteractiveConverter()
-#: ../data/gourmet.appdata.xml.in.h:1
-msgid ""
-"Gourmet Recipe Manager is a recipe-organizer that allows you to collect, "
-"search, organize, and browse your recipes. Gourmet can also generate "
-"shopping lists and calculate nutritional information."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:2
-msgid ""
-"A simple index view allows you to look at all your recipes as a list and "
-"quickly search through them by ingredient, title, category, cuisine, rating, "
-"or instructions."
-msgstr ""
-
-#: ../data/gourmet.appdata.xml.in.h:3
-msgid ""
-"Individual recipes open in their own windows, just like recipe cards drawn "
-"out of a recipe box. From the recipe card view, you can instantly multiply "
-"or divide a recipe, and Gourmet will adjust all ingredient amounts for you."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:1
-msgid "Gourmet"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:2
-msgid "Recipe Manager"
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:4
-msgid ""
-"Organize recipes, create shopping lists, calculate nutritional information, "
-"and more."
-msgstr ""
-
-#: ../data/gourmet.desktop.in.h:5
-msgid "recipes;cooking;nutrition;nutritional information;shopping lists;"
-msgstr ""
-
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:1
 msgid "Browse Recipes"
 msgstr ""
@@ -3881,7 +3700,6 @@ msgid "Selecting recipes by browsing by category, cuisine, etc."
 msgstr ""
 
 #: ../data/plugins/browse_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/email.gourmet-plugin.in.h:3
 #: ../data/plugins/nutritional_information.gourmet-plugin.in.h:3
 msgid "Main"
 msgstr ""
@@ -3894,44 +3712,24 @@ msgstr ""
 msgid "A wizard to find and remove or merge duplicate recipes."
 msgstr ""
 
-#: ../data/plugins/email.gourmet-plugin.in.h:1
-msgid "Send to Email"
-msgstr ""
-
-#: ../data/plugins/email.gourmet-plugin.in.h:2
-msgid "Email recipes from Gourmet"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:1
-msgid "Zip, Gzip, and Tarball support"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:2
-msgid "Import recipes from zip and tar archives"
-msgstr ""
-
-#: ../data/plugins/import_export/archive.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:3
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:3
-#: ../data/plugins/utf16.gourmet-plugin.in.h:3
-msgid "Importer/Exporter"
-msgstr ""
-
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:1
 msgid "EPub Export"
 msgstr ""
 
 #: ../data/plugins/import_export/epub.gourmet-plugin.in.h:2
 msgid "Create an epub book from recipes."
+msgstr ""
+
+#: ../data/plugins/import_export/epub.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mastercook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mycookbook_plugin.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/mealmaster.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/pdf.gourmet-plugin.in.h:3
+#: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:3
+#: ../data/plugins/utf16.gourmet-plugin.in.h:3
+msgid "Importer/Exporter"
 msgstr ""
 
 #: ../data/plugins/import_export/gxml.gourmet-plugin.in.h:1
@@ -3942,14 +3740,6 @@ msgstr ""
 msgid ""
 "Import and Export recipes as Gourmet XML files, suitable for backup or "
 "exchange with other Gourmet users."
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:1
-msgid "HTML Export"
-msgstr ""
-
-#: ../data/plugins/import_export/html.gourmet-plugin.in.h:2
-msgid "Create recipe webpages from recipes."
 msgstr ""
 
 #: ../data/plugins/import_export/krecipe_plugin.gourmet-plugin.in.h:1
@@ -4003,22 +3793,6 @@ msgstr ""
 #: ../data/plugins/import_export/plaintext.gourmet-plugin.in.h:2
 msgid ""
 "Help user mark up and import plain text. Also provides plain text export."
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:1
-msgid "Webpage import"
-msgstr ""
-
-#: ../data/plugins/import_export/webimport.gourmet-plugin.in.h:2
-msgid "Import recipes from the web."
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:1
-msgid "Website Importers"
-msgstr ""
-
-#: ../data/plugins/import_export/website_import.gourmet-plugin.in.h:2
-msgid "Importers for about.com, www.foodnetwork.com, and others"
 msgstr ""
 
 #: ../data/plugins/key_editor.gourmet-plugin.in.h:2

--- a/private/update_i18n.py
+++ b/private/update_i18n.py
@@ -1,0 +1,35 @@
+"""
+Create/update po/pot translation files.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+PACKAGE = "gourmand"
+CURRENT_DIRECTORY = Path(__file__).parent
+PACKAGEDIR = CURRENT_DIRECTORY.parent / "src" / PACKAGE
+PODIR = CURRENT_DIRECTORY.parent / "po"
+LANGS = sorted(f.stem for f in PODIR.glob("*.po"))
+
+
+def main():
+    print("Creating POT files")
+    intltool_update = shutil.which("intltool-update")
+    cmd = [intltool_update, "--pot", f"--gettext-package={PACKAGE}"]
+    if not intltool_update:
+        print(f"intltool-update not found, skipping {cmd!r} call ...")
+    else:
+        subprocess.run(cmd, cwd=PODIR)
+
+    for lang in LANGS:
+        print(f"Updating {lang}.po")
+        cmd = [intltool_update, "--dist", f"--gettext-package={PACKAGE}", lang]
+        if not intltool_update:
+            print(f"intltool-update not found, skipping {cmd!r} call ...")
+        else:
+            subprocess.run(cmd, cwd=PODIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+requires = [
+    "setuptools",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.pytest.ini_options]
 addopts = "-vv"
 testpaths = [


### PR DESCRIPTION
## Description

This ensures that editable installs keep working after the explicit `setup.py develop` call is removed. For now, `setup.py develop` and the new approach by hooking into `build_py` are maintained. Additionally, declare the build backend in the `pyproject.toml` file.

As custom `setup.py *` calls are discouraged, move `update_i18n` to a dedicated script and update the corresponding files as well. This ensures that the additional migration from the (possibly unsafe) `os.system` to `subprocess.run` did not break anything as well.

Closes #203.

## How Has This Been Tested?

The corresponding commands still run successfully and generate the correct files.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
