### PR TITLE
Bugfix: Import can handle recipe with category = None

### DIFF
--- a/src/gourmand/backends/db.py
+++ b/src/gourmand/backends/db.py
@@ -1266,7 +1266,7 @@ class RecData(Pluggable):
         and returns the entry in the database as a RowProxy.
         """
         cats = []
-        if "category" in dic:
+        if dic.get('category') is not None:
             cats = [v.strip() for v in dic["category"].split(",") if v]
             del dic["category"]
         if "servings" in dic:

--- a/src/gourmand/importers/web_importer.py
+++ b/src/gourmand/importers/web_importer.py
@@ -43,85 +43,14 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
 
     for url in urls:
         recipe = scrape_html(html=None, org_url=url)
+
         # Fetch the image if available, or else open an ImageBrowser
         # to let the user select one.
         image = thumbnail = None
+        image, thumbnail = capture_image_and_thumbnail(recipe)
 
-        if recipe.image():
-            image = make_thumbnail(recipe.image())
-            thumbnail = image.copy()
-            thumbnail.thumbnail((40, 40))
-            thumbnail = image_to_bytes(thumbnail)
-            image = image_to_bytes(image)
-        else:
-            uris = []
-            for schema in recipe.links():
-                link = schema.get("href", "")
-                if link.endswith("jpg"):
-                    uris.append(link)
-            browser = ImageBrowser(parent=None, uris=uris)
-            response = browser.run()
-            browser.destroy()
-            if response == Gtk.ResponseType.OK:
-                thumbnail = browser.image.copy()
-                thumbnail.thumbnail((40, 40))
-                thumbnail = image_to_bytes(thumbnail)
-                image = image_to_bytes(browser.image)
-
-        # If a recipe doesn't have all the expected information a
-        # SchemaOrgException is raised.  Catch it and assign a default
-        # rating value.
-        try:
-            rating = recipe.ratings()
-        except SchemaOrgException:
-            rating = 0
-        # Gourmet has a 5-stars rating, stored as int between 0 and 10.
-        # We assume that if the value is a float below 5, it's scaled to 5, and
-        # we rescale it to 10.
-        if isinstance(rating, float) and rating <= 5.0:
-            rating = rating * 2
-        rating = int(rating)
-
-        # recipe_scrapers keeps servings, yield, and yield units in one string
-        yields, yield_unit = recipe.yields().split()
-        yields = int(yields)
-
-        # Convert the recipe into the expected namedtuple `recipe_tuple`
-        # expected by the rest of the application.
-        try:
-            preptime = recipe.schema.prep_time()
-            cooktime = recipe.schema.cook_time()
-        except SchemaOrgException:
-            preptime = ""
-            cooktime = ""
-
-        rec = Recipe(
-            id=None,
-            title=recipe.title(),
-            instructions=recipe.instructions(),
-            modifications=None,
-            cuisine="",
-            rating=rating,
-            description="",
-            source=recipe.author(),
-            totaltime=recipe.total_time(),
-            preptime=preptime,
-            cooktime=cooktime,
-            servings=yields,
-            yields=yields,
-            yield_unit=yield_unit,
-            ingredients=recipe.ingredients(),
-            image=image,
-            thumb=thumbnail,
-            deleted=False,
-            recipe_hash=None,
-            ingredient_hash=None,
-            link=recipe.canonical_url(),
-            last_modified=None,
-            nutrients=recipe.nutrients(),
-            category=recipe.category(),
-        )
-
+        # Create local Recipe object
+        rec = initialize_recipe(recipe, image, thumbnail)
         rec = rec._asdict()
         rec.pop("id")
         rec.pop("servings")
@@ -137,3 +66,88 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
         imported.append(url)
 
     return imported, unsupported
+
+
+def capture_image_and_thumbnail(scraped_recipe):
+    image = thumbnail = None
+
+    if scraped_recipe.image():
+        image = make_thumbnail(scraped_recipe.image())
+        thumbnail = image.copy()
+        thumbnail.thumbnail((40, 40))
+        thumbnail = image_to_bytes(thumbnail)
+        image = image_to_bytes(image)
+    else:
+        uris = []
+        for schema in scraped_recipe.links():
+            link = schema.get("href", "")
+            if link.endswith("jpg"):
+                uris.append(link)
+        browser = ImageBrowser(parent=None, uris=uris)
+        response = browser.run()
+        browser.destroy()
+        if response == Gtk.ResponseType.OK:
+            thumbnail = browser.image.copy()
+            thumbnail.thumbnail((40, 40))
+            thumbnail = image_to_bytes(thumbnail)
+            image = image_to_bytes(browser.image)
+
+    return image, thumbnail
+
+
+def initialize_recipe(recipe_scraped, image=None, thumbnail=None):
+    # If a recipe doesn't have all the expected information a
+    # SchemaOrgException is raised.  Catch it and assign a default
+    # rating value.
+    try:
+        rating = recipe_scraped.ratings()
+    except SchemaOrgException:
+        rating = 0
+    # Gourmet has a 5-stars rating, stored as int between 0 and 10.
+    # We assume that if the value is a float below 5, it's scaled to 5, and
+    # we rescale it to 10.
+    if isinstance(rating, float) and rating <= 5.0:
+        rating = rating * 2
+    rating = int(rating)
+
+    # recipe_scrapers keeps servings, yield, and yield units in one string
+    yields, yield_unit = recipe_scraped.yields().split()
+    yields = int(yields)
+
+    # Convert the recipe into the expected namedtuple `recipe_tuple`
+    # expected by the rest of the application.
+    try:
+        preptime = recipe_scraped.schema.prep_time()
+        cooktime = recipe_scraped.schema.cook_time()
+    except SchemaOrgException:
+        preptime = ""
+        cooktime = ""
+
+    rec = Recipe(
+        id=None,
+        title=recipe_scraped.title(),
+        instructions=recipe_scraped.instructions(),
+        modifications=None,
+        cuisine="",
+        rating=rating,
+        description="",
+        source=recipe_scraped.author(),
+        totaltime=recipe_scraped.total_time(),
+        preptime=preptime,
+        cooktime=cooktime,
+        servings=yields,
+        yields=yields,
+        yield_unit=yield_unit,
+        ingredients=recipe_scraped.ingredients(),
+        image=image,
+        thumb=thumbnail,
+        deleted=False,
+        recipe_hash=None,
+        ingredient_hash=None,
+        link=recipe_scraped.canonical_url(),
+        last_modified=None,
+        nutrients=recipe_scraped.nutrients(),
+        category=recipe_scraped.category(),
+    )
+
+    return rec

--- a/src/gourmand/importers/web_importer.py
+++ b/src/gourmand/importers/web_importer.py
@@ -48,7 +48,7 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
             unsupported.append(url)
             urls.remove(url)
 
-    for url in urls:      
+    for url in urls:
         req = Request(url, headers=HEADERS)
         try:
             with urlopen(req) as response:

--- a/src/gourmand/importers/web_importer.py
+++ b/src/gourmand/importers/web_importer.py
@@ -68,10 +68,16 @@ def import_urls(urls: List[str]) -> Tuple[List[str], List[str]]:
                 thumbnail = image_to_bytes(thumbnail)
                 image = image_to_bytes(browser.image)
 
+        # If a recipe doesn't have all the expected information a
+        # SchemaOrgException is raised.  Catch it and assign a default
+        # rating value.
+        try:
+            rating = recipe.ratings()
+        except SchemaOrgException:
+            rating = 0
         # Gourmet has a 5-stars rating, stored as int between 0 and 10.
         # We assume that if the value is a float below 5, it's scaled to 5, and
         # we rescale it to 10.
-        rating = recipe.ratings()
         if isinstance(rating, float) and rating <= 5.0:
             rating = rating * 2
         rating = int(rating)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -241,6 +241,12 @@ class TestMoreDataStuff(DBTest):
             # Change back our ingredient...
             r = self.db.modify_ing(i, {attr: orig_attrs[attr]})
 
+    def test_category_none(self):
+        expected = []
+        r = self.db.add_rec({"title": "Category None Test", "category": None})
+        result = self.db.get_cats(r)
+        self.assertEqual(expected, result)
+
 
 def test_format_amount_string_from_amount():
     ret = db.RecData.format_amount_string_from_amount((0.5, 1))

--- a/tests/test_web_importer.py
+++ b/tests/test_web_importer.py
@@ -1,10 +1,16 @@
+import unittest
 from unittest import mock
 
 import gi
 import pytest
+from recipe_scrapers._exceptions import SchemaOrgException
+
+from gourmand.importers.web_importer import (
+    import_urls,
+    initialize_recipe,  # noqa: E402
+)
 
 gi.require_version("Gtk", "3.0")
-from gourmand.importers.web_importer import import_urls  # noqa: E402
 
 
 @pytest.mark.parametrize(
@@ -25,3 +31,14 @@ def test_import_urls(tmp_path, urls, expected_pass, expected_fails):
 
     assert len(recipes) == expected_pass
     assert failures == expected_fails
+
+
+class TestWebImporter(unittest.TestCase):
+
+    def test_no_rating_gets_set_to_zero(self):
+        recipe_scrape_mock = mock.Mock()
+        recipe_scrape_mock.ratings.side_effect = SchemaOrgException("Error")
+        recipe_scrape_mock.yields.return_value = ('5 muffins')
+
+        recipe = initialize_recipe(recipe_scrape_mock)
+        self.assertEqual(0, recipe.rating)

--- a/tests/test_web_importer.py
+++ b/tests/test_web_importer.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from unittest.mock import Mock, patch
 
 import gi
 import pytest
@@ -26,7 +26,7 @@ gi.require_version("Gtk", "3.0")
     ],
 )
 def test_import_urls(tmp_path, urls, expected_pass, expected_fails):
-    with mock.patch("gourmand.gglobals.gourmanddir", tmp_path):
+    with patch("gourmand.gglobals.gourmanddir", tmp_path):
         recipes, failures = import_urls(urls)
 
     assert len(recipes) == expected_pass
@@ -36,7 +36,7 @@ def test_import_urls(tmp_path, urls, expected_pass, expected_fails):
 class TestWebImporter(unittest.TestCase):
 
     def test_no_rating_gets_set_to_zero(self):
-        recipe_scrape_mock = mock.Mock()
+        recipe_scrape_mock = Mock()
         recipe_scrape_mock.ratings.side_effect = SchemaOrgException("Error")
         recipe_scrape_mock.yields.return_value = ('5 muffins')
 


### PR DESCRIPTION
## Description
This is a stacked PR on top of the rating SchemaOrgException bug (#225).

The main code added was to `db.py` and was exactly what was suggested in the issue:

> Replace 'category' in dic condition with dic.get('category') is not None

Also the `test_category_none()` method was added to `test_db.py`:
```py
    def test_category_none(self):
        expected = []
        r = self.db.add_rec({"title": "Category None Test", "category": None})
        result = self.db.get_cats(r)
        self.assertEqual(expected, result)
```

## How Has This Been Tested?
An automated test of importing a recipe with category: None in the dictionary and then retrieving the category from the db was added.

The test suite passes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
