### PR TITLE
Add Wayland socket support to Gourmand flatpak

### DIFF
--- a/.flatpak/io.github.GourmandRecipeManager.Gourmand.yml
+++ b/.flatpak/io.github.GourmandRecipeManager.Gourmand.yml
@@ -7,6 +7,7 @@ command: gourmand
 
 finish-args:
   - --filesystem=host
+  - --socket=wayland
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --share=network


### PR DESCRIPTION
should solve https://github.com/GourmandRecipeManager/gourmand/issues/293

Added the Wayland socket to the finish arguments in the Gourmand flatpak. Per Flathub docs at https://docs.flatpak.org/en/latest/sandbox-permissions.html#f1 `--socket=fallback-x11 - Show windows using X11, if Wayland is not available, overrides x11 socket permission. Note that you must still use --socket=wayland for wayland permission`

I tested this flatpak in a new Almalinux 10 Gnome VM. It opens and functions. Even though this uses python 3.11, it also has the already reported Attribute Error in the nutrition plugin when attempting to modify existing USDA ingredient assoiciations https://github.com/GourmandRecipeManager/gourmand/issues/261 . There is only one line changed in the code.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [? ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
