### PR TITLE
Changed AppImage workflow to correctly convert svg to png

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -46,8 +46,8 @@ jobs:
           cp data/io.github.GourmandRecipeManager.Gourmand.desktop squashfs-root/usr/share/applications/io.github.GourmandRecipeManager.Gourmand.desktop
           cp data/io.github.GourmandRecipeManager.Gourmand.desktop squashfs-root/io.github.GourmandRecipeManager.Gourmand.desktop
           cp data/io.github.GourmandRecipeManager.Gourmand.appdata.xml squashfs-root/usr/share/metainfo/io.github.GourmandRecipeManager.Gourmand.desktop.appdata.xml
-          convert data/io.github.GourmandRecipeManager.Gourmand.svg squashfs-root/usr/share/icons/hicolor/256x256/apps/io.github.GourmandRecipeManager.Gourmand.png
-          convert data/io.github.GourmandRecipeManager.Gourmand.svg squashfs-root/io.github.GourmandRecipeManager.Gourmand.png
+          convert -resize 256x256 -background none data/io.github.GourmandRecipeManager.Gourmand.svg squashfs-root/usr/share/icons/hicolor/256x256/apps/io.github.GourmandRecipeManager.Gourmand.png
+          convert -resize 256x256 -background none data/io.github.GourmandRecipeManager.Gourmand.svg squashfs-root/io.github.GourmandRecipeManager.Gourmand.png
 
     - name: Pack AppImage
       run: |


### PR DESCRIPTION
…ze and transparent background)

<!--- Provide a general summary of your changes in the Title above -->

## Description

Current appimage has a low resolution icon (110x110 png) with white background, so it ends up pretty ugly in the taskbar and applications menu.

This small fix correctly produces a 256x256 png with transparent background.

## How Has This Been Tested?
I have just checked that the convert command works (tested on Linux Mint 22.3). I don't have experience of building appimages, so let me know if I need to test the build process, even if I'm just changing the images.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
