### PR TITLE
Download html content before passing to scrape_html.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ setup(
         "sqlalchemy>=1.4.36,<2",
         "tomli-w>=1.0.0",
         'toml==0.10.2; python_version<"3.11"',
-        "recipe-scrapers>=14.27.0,<15",
+        "recipe-scrapers>=14.27.0",
     ],
     extras_require={
         "epub-export": ["ebooklib==0.17.1"],

--- a/src/gourmand/importers/web_importer.py
+++ b/src/gourmand/importers/web_importer.py
@@ -1,17 +1,23 @@
 """Import recipes from the web using recipe-scrapers."""
 
 from typing import List, Tuple
+from urllib.error import URLError
 from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 from gi.repository import Gtk
 from recipe_scrapers import SCRAPERS, scrape_html
 from recipe_scrapers._exceptions import SchemaOrgException
 
+from gourmand import __version__
 from gourmand.image_utils import ImageBrowser, image_to_bytes, make_thumbnail
 from gourmand.recipeManager import get_recipe_manager
 from gourmand.structure import Recipe
 
 supported_sites = list(SCRAPERS.keys())
+HEADERS = {
+    "User-Agent": f"Mozilla/5.0 (compatible; Windows NT 10.0; Win64; x64) gourmand/{__version__}"
+}
 
 
 def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
@@ -42,7 +48,19 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
             urls.remove(url)
 
     for url in urls:
-        recipe = scrape_html(html=None, org_url=url)
+        req = Request(url, headers=HEADERS)
+        try:
+            response = urlopen(req)
+            html = response.read()
+        except URLError as e:
+            if hasattr(e, 'reason'):
+                print('We failed to reach a server.')
+                print('Reason: ', e.reason)
+            elif hasattr(e, 'code'):
+                print('The server couldn\'t fulfill the request.')
+                print('Error code: ', e.code)
+            continue
+        recipe = scrape_html(html, org_url=url)
         # Fetch the image if available, or else open an ImageBrowser
         # to let the user select one.
         image = thumbnail = None

--- a/src/gourmand/importers/web_importer.py
+++ b/src/gourmand/importers/web_importer.py
@@ -54,7 +54,7 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
             with urlopen(req) as response:
                 html = response.read()
         except URLError as e:
-            debug('The server couldn\'t fulfill the request.', 1)
+            debug('The server could not fulfill the request.', 1)
             debug(f'Reason: {e.reason}', 1)
             continue
         recipe = scrape_html(html, org_url=url)

--- a/src/gourmand/importers/web_importer.py
+++ b/src/gourmand/importers/web_importer.py
@@ -10,6 +10,7 @@ from recipe_scrapers import SCRAPERS, scrape_html
 from recipe_scrapers._exceptions import SchemaOrgException
 
 from gourmand import __version__
+from gourmand.gdebug import debug
 from gourmand.image_utils import ImageBrowser, image_to_bytes, make_thumbnail
 from gourmand.recipeManager import get_recipe_manager
 from gourmand.structure import Recipe
@@ -50,15 +51,11 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
     for url in urls:
         req = Request(url, headers=HEADERS)
         try:
-            response = urlopen(req)
-            html = response.read()
+            with urlopen(req) as response:
+                html = response.read()
         except URLError as e:
-            if hasattr(e, 'reason'):
-                print('We failed to reach a server.')
-                print('Reason: ', e.reason)
-            elif hasattr(e, 'code'):
-                print('The server couldn\'t fulfill the request.')
-                print('Error code: ', e.code)
+            debug('The server couldn\'t fulfill the request.', 1)
+            debug(f'Reason: {e.reason}', 1)
             continue
         recipe = scrape_html(html, org_url=url)
         # Fetch the image if available, or else open an ImageBrowser


### PR DESCRIPTION
## Description
See issue #176.  The recipe_scrapers library will stop supporting downloads at some point and expects to be passed an html document. This commit uses urllib to download the webpage content before passing it along to scrape_html.  In order to bypass bot detection the header string referencing Mozilla/5.0 is added.

The boilerplate urllib code is taken from the official python docs. See https://docs.python.org/3.8/howto/urllib2.html.

All tests pass.  Before the HEADER was added one of the tests in test_web_importer.py failed because allrecipes rejected it for being a bot.  No additional tests were included since the same functionality is expected.

## How Has This Been Tested?
Manually and with the gourmand test suite.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
