### PR TITLE
Run AppImage and Flatpak builds on every main commit and PR as well

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - '*'
+    branches:
+      - 'main'
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - '*'
+    branches:
+      - 'main'
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Previously, AppImage and Flatpak builds would require manual triggering or releases. To allow pre-release builds and easier testing of proposed changes, enable these builds for all commits to main and PRs as well.

Closes #188.

## How Has This Been Tested?

GitHub Actions run through.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
